### PR TITLE
Add authenticated pause controls for connected devices

### DIFF
--- a/LOCAL-API.md
+++ b/LOCAL-API.md
@@ -98,11 +98,51 @@ July 2026 firmware rejects **all** LAN write RPCs — rename, `set_config` —
 with grpc status 7. The official app performs writes via Starlink's cloud,
 not over the LAN. No local elevation path exists.
 
+## Authenticated cloud router writes
+
+Pause and unpause were measured through Starlink's authenticated grpc-web
+`SpaceX.API.Device.Device/Handle` endpoint. This is an unofficial, observed
+interface rather than a published API and may change with Starlink firmware or
+service updates. The behavior was verified on the same installation described
+at the top of this document; record the router hardware and firmware from
+**Copy debug data** when reporting or re-testing it.
+
+The accepted request uses `wifiSetConfig.wifiConfig.clientConfigs` with
+`applyClientConfigs: true`. A permanently paused client has a
+`weeklyBlockSchedules` entry whose `groupId` is `_permanent` and whose single
+range covers the full week (`0` through `10080` minutes). Unpausing removes
+only that entry so unrelated schedules remain intact.
+
+This is a whole-list update, not a single-client patch. Dishylink therefore
+reads the current router configuration over the LAN immediately before each
+write, preserves every client and unrelated schedule, changes only the selected
+client, and serializes mutations so concurrent writes cannot overwrite one
+another. The encoded request is built by the trusted host; renderer-provided
+protobuf is never accepted.
+
+The write requires a current Starlink account session and is available only for
+a device present in the router's live client list. Dishylink does not expose the
+control for the device it is running on, avoiding a self-inflicted disconnect.
+The browser extension disables the control entirely because it cannot reliably
+identify its own LAN client; desktop and the web development host can establish
+that identity before offering the write. Electron reads the host's network
+interfaces, while the web development server answers `/api/whoami` from its local
+host or caller address. The extension has neither path: its `/api/*` requests are
+messages to an internal service worker/IndexedDB router, and ordinary desktop
+Chrome extensions do not expose a reliable host LAN IP or MAC. The cloud mutation
+itself works, but enabling it without self-identity could let a user pause the
+computer running Dishylink, so both the extension UI capability and background
+mutation route are disabled.
+Use `scripts/probe-client-pause-state.mts` for a read-only snapshot of persisted
+block schedules and effective connected-client state.
+
 ## Probing
 
 `scripts/probe-rpcs.mts` — which optional RPCs this firmware implements.
 `scripts/probe-client-history.mts` — buffer depth and sample interval for
 the per-client history RPC.
+`scripts/probe-client-pause-state.mts` — read-only persisted pause schedules
+and effective state for connected clients.
 
 Two lessons worth keeping, both learned the hard way:
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ the performance and health of your Starlink.
 It reads your dish and router directly over your local network, so it keeps
 working during an outage — which is exactly when you want to see what happened.
 No account, no cloud, no telemetry: everything it records is written to your own
-machine and stays there. Connecting a Starlink account is optional, read-only,
-and only adds your plan and billing figures.
+machine and stays there. Connecting a Starlink account is optional. It adds
+your plan and billing figures and enables supported router controls such as
+pausing connected devices. Your session remains stored locally and is sent
+only to Starlink.
 
 ## What it shows
 
@@ -51,12 +53,14 @@ and only adds your plan and billing figures.
 - **Speed test**, **alerts** with severity and an in-app bell, light/dark/system
   instrument themes.
 - **Cloud account tab** (optional, opt-in) — your Starlink plan, billing
-  cycles, and authoritative monthly data usage, read-only.
+  cycles, and authoritative monthly data usage, plus authenticated controls
+  supported by the connected router.
 
 ## What it controls
 
-Monitoring is only half of it — the settings panel writes to the dish over the
-same LAN API:
+Monitoring is only half of it. Most settings write to the dish or router over
+the same LAN API; controls that current firmware rejects locally are identified
+below as requiring an optional Starlink account connection:
 
 - **Snow melt** — automatic, always on, or off.
 - **Sleep schedule** — power the dish down for a set number of hours each day.
@@ -65,6 +69,15 @@ same LAN API:
   stow/unstow motorized kits.
 - **Router** — SSIDs and their bands, mesh node trust, firmware and country, and
   a router reboot.
+- **Connected devices** — pause or unpause another device while it is connected.
+  Available in the desktop app and web development harness, this control requires
+  an optional Starlink account sign-in: Dishylink reads the router configuration
+  locally, prepares the smallest accepted client update on the trusted host, and
+  sends it only to Starlink's authenticated device endpoint. The device running
+  Dishylink cannot pause itself. The browser extension does not expose this control
+  because ordinary desktop extensions cannot reliably read the host computer's LAN
+  IP or MAC address. Although the extension can send the update, it cannot prove
+  which router client is itself and therefore cannot safely prevent self-pausing.
 - **Copy debug data** — diagnostics + status + config as JSON, for bug reports.
 
 Custom DNS, bypass mode, and content filtering are deliberately _not_ exposed: a

--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -4,7 +4,7 @@
 // attached and come back 401. That must self-heal into a loaded account, not a
 // hard "not connected".
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCloudHandler } from "./starlinkCloudHandler";
 
 const AUTH_URL = "https://api.starlink.com/auth-rp/auth/user";
@@ -125,5 +125,196 @@ describe("createCloudHandler token refresh", () => {
     expect(result.status).toBe(200);
     expect((result.body as { identity: unknown }).identity).toBeNull();
     expect((result.body as { serviceLine: unknown }).serviceLine).not.toBeNull();
+  });
+});
+
+describe("createCloudHandler pauseClient", () => {
+  it("given: a trusted host request, should: send framed protobuf with its cookie", async () => {
+    const request = new Uint8Array([8, 1, 18, 0]);
+    const responseMessage = new Uint8Array([10, 0]);
+    const responseFrame = new Uint8Array([0, 0, 0, 0, responseMessage.length, ...responseMessage]);
+    const captured: { url: string; init?: RequestInit } = { url: "" };
+    const doFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === AUTH_URL) return res(200);
+      captured.url = url;
+      captured.init = init;
+      return {
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => responseFrame.buffer,
+      } as unknown as Response;
+    }) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      prepareDevicePause: async (clientId, paused) => {
+        expect({ clientId, paused }).toEqual({ clientId: 7, paused: true });
+        return request;
+      },
+    });
+
+    await expect(handler.pauseClient(7, true)).resolves.toEqual({
+      status: 200,
+      body: { ok: true },
+    });
+    expect(captured.url).toBe("https://starlink.com/api/SpaceX.API.Device.Device/Handle");
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers.cookie).toBe(SESSION);
+    expect(headers["Content-Type"]).toBe("application/grpc-web+proto");
+    expect(new Uint8Array(captured.init?.body as ArrayBufferLike)).toEqual(
+      new Uint8Array([0, 0, 0, 0, request.length, ...request]),
+    );
+  });
+
+  it("given: the gateway rejects an expired token, should: refresh once and retry", async () => {
+    let authCalls = 0;
+    let deviceCalls = 0;
+    const responseFrame = new Uint8Array([0, 0, 0, 0, 0]);
+    const doFetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === AUTH_URL) {
+        authCalls++;
+        return res(200);
+      }
+      deviceCalls++;
+      if (deviceCalls === 1) return res(401);
+      return {
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => responseFrame.buffer,
+      } as unknown as Response;
+    }) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      prepareDevicePause: async () => new Uint8Array(),
+    });
+
+    await expect(handler.pauseClient(7, false)).resolves.toMatchObject({ status: 200 });
+    expect(deviceCalls).toBe(2);
+    expect(authCalls).toBe(2);
+  });
+
+  it("given: an expired session after retry, should: return the reconnect response", async () => {
+    const doFetch = (async () => res(401)) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      prepareDevicePause: async () => new Uint8Array(),
+    });
+
+    await expect(handler.pauseClient(7, true)).resolves.toMatchObject({
+      status: 428,
+      body: { error: "not_connected" },
+    });
+  });
+
+  it("given: the device gateway stalls, should: abort and return a retryable timeout", async () => {
+    const doFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === AUTH_URL) return res(200);
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    }) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceCallTimeoutMs: 5,
+      prepareDevicePause: async () => new Uint8Array(),
+    });
+
+    await expect(handler.pauseClient(7, true)).resolves.toEqual({
+      status: 504,
+      body: {
+        error: "device_call_timeout",
+        message: "Starlink did not answer the device update in time. Try again.",
+      },
+    });
+  });
+
+  it("given: token refresh stalls, should: abort the complete device operation", async () => {
+    const doFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    }) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceCallTimeoutMs: 5,
+      prepareDevicePause: async () => new Uint8Array(),
+    });
+
+    await expect(handler.pauseClient(7, true)).resolves.toMatchObject({
+      status: 504,
+      body: { error: "device_call_timeout" },
+    });
+  });
+
+  it("given: two device updates overlap, should: prepare the second after the first write", async () => {
+    const responseFrame = new Uint8Array([0, 0, 0, 0, 0]);
+    let releaseFirstWrite: (() => void) | undefined;
+    let deviceCalls = 0;
+    const doFetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === AUTH_URL) return res(200);
+      deviceCalls++;
+      if (deviceCalls === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirstWrite = resolve;
+        });
+      }
+      return {
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => responseFrame.buffer,
+      } as unknown as Response;
+    }) as typeof fetch;
+    const prepared: number[] = [];
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      prepareDevicePause: async (clientId) => {
+        prepared.push(clientId);
+        return new Uint8Array();
+      },
+    });
+
+    const first = handler.pauseClient(7, true);
+    const second = handler.pauseClient(8, true);
+    await vi.waitFor(() => expect(deviceCalls).toBe(1));
+    expect(prepared).toEqual([7]);
+
+    releaseFirstWrite?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { status: 200, body: { ok: true } },
+      { status: 200, body: { ok: true } },
+    ]);
+    expect(prepared).toEqual([7, 8]);
+  });
+
+  it("given: invalid renderer input, should: reject it before preparing a request", async () => {
+    let prepared = false;
+    const handler = createCloudHandler({
+      readCookie: () => SESSION,
+      prepareDevicePause: async () => {
+        prepared = true;
+        return new Uint8Array();
+      },
+    });
+
+    await expect(handler.pauseClient(Number.NaN, true)).resolves.toMatchObject({ status: 400 });
+    await expect(handler.pauseClient(7, "yes" as unknown as boolean)).resolves.toMatchObject({
+      status: 400,
+    });
+    expect(prepared).toBe(false);
   });
 });

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -7,8 +7,11 @@
 // This is separate from the historian on purpose: cloud data needs only the
 // internet and a cookie, and must not depend on the dish poller's health.
 
+import { GrpcWebError, grpcWebUnaryCall } from "../core/grpcWeb";
+
 const AUTH_URL = "https://api.starlink.com/auth-rp/auth/user";
 const API = "https://starlink.com/api";
+const DEVICE_HANDLE = `${API}/SpaceX.API.Device.Device/Handle`;
 const REFRESH_TTL_MS = 60_000; // the Access.V1 token is short-lived; refresh at most this often
 const IDS_TTL_MS = 5 * 60_000; // account/service-line numbers change ~never; cache across routes
 
@@ -39,6 +42,11 @@ export interface CloudHandlerOptions {
    *  microseconds earlier is not reliably applied to the very next worker fetch;
    *  the pause gives it a beat to take. Injected so tests retry without waiting. */
   retryDelayMs?: number;
+  /** Maximum time for each remote router mutation attempt. */
+  deviceCallTimeoutMs?: number;
+  /** Trusted host callback: reads the local router and encodes exactly one
+   *  pause/unpause request. Renderer-provided protobuf is never accepted. */
+  prepareDevicePause?: (clientId: number, paused: boolean) => Promise<Uint8Array>;
 }
 
 /** The durable half of the session — without it a token refresh can't happen, so
@@ -121,12 +129,15 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
   const writeCookie = options.writeCookie ?? (() => {});
   const clearCookie = options.clearCookie ?? (() => {});
   const retryDelayMs = options.retryDelayMs ?? 150;
+  const deviceCallTimeoutMs = options.deviceCallTimeoutMs ?? 15_000;
+  const prepareDevicePause = options.prepareDevicePause;
 
   let cachedCookie: string | null = null;
   let cachedAt = 0;
   let refreshInFlight: Promise<string | null> | null = null;
   let cachedIds: { acc: string; sl: string } | null = null;
   let cachedIdsAt = 0;
+  let deviceMutationTail: Promise<void> = Promise.resolve();
 
   function forgetSession() {
     cachedCookie = null;
@@ -139,31 +150,37 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
    *  without it). `force` busts the 60s cache after a mid-flight token expiry.
    *  Concurrent callers share one in-flight refresh so opening a surface fires
    *  one auth/user. */
-  async function freshCookie(force = false): Promise<string | null> {
+  async function freshCookie(force = false, abortSignal?: AbortSignal): Promise<string | null> {
     const base = readCookie();
     if (!base) return null;
     if (!force && cachedCookie && Date.now() - cachedAt < REFRESH_TTL_MS) return cachedCookie;
-    if (!force && refreshInFlight) return refreshInFlight;
+    if (!force && refreshInFlight && !abortSignal) return refreshInFlight;
 
-    refreshInFlight = (async () => {
-      try {
-        const authResponse = await doFetch(AUTH_URL, { headers: { cookie: base } });
-        // A dead SSO session answers the refresh itself with 401/403 — that's a
-        // reconnect, not an upstream failure. Surface it as such.
-        if (authResponse.status === 401 || authResponse.status === 403) {
-          forgetSession();
-          throw new SessionExpiredError();
-        }
-        const setCookie = authResponse.headers.get("set-cookie") ?? "";
-        const match = setCookie.match(/Starlink\.Com\.Access\.V1=([^;]+)/);
-        const withoutOld = base.replace(/Starlink\.Com\.Access\.V1=[^;]*;?/g, "").trim();
-        cachedCookie = match ? `Starlink.Com.Access.V1=${match[1]};${withoutOld}` : base;
-        cachedAt = Date.now();
-        return cachedCookie;
-      } finally {
-        refreshInFlight = null;
+    const refresh = (async () => {
+      const authResponse = await doFetch(AUTH_URL, {
+        headers: { cookie: base },
+        signal: abortSignal,
+      });
+      // A dead SSO session answers the refresh itself with 401/403 — that's a
+      // reconnect, not an upstream failure. Surface it as such.
+      if (authResponse.status === 401 || authResponse.status === 403) {
+        forgetSession();
+        throw new SessionExpiredError();
       }
+      const setCookie = authResponse.headers.get("set-cookie") ?? "";
+      const match = setCookie.match(/Starlink\.Com\.Access\.V1=([^;]+)/);
+      const withoutOld = base.replace(/Starlink\.Com\.Access\.V1=[^;]*;?/g, "").trim();
+      cachedCookie = match ? `Starlink.Com.Access.V1=${match[1]};${withoutOld}` : base;
+      cachedAt = Date.now();
+      return cachedCookie;
     })();
+
+    // Bounded mutations use their own abortable refresh rather than inheriting
+    // an unrelated, potentially stalled shared read request.
+    if (abortSignal) return refresh;
+    refreshInFlight = refresh.finally(() => {
+      refreshInFlight = null;
+    });
     return refreshInFlight;
   }
 
@@ -176,9 +193,12 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
    *  and try once more. A genuinely dead session throws again on that retry and
    *  surfaces as not-connected. The initial refresh is inside the retry because
    *  that first auth/user is exactly where the late cookie bites. */
-  async function withFreshCookie<T>(run: (cookie: string) => Promise<T>): Promise<T> {
+  async function withFreshCookie<T>(
+    run: (cookie: string) => Promise<T>,
+    abortSignal?: AbortSignal,
+  ): Promise<T> {
     const attempt = async (force: boolean): Promise<T> => {
-      const cookie = await freshCookie(force);
+      const cookie = await freshCookie(force, abortSignal);
       if (!cookie) throw new SessionExpiredError();
       return run(cookie);
     };
@@ -337,5 +357,63 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     return { status: 200, body: { ok: true } };
   }
 
-  return { handle, connect, disconnect };
+  async function applyClientPaused(clientId: number, paused: boolean): Promise<CloudResult> {
+    if (!readCookie()) return NOT_CONNECTED;
+    try {
+      // This callback reads the full client-config list. Keep preparation and
+      // the corresponding write in one serialized critical section so a later
+      // mutation cannot be built from a snapshot predating an earlier write.
+      if (!prepareDevicePause) return { status: 503, body: { error: "pause_unavailable" } };
+      const requestBytes = await prepareDevicePause(clientId, paused);
+      const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
+      await withFreshCookie(async (cookie) => {
+        try {
+          await grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
+            fetch: doFetch,
+            headers: { cookie },
+          });
+        } catch (error) {
+          if (error instanceof GrpcWebError && error.grpcStatus === 16)
+            throw new SessionExpiredError();
+          throw error;
+        }
+      }, abortSignal);
+      return { status: 200, body: { ok: true } };
+    } catch (error) {
+      if (error instanceof SessionExpiredError) return NOT_CONNECTED;
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        return {
+          status: 504,
+          body: {
+            error: "device_call_timeout",
+            message: "Starlink did not answer the device update in time. Try again.",
+          },
+        };
+      }
+      return {
+        status: 502,
+        body: { error: "device_call_failed", message: (error as Error).message },
+      };
+    }
+  }
+
+  function pauseClient(clientId: number, paused: boolean): Promise<CloudResult> {
+    if (
+      !Number.isInteger(clientId) ||
+      clientId < 0 ||
+      clientId > 0xffff_ffff ||
+      typeof paused !== "boolean"
+    )
+      return Promise.resolve({ status: 400, body: { error: "bad_request" } });
+
+    const mutation = deviceMutationTail.then(() => applyClientPaused(clientId, paused));
+    // A rejected mutation must not poison the queue for every later device.
+    deviceMutationTail = mutation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return mutation;
+  }
+
+  return { handle, connect, disconnect, pauseClient };
 }

--- a/core/dishClient.ts
+++ b/core/dishClient.ts
@@ -44,6 +44,7 @@ export function setDishHost(binding: DishHost): void {
  *  collidable with another router's default. lib/routerDiagnosis turns a failure
  *  to reach it into the one wording every surface reports. */
 export const ROUTER_LAN_ADDRESS = "192.168.1.1";
+export const ROUTER_LAN_HANDLE_URL = `http://${ROUTER_LAN_ADDRESS}:9001/SpaceX.API.Device.Device/Handle`;
 
 // Oneof field numbers inside SpaceX.API.Device.Request (from the dish schema).
 const REQUEST_FIELD = {
@@ -273,8 +274,27 @@ export interface WifiNetworkConfigJson {
   countryCode?: string;
   networks?: WifiLanNetworkJson[];
   meshConfigs?: Record<string, WifiMeshNodeJson>;
-  clientConfigs?: Array<{ clientId?: number; macAddress?: string; givenName?: string }>;
+  clientConfigs?: WifiClientConfigJson[];
   boot?: { evenSideSoftwareVersion?: string; oddSideSoftwareVersion?: string; lastReason?: string };
+  [key: string]: unknown;
+}
+
+export interface WifiBlockRangeJson {
+  startMinutes?: number;
+  endMinutes?: number;
+}
+
+export interface WifiWeeklyBlockScheduleJson {
+  blockRanges?: WifiBlockRangeJson[];
+  groupId?: string;
+}
+
+export interface WifiClientConfigJson {
+  clientId?: number;
+  macAddress?: string;
+  givenName?: string;
+  weeklyBlockSchedules?: WifiWeeklyBlockScheduleJson[];
+  groupId?: string;
   [key: string]: unknown;
 }
 
@@ -455,12 +475,15 @@ export class DishClient {
    */
   static async load(
     target: "dish" | "router" = "dish",
-    options: { handleUrl?: string; protosetUrl?: string } = {},
+    options: { handleUrl?: string; protosetUrl?: string; protosetBytes?: Uint8Array } = {},
   ): Promise<DishClient> {
-    const protosetResponse = await fetch(
-      options.protosetUrl ?? dishHost.protosetUrl ?? "/dish.protoset",
-    );
-    const protosetBytes = new Uint8Array(await protosetResponse.arrayBuffer());
+    const protosetBytes = options.protosetBytes
+      ? options.protosetBytes
+      : new Uint8Array(
+          await (
+            await fetch(options.protosetUrl ?? dishHost.protosetUrl ?? "/dish.protoset")
+          ).arrayBuffer(),
+        );
     const fileDescriptorSet = fromBinary(FileDescriptorSetSchema, protosetBytes);
     const registry = createFileRegistry(fileDescriptorSet);
     const requestSchema = registry.getMessage("SpaceX.API.Device.Request");
@@ -568,6 +591,15 @@ export class DishClient {
     return toJson(this.responseSchema, responseMessage, {
       registry: this.registry,
     }) as DishResponseJson;
+  }
+
+  /** Encode a Device.Request for an authenticated host to send through the cloud
+   *  gateway. This does not perform a local router write. */
+  encodeRequest(requestJson: object): Uint8Array {
+    return toBinary(
+      this.requestSchema,
+      fromJson(this.requestSchema, requestJson as JsonValue, { registry: this.registry }),
+    );
   }
 
   /** Current dish configuration (sleep schedule, snow melt, update window …). */

--- a/core/grpcWeb.ts
+++ b/core/grpcWeb.ts
@@ -46,10 +46,19 @@ export async function grpcWebUnaryCall(
   methodUrl: string,
   requestBytes: Uint8Array,
   abortSignal?: AbortSignal,
+  options: {
+    fetch?: typeof fetch;
+    headers?: Record<string, string>;
+  } = {},
 ): Promise<Uint8Array> {
-  const httpResponse = await fetch(methodUrl, {
+  const doFetch = options.fetch ?? fetch;
+  const httpResponse = await doFetch(methodUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/grpc-web+proto", "X-Grpc-Web": "1" },
+    headers: {
+      "Content-Type": "application/grpc-web+proto",
+      "X-Grpc-Web": "1",
+      ...options.headers,
+    },
     body: encodeFrame(requestBytes) as unknown as BodyInit,
     signal: abortSignal ?? null,
   });
@@ -63,7 +72,10 @@ export async function grpcWebUnaryCall(
     );
   }
   if (!httpResponse.ok) {
-    throw new GrpcWebError(2, `HTTP ${httpResponse.status}`);
+    throw new GrpcWebError(
+      httpResponse.status === 401 || httpResponse.status === 403 ? 16 : 2,
+      `HTTP ${httpResponse.status}`,
+    );
   }
 
   const body = new Uint8Array(await httpResponse.arrayBuffer());

--- a/core/hostNetworkIdentity.ts
+++ b/core/hostNetworkIdentity.ts
@@ -1,0 +1,26 @@
+// Node-only: never import this from the browser bundle.
+
+import { networkInterfaces } from "node:os";
+
+export interface HostNetworkIdentity {
+  macAddresses: string[];
+  ipAddresses: string[];
+}
+
+export function localNetworkIdentity(): HostNetworkIdentity {
+  const interfaces = Object.values(networkInterfaces())
+    .flatMap((entries) => entries ?? [])
+    .filter((entry) => !entry.internal);
+  return {
+    macAddresses: [
+      ...new Set(
+        interfaces
+          .map((entry) => entry.mac.toLowerCase())
+          .filter((macAddress) => macAddress && macAddress !== "00:00:00:00:00:00"),
+      ),
+    ],
+    ipAddresses: [
+      ...new Set(interfaces.map((entry) => entry.address.replace(/^::ffff:/i, "").toLowerCase())),
+    ],
+  };
+}

--- a/core/routerPause.test.ts
+++ b/core/routerPause.test.ts
@@ -112,4 +112,35 @@ describe("buildRouterPauseRequest", () => {
       },
     });
   });
+
+  test("given: the target is the host itself, should: refuse to pause but allow unpause", async () => {
+    const router = {
+      getWifiConfig: async () => config,
+      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
+      getWifiClients: async () => [
+        { clientId: 7, macAddress: "AA:BB:CC:XX:XX:XX", ipAddress: "192.168.1.5" },
+      ],
+      encodeRequest: () => new Uint8Array([9]),
+    } as unknown as DishClient;
+    const host = { macAddresses: ["aa:bb:cc:XX:XX:XX"], ipAddresses: [] };
+
+    await expect(prepareRouterPauseRequest(router, 7, true, host)).rejects.toThrow(/Refusing/);
+    await expect(prepareRouterPauseRequest(router, 7, false, host)).resolves.toBeInstanceOf(
+      Uint8Array,
+    );
+  });
+
+  test("given: the host matches only by address, should: still refuse the pause", async () => {
+    const router = {
+      getWifiConfig: async () => config,
+      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
+      getWifiClients: async () => [
+        { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" },
+      ],
+      encodeRequest: () => new Uint8Array([9]),
+    } as unknown as DishClient;
+    const host = { macAddresses: [], ipAddresses: ["192.168.1.5"] };
+
+    await expect(prepareRouterPauseRequest(router, 7, true, host)).rejects.toThrow(/Refusing/);
+  });
 });

--- a/core/routerPause.test.ts
+++ b/core/routerPause.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+import type { DishClient } from "./dishClient";
+import { buildRouterPauseRequest, prepareRouterPauseRequest } from "./routerPause";
+
+const TARGET = "Router-010000000000000001B31340";
+const config = {
+  clientConfigs: [
+    {
+      clientId: 7,
+      macAddress: "aa:bb:cc:XX:XX:XX",
+      givenName: "Tablet",
+      weeklyBlockSchedules: [
+        { groupId: "bedtime", blockRanges: [{ startMinutes: 60, endMinutes: 120 }] },
+      ],
+    },
+    { clientId: 8, macAddress: "dd:ee:ff:XX:XX:XX", groupId: "family" },
+  ],
+};
+
+describe("buildRouterPauseRequest", () => {
+  test("given: a client with another schedule, should: add permanent pause without losing data", () => {
+    const request = buildRouterPauseRequest(TARGET, config, 7, true);
+    const clients = request.wifiSetConfig.wifiConfig.clientConfigs;
+
+    expect(clients[0]).toEqual({
+      ...config.clientConfigs[0],
+      weeklyBlockSchedules: [
+        config.clientConfigs[0].weeklyBlockSchedules?.[0],
+        {
+          groupId: "_permanent",
+          blockRanges: [{ startMinutes: 0, endMinutes: 10080 }],
+        },
+      ],
+    });
+    expect(clients[1]).toEqual(config.clientConfigs[1]);
+    expect(request.wifiSetConfig.wifiConfig.applyClientConfigs).toBe(true);
+  });
+
+  test("given: a paused client, should: remove only the permanent schedule", () => {
+    const paused = buildRouterPauseRequest(TARGET, config, 7, true);
+    const request = buildRouterPauseRequest(
+      TARGET,
+      { clientConfigs: paused.wifiSetConfig.wifiConfig.clientConfigs },
+      7,
+      false,
+    );
+
+    expect(request.wifiSetConfig.wifiConfig.clientConfigs[0].weeklyBlockSchedules).toEqual([
+      config.clientConfigs[0].weeklyBlockSchedules?.[0],
+    ]);
+  });
+
+  test("given: a connected client has no saved config, should: append a minimal paused entry", () => {
+    const request = buildRouterPauseRequest(TARGET, config, 99, true, {
+      clientId: 99,
+      macAddress: "11:22:33:XX:XX:XX",
+    });
+
+    expect(request.wifiSetConfig.wifiConfig.clientConfigs).toHaveLength(3);
+    expect(request.wifiSetConfig.wifiConfig.clientConfigs[2]).toEqual({
+      clientId: 99,
+      macAddress: "11:22:33:XX:XX:XX",
+      weeklyBlockSchedules: [
+        {
+          groupId: "_permanent",
+          blockRanges: [{ startMinutes: 0, endMinutes: 10080 }],
+        },
+      ],
+    });
+    expect(request.wifiSetConfig.wifiConfig.clientConfigs.slice(0, 2)).toEqual(
+      config.clientConfigs,
+    );
+  });
+
+  test("given: an unknown client or non-router target, should: refuse the write", () => {
+    expect(() => buildRouterPauseRequest(TARGET, config, 99, true)).toThrow(/live clients/);
+    expect(() => buildRouterPauseRequest("ut-dish", config, 7, true)).toThrow(/router target/);
+  });
+
+  test("given: a trusted host, should: source and encode the request from router reads", async () => {
+    const encoded = new Uint8Array([1, 2, 3]);
+    let request: object | undefined;
+    const router = {
+      getWifiConfig: async () => config,
+      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
+      getWifiClients: async () => [
+        { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", givenName: "Tablet" },
+      ],
+      encodeRequest: (value: object) => {
+        request = value;
+        return encoded;
+      },
+    } as unknown as DishClient;
+
+    await expect(prepareRouterPauseRequest(router, 7, true)).resolves.toBe(encoded);
+    expect(request).toMatchObject({
+      targetId: TARGET,
+      wifiSetConfig: {
+        wifiConfig: {
+          applyClientConfigs: true,
+          clientConfigs: [
+            expect.objectContaining({
+              clientId: 7,
+              weeklyBlockSchedules: [
+                expect.objectContaining({ groupId: "bedtime" }),
+                expect.objectContaining({ groupId: "_permanent" }),
+              ],
+            }),
+            config.clientConfigs[1],
+          ],
+        },
+      },
+    });
+  });
+});

--- a/core/routerPause.ts
+++ b/core/routerPause.ts
@@ -1,0 +1,80 @@
+import type { DishClient, WifiClientConfigJson, WifiNetworkConfigJson } from "./dishClient";
+
+const PERMANENT_GROUP = "_permanent";
+const WEEK_MINUTES = 7 * 24 * 60;
+
+export interface RouterPauseRequestJson {
+  targetId: string;
+  wifiSetConfig: {
+    wifiConfig: {
+      clientConfigs: WifiClientConfigJson[];
+      applyClientConfigs: true;
+    };
+  };
+}
+
+/**
+ * Build the smallest client-config update accepted by the router schema.
+ * Every existing client entry and non-permanent schedule is preserved; only
+ * the selected client's `_permanent` schedule is added or removed.
+ */
+export function buildRouterPauseRequest(
+  targetId: string,
+  config: WifiNetworkConfigJson,
+  clientId: number,
+  paused: boolean,
+  liveClient?: { clientId?: number; macAddress?: string },
+): RouterPauseRequestJson {
+  if (!targetId.startsWith("Router-")) throw new Error("invalid router target id");
+  const existing = [...(config.clientConfigs ?? [])];
+  if (!existing.some((client) => client.clientId === clientId)) {
+    if (liveClient?.clientId !== clientId || !liveClient.macAddress)
+      throw new Error("client is absent from router configuration and live clients");
+    existing.push({ clientId, macAddress: liveClient.macAddress });
+  }
+
+  const clientConfigs = existing.map((client) => {
+    if (client.clientId !== clientId) return { ...client };
+    const schedules = (client.weeklyBlockSchedules ?? []).filter(
+      (schedule) => schedule.groupId !== PERMANENT_GROUP,
+    );
+    if (paused) {
+      schedules.push({
+        blockRanges: [{ startMinutes: 0, endMinutes: WEEK_MINUTES }],
+        groupId: PERMANENT_GROUP,
+      });
+    }
+    return { ...client, weeklyBlockSchedules: schedules };
+  });
+
+  return {
+    targetId,
+    wifiSetConfig: {
+      wifiConfig: {
+        clientConfigs,
+        applyClientConfigs: true,
+      },
+    },
+  };
+}
+
+/** Trusted-host preparation: source target, config, and client identity directly
+ *  from the local router immediately before encoding the cloud write. */
+export async function prepareRouterPauseRequest(
+  router: DishClient,
+  clientId: number,
+  paused: boolean,
+): Promise<Uint8Array> {
+  const [config, status, clients] = await Promise.all([
+    router.getWifiConfig(AbortSignal.timeout(5_000)),
+    router.getRouterStatus(AbortSignal.timeout(5_000)),
+    router.getWifiClients(AbortSignal.timeout(5_000)),
+  ]);
+  const targetId = status.deviceInfo?.id;
+  if (!targetId) throw new Error("Starlink router identity is unavailable");
+  const liveClient = clients.find((client) => client.clientId === clientId);
+  if (!liveClient) throw new Error("Device is no longer connected to the router");
+  return router.encodeRequest(
+    buildRouterPauseRequest(targetId, config, clientId, paused, liveClient),
+  );
+}

--- a/core/routerPause.ts
+++ b/core/routerPause.ts
@@ -1,4 +1,10 @@
-import type { DishClient, WifiClientConfigJson, WifiNetworkConfigJson } from "./dishClient";
+import type {
+  DishClient,
+  WifiClientConfigJson,
+  WifiClientJson,
+  WifiNetworkConfigJson,
+} from "./dishClient";
+import type { HostNetworkIdentity } from "./hostNetworkIdentity";
 
 const PERMANENT_GROUP = "_permanent";
 const WEEK_MINUTES = 7 * 24 * 60;
@@ -58,12 +64,32 @@ export function buildRouterPauseRequest(
   };
 }
 
+const normalizeAddress = (address: string): string =>
+  address.replace(/^::ffff:/i, "").toLowerCase();
+
+/** True when this router client entry is the machine preparing the request.
+ *  Both sides are normalised here so no caller has to pre-lowercase. */
+export function clientIsHost(client: WifiClientJson, host: HostNetworkIdentity): boolean {
+  const macAddress = client.macAddress?.toLowerCase();
+  if (macAddress && host.macAddresses.some((candidate) => candidate.toLowerCase() === macAddress))
+    return true;
+  const hostAddresses = host.ipAddresses.map(normalizeAddress);
+  return [client.ipAddress, ...(client.ipv6Addresses ?? [])].some(
+    (address) => address && hostAddresses.includes(normalizeAddress(address)),
+  );
+}
+
 /** Trusted-host preparation: source target, config, and client identity directly
- *  from the local router immediately before encoding the cloud write. */
+ *  from the local router immediately before encoding the cloud write.
+ *
+ *  A device that pauses itself cannot undo it — the official Starlink app hides
+ *  the control for the device it runs on, so recovery needs a second machine.
+ *  `hostIdentity` refuses that write here because the UI guard is bypassable. */
 export async function prepareRouterPauseRequest(
   router: DishClient,
   clientId: number,
   paused: boolean,
+  hostIdentity?: HostNetworkIdentity,
 ): Promise<Uint8Array> {
   const [config, status, clients] = await Promise.all([
     router.getWifiConfig(AbortSignal.timeout(5_000)),
@@ -74,6 +100,8 @@ export async function prepareRouterPauseRequest(
   if (!targetId) throw new Error("Starlink router identity is unavailable");
   const liveClient = clients.find((client) => client.clientId === clientId);
   if (!liveClient) throw new Error("Device is no longer connected to the router");
+  if (paused && hostIdentity && clientIsHost(liveClient, hostIdentity))
+    throw new Error("Refusing to pause the device Dishylink is running on");
   return router.encodeRequest(
     buildRouterPauseRequest(targetId, config, clientId, paused, liveClient),
   );

--- a/dev/starlinkCloudProxy.ts
+++ b/dev/starlinkCloudProxy.ts
@@ -14,6 +14,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler.ts";
 import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
 import { prepareRouterPauseRequest } from "../core/routerPause.ts";
+import { localNetworkIdentity } from "../core/hostNetworkIdentity.ts";
 
 const COOKIE_FILE = resolve(process.cwd(), ".starlink-cookie");
 
@@ -43,6 +44,19 @@ function sendJson(res: ServerResponse, status: number, payload: unknown) {
   res.end(JSON.stringify(payload));
 }
 
+// A text/plain POST is a CORS simple request: no preflight, so a page on any site
+// lands the write without ever reading the reply. Loopback binding is no defence,
+// the request comes from a browser on this machine.
+function isLocalOrigin(origin?: string): boolean {
+  if (!origin) return true;
+  try {
+    const { hostname } = new URL(origin);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolveBody, reject) => {
     let data = "";
@@ -70,12 +84,19 @@ export function starlinkCloudProxy(): Plugin {
               readFileSync(resolve(process.cwd(), "public/dish.protoset")),
             ),
           });
-          return prepareRouterPauseRequest(await routerPromise, clientId, paused);
+          return prepareRouterPauseRequest(
+            await routerPromise,
+            clientId,
+            paused,
+            localNetworkIdentity(),
+          );
         },
       });
       server.middlewares.use(async (req: IncomingMessage, res: ServerResponse, next) => {
         const url = req.url ?? "";
         if (!url.startsWith("/cloud/")) return next();
+        if (!isLocalOrigin(req.headers.origin))
+          return sendJson(res, 403, { error: "forbidden_origin" });
         const route = url.split("?")[0];
 
         // Connect / disconnect the session pasted from the UI.

--- a/dev/starlinkCloudProxy.ts
+++ b/dev/starlinkCloudProxy.ts
@@ -12,6 +12,8 @@ import { resolve } from "node:path";
 import type { Plugin } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler.ts";
+import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
+import { prepareRouterPauseRequest } from "../core/routerPause.ts";
 
 const COOKIE_FILE = resolve(process.cwd(), ".starlink-cookie");
 
@@ -56,7 +58,21 @@ export function starlinkCloudProxy(): Plugin {
   return {
     name: "starlink-cloud-proxy",
     configureServer(server) {
-      const handler = createCloudHandler({ readCookie, writeCookie, clearCookie });
+      let routerPromise: Promise<DishClient> | null = null;
+      const handler = createCloudHandler({
+        readCookie,
+        writeCookie,
+        clearCookie,
+        prepareDevicePause: async (clientId, paused) => {
+          routerPromise ??= DishClient.load("router", {
+            handleUrl: ROUTER_LAN_HANDLE_URL,
+            protosetBytes: new Uint8Array(
+              readFileSync(resolve(process.cwd(), "public/dish.protoset")),
+            ),
+          });
+          return prepareRouterPauseRequest(await routerPromise, clientId, paused);
+        },
+      });
       server.middlewares.use(async (req: IncomingMessage, res: ServerResponse, next) => {
         const url = req.url ?? "";
         if (!url.startsWith("/cloud/")) return next();
@@ -81,6 +97,19 @@ export function starlinkCloudProxy(): Plugin {
             }
           }
           return sendJson(res, 405, { error: "method_not_allowed" });
+        }
+
+        if (route === "/cloud/device" && req.method === "POST") {
+          try {
+            const { clientId, paused } = JSON.parse((await readBody(req)) || "{}") as {
+              clientId?: number;
+              paused?: boolean;
+            };
+            const result = await handler.pauseClient(clientId as number, paused as boolean);
+            return sendJson(res, result.status, result.body);
+          } catch (error) {
+            return sendJson(res, 400, { error: "bad_request", message: (error as Error).message });
+          }
         }
 
         const { status, body } = await handler.handle(route);

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler";
 import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient";
 import { prepareRouterPauseRequest } from "../core/routerPause";
+import { localNetworkIdentity } from "../core/hostNetworkIdentity";
 
 const LOGIN_URL = "https://www.starlink.com/account";
 // The login window gets its own session, so signing out can wipe its Starlink
@@ -63,7 +64,12 @@ export function startCloud(rendererRoot: string): void {
         handleUrl: ROUTER_LAN_HANDLE_URL,
         protosetBytes: new Uint8Array(readFileSync(protosetPath)),
       });
-      return prepareRouterPauseRequest(await routerPromise, clientId, paused);
+      return prepareRouterPauseRequest(
+        await routerPromise,
+        clientId,
+        paused,
+        localNetworkIdentity(),
+      );
     },
   });
 }

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -9,6 +9,8 @@ import { app, safeStorage, BrowserWindow, session } from "electron";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler";
+import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient";
+import { prepareRouterPauseRequest } from "../core/routerPause";
 
 const LOGIN_URL = "https://www.starlink.com/account";
 // The login window gets its own session, so signing out can wipe its Starlink
@@ -46,9 +48,24 @@ function clearCookie(): void {
 }
 
 /** Create the cloud client once, after the app is ready (the data path needs it). */
-export function startCloud(): void {
+export function startCloud(rendererRoot: string): void {
   cookieFile = join(app.getPath("userData"), "starlink-session.bin");
-  handler = createCloudHandler({ readCookie, writeCookie, clearCookie });
+  const protosetPath = app.isPackaged
+    ? join(rendererRoot, "dish.protoset")
+    : join(app.getAppPath(), "public/dish.protoset");
+  let routerPromise: Promise<DishClient> | null = null;
+  handler = createCloudHandler({
+    readCookie,
+    writeCookie,
+    clearCookie,
+    prepareDevicePause: async (clientId, paused) => {
+      routerPromise ??= DishClient.load("router", {
+        handleUrl: ROUTER_LAN_HANDLE_URL,
+        protosetBytes: new Uint8Array(readFileSync(protosetPath)),
+      });
+      return prepareRouterPauseRequest(await routerPromise, clientId, paused);
+    },
+  });
 }
 
 function json(status: number, body: unknown): Response {
@@ -77,6 +94,15 @@ export async function handleCloudRequest(request: Request): Promise<Response> {
       return json(status, body);
     }
     return json(405, { error: "method_not_allowed" });
+  }
+
+  if (route === "/cloud/device" && request.method === "POST") {
+    const { clientId, paused } = (await request.json().catch(() => ({}))) as {
+      clientId?: number;
+      paused?: boolean;
+    };
+    const { status, body } = await handler.pauseClient(clientId as number, paused as boolean);
+    return json(status, body);
   }
 
   const { status, body } = await handler.handle(route);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -553,7 +553,7 @@ void app.whenReady().then(async () => {
   }
   // The cloud account belongs to this host, not to packaging; bound before the window
   // loads so the renderer's first /cloud/* call has somewhere to land.
-  startCloud();
+  startCloud(rendererRoot);
   registerCloudHandlers();
   // Only the packaged app serves itself; in dev Vite proxies /api to the dev historian,
   // so a second collector here would double-poll the dish.

--- a/extension/entrypoints/dashboard/main.tsx
+++ b/extension/entrypoints/dashboard/main.tsx
@@ -24,7 +24,14 @@ setApiHost({ transport: extensionApiTransport });
 
 // Account features read starlink.com over the internet, carried to the service
 // worker which holds the browser's own session; the app never learns the host.
-setCloudHost({ transport: extensionCloudTransport, signIn: extensionCloudSignIn });
+setCloudHost({
+  transport: extensionCloudTransport,
+  signIn: extensionCloudSignIn,
+  // Chrome extensions cannot reliably resolve the viewer's LAN IP or MAC on
+  // desktop platforms. Disable the control so the extension can never offer to
+  // pause the device it is running on.
+  supportsRouterClientPause: false,
+});
 
 // The background worker posts OS notifications for alerts the user is not looking
 // at — its alarm fires with no dashboard open. So the extension declares itself an

--- a/scripts/probe-client-pause-state.mts
+++ b/scripts/probe-client-pause-state.mts
@@ -1,0 +1,40 @@
+// Read-only snapshot of persisted block schedules and effective client state.
+// Run: npx tsx scripts/probe-client-pause-state.mts [device-name]
+import { readFileSync } from "node:fs";
+import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
+
+const nativeFetch = globalThis.fetch;
+globalThis.fetch = (input, init) => {
+  if (String(input) === "local:router-protoset")
+    return Promise.resolve(new Response(readFileSync("public/dish.protoset")));
+  return nativeFetch(input, init);
+};
+
+const client = await DishClient.load("router", {
+  handleUrl: ROUTER_LAN_HANDLE_URL,
+  protosetUrl: "local:router-protoset",
+});
+const [config, clients] = await Promise.all([
+  client.getWifiConfig(AbortSignal.timeout(5_000)),
+  client.getWifiClients(AbortSignal.timeout(5_000)),
+]);
+const wanted = process.argv.slice(2).join(" ").toLowerCase();
+const liveById = new Map(clients.map((entry) => [entry.clientId, entry]));
+const rows = (config.clientConfigs ?? [])
+  .filter((entry) => {
+    const live = liveById.get(entry.clientId);
+    const name = String(entry.givenName ?? live?.givenName ?? live?.name ?? "");
+    return !wanted || name.toLowerCase().includes(wanted);
+  })
+  .map((entry) => {
+    const live = liveById.get(entry.clientId);
+    return {
+      name: entry.givenName ?? live?.givenName ?? live?.name ?? "Unnamed device",
+      clientId: entry.clientId,
+      blocked: live?.blocked ?? false,
+      connected: Boolean(live),
+      weeklyBlockSchedules: entry.weeklyBlockSchedules ?? [],
+    };
+  });
+
+console.log(JSON.stringify(rows, null, 2));

--- a/src/components/account/AccountPanel.tsx
+++ b/src/components/account/AccountPanel.tsx
@@ -1,6 +1,6 @@
-// Portal-style account view from the user's own starlink.com session (read-only):
-// identity, plan, service address, and the dish/router device list. Mirrors
-// starlink.com/account. Cloud-only, entirely separate from the local dish surfaces.
+// Portal-style account view from the user's own starlink.com session: identity,
+// plan, service address, and the dish/router device list. The same optional
+// session also authorizes supported router controls from local device surfaces.
 //
 // What is left here is the page: fetch state, and the four cards. The device
 // browser is its own component, and the list it renders is built by a pure

--- a/src/components/network/DeviceDetail.tsx
+++ b/src/components/network/DeviceDetail.tsx
@@ -1,7 +1,7 @@
 // Drill-in for one client device: identity header with rename, the spec sheet,
 // and its throughput charts.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { throughputMbps, type WifiClientJson } from "@core/dishClient";
 import { usageKey, type ClientUsageTotal } from "@core/clientUsage";
 import type { TelemetrySample } from "@core/telemetry";
@@ -21,6 +21,20 @@ import { Button } from "../ui/button";
 import { clientPauseControlAvailable, setRouterClientPaused } from "../../lib/routerPause";
 import { useCloudAccount } from "../../hooks/useCloudAccount";
 import { supportsRouterClientPause } from "../../lib/cloudHost";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+
+// The router's client roster is what says whether a pause landed, and it is polled
+// on its own 5s cadence. Holding the control pending until that roster agrees is
+// what keeps the label from flicking back through its old value in between. The
+// timeout is the backstop for a write the gateway accepts but never applies.
+const PAUSE_SETTLE_TIMEOUT_MS = 20_000;
 
 export function DeviceDetail({
   client,
@@ -29,6 +43,7 @@ export function DeviceDetail({
   total,
   upstreamName,
   isThisDevice,
+  viewerIdentified,
   onRename,
 }: {
   client: WifiClientJson;
@@ -41,38 +56,50 @@ export function DeviceDetail({
   upstreamName?: string;
   /** True when this is the device viewing the dashboard. */
   isThisDevice: boolean;
+  /** Whether the viewer's own device could be resolved at all. False makes
+   *  `isThisDevice` meaningless, since nothing can match an unknown identity. */
+  viewerIdentified: boolean;
   onRename: (macAddress: string, givenName: string) => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
-  const [pauseBusy, setPauseBusy] = useState(false);
+  const [pendingPaused, setPendingPaused] = useState<boolean | null>(null);
+  const [confirmingPause, setConfirmingPause] = useState(false);
   const [pauseError, setPauseError] = useState<string | null>(null);
   const paused = client.blocked === true;
+  // The roster agreeing with what was asked is what ends the pending state, and
+  // adjusting it here rather than in an effect keeps the label from rendering one
+  // frame of the stale value first.
+  if (pendingPaused !== null && paused === pendingPaused) setPendingPaused(null);
+  const pauseBusy = pendingPaused !== null && paused !== pendingPaused;
   const { status: cloudStatus } = useCloudAccount(true);
-  const showPauseControl = clientPauseControlAvailable(
-    client.clientId,
+  const showPauseControl = clientPauseControlAvailable({
+    clientId: client.clientId,
     isThisDevice,
-    cloudStatus === "ready",
-    supportsRouterClientPause(),
-  );
+    viewerIdentified,
+    cloudConnected: cloudStatus === "ready",
+    hostSupportsPause: supportsRouterClientPause(),
+  });
 
-  const togglePaused = async () => {
-    if (
-      client.clientId === undefined ||
-      pauseBusy ||
-      isThisDevice ||
-      cloudStatus !== "ready" ||
-      !supportsRouterClientPause()
-    )
-      return;
-    const next = !paused;
-    setPauseBusy(true);
+  useEffect(() => {
+    if (pendingPaused === null) return;
+    const timer = window.setTimeout(() => {
+      setPendingPaused(null);
+      setPauseError("The router has not applied this yet. Give it a moment, then try again.");
+    }, PAUSE_SETTLE_TIMEOUT_MS);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [pendingPaused]);
+
+  const applyPaused = async (next: boolean) => {
+    if (client.clientId === undefined || pauseBusy || !showPauseControl) return;
+    setPendingPaused(next);
     setPauseError(null);
     try {
       await setRouterClientPaused(client.clientId, next);
     } catch (error) {
+      setPendingPaused(null);
       setPauseError((error as Error).message);
-    } finally {
-      setPauseBusy(false);
     }
   };
 
@@ -139,13 +166,58 @@ export function DeviceDetail({
               size='sm'
               className='cursor-pointer disabled:cursor-not-allowed'
               disabled={pauseBusy}
-              onClick={() => void togglePaused()}
+              onClick={() => {
+                if (paused) void applyPaused(false);
+                else setConfirmingPause(true);
+              }}
             >
-              {pauseBusy ? (paused ? "Unpausing…" : "Pausing…") : paused ? "Unpause" : "Pause"}
+              {pauseBusy
+                ? pendingPaused
+                  ? "Pausing…"
+                  : "Unpausing…"
+                : paused
+                  ? "Unpause"
+                  : "Pause"}
             </Button>
           )}
         </div>
       </div>
+
+      {/* Pausing is confirmed, unpausing is not: only one of the two takes a device
+          off the internet, and the way back is not obvious from the device itself. */}
+      <Dialog open={confirmingPause} onOpenChange={setConfirmingPause}>
+        <DialogContent
+          showCloseButton={false}
+          className='gap-3 border-border/50 sm:max-w-md'
+          overlayClassName='bg-black/30 backdrop-blur-[2px]'
+        >
+          <DialogHeader>
+            <DialogTitle className='text-[19px] leading-snug'>Pause “{name}”?</DialogTitle>
+            <DialogDescription className='text-[13.5px] leading-relaxed'>
+              This will pause internet access for this device. It stays connected to your network,
+              and you can unpause it at any time.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className='mt-2 gap-2'>
+            <Button
+              variant='outline'
+              className='cursor-pointer sm:min-w-28'
+              onClick={() => setConfirmingPause(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              className='cursor-pointer sm:min-w-28'
+              onClick={() => {
+                setConfirmingPause(false);
+                void applyPaused(true);
+              }}
+            >
+              Pause
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {pauseError && (
         <div className='mb-3 rounded-md border border-destructive/30 bg-destructive/8 px-3 py-2 text-[12px] text-destructive'>

--- a/src/components/network/DeviceDetail.tsx
+++ b/src/components/network/DeviceDetail.tsx
@@ -17,6 +17,10 @@ import { DeviceThroughput } from "./DeviceThroughput";
 import { buildDeviceFacts } from "./deviceFacts";
 import { deviceRowSubtitle } from "./deviceRowSubtitle";
 import { displayName, signalQuality } from "./networkFormat";
+import { Button } from "../ui/button";
+import { clientPauseControlAvailable, setRouterClientPaused } from "../../lib/routerPause";
+import { useCloudAccount } from "../../hooks/useCloudAccount";
+import { supportsRouterClientPause } from "../../lib/cloudHost";
 
 export function DeviceDetail({
   client,
@@ -40,6 +44,37 @@ export function DeviceDetail({
   onRename: (macAddress: string, givenName: string) => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
+  const [pauseBusy, setPauseBusy] = useState(false);
+  const [pauseError, setPauseError] = useState<string | null>(null);
+  const paused = client.blocked === true;
+  const { status: cloudStatus } = useCloudAccount(true);
+  const showPauseControl = clientPauseControlAvailable(
+    client.clientId,
+    isThisDevice,
+    cloudStatus === "ready",
+    supportsRouterClientPause(),
+  );
+
+  const togglePaused = async () => {
+    if (
+      client.clientId === undefined ||
+      pauseBusy ||
+      isThisDevice ||
+      cloudStatus !== "ready" ||
+      !supportsRouterClientPause()
+    )
+      return;
+    const next = !paused;
+    setPauseBusy(true);
+    setPauseError(null);
+    try {
+      await setRouterClientPaused(client.clientId, next);
+    } catch (error) {
+      setPauseError((error as Error).message);
+    } finally {
+      setPauseBusy(false);
+    }
+  };
 
   const quality = signalQuality(client);
   const name = displayName(client);
@@ -95,11 +130,28 @@ export function DeviceDetail({
               {client.clientId}
             </span>
           )}
-          {client.blocked && <Badge className='mt-1'>Paused</Badge>}
+          {paused && <Badge className='mt-1'>Paused</Badge>}
         </div>
-        {/* Empty flank balances the left one so the glyph column stays centred. */}
-        <div aria-hidden />
+        <div className='flex justify-end'>
+          {showPauseControl && (
+            <Button
+              variant={paused ? "outline" : "secondary"}
+              size='sm'
+              className='cursor-pointer disabled:cursor-not-allowed'
+              disabled={pauseBusy}
+              onClick={() => void togglePaused()}
+            >
+              {pauseBusy ? (paused ? "Unpausing…" : "Pausing…") : paused ? "Unpause" : "Pause"}
+            </Button>
+          )}
+        </div>
       </div>
+
+      {pauseError && (
+        <div className='mb-3 rounded-md border border-destructive/30 bg-destructive/8 px-3 py-2 text-[12px] text-destructive'>
+          {pauseError}
+        </div>
+      )}
 
       {editing && (
         <DeviceNameEditor

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -68,7 +68,7 @@ function NetworkPanelBody({
   selectedKey: string | null;
   onSelect: (entryKey: string | null) => void;
 }) {
-  const [tab, setTab] = useState<"devices" | "nodes">("devices");
+  const [tab, setTab] = useState<"connected" | "nodes">("connected");
   useOuiRegistry();
   // Radio temps come from the historian, not the router directly. Poll only
   // while the panel is mounted (i.e. the Network panel is open).
@@ -157,12 +157,12 @@ function NetworkPanelBody({
         value={tab}
         onChange={setTab}
         options={[
-          { value: "devices", label: <TabLabel text='Devices' count={devices.length} /> },
+          { value: "connected", label: <TabLabel text='Connected' count={devices.length} /> },
           { value: "nodes", label: <TabLabel text='Nodes' count={nodes.length} /> },
         ]}
       />
 
-      {tab === "devices" && (
+      {tab === "connected" && (
         <>
           <ListSection
             caption={`${devices.length} device${devices.length === 1 ? "" : "s"} · live from the router, refreshed every 5 s`}

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -143,6 +143,7 @@ function NetworkPanelBody({
           nodes.find((node) => node.client?.macAddress === selected.upstreamMacAddress)?.name
         }
         isThisDevice={matchesSelf(selected, self)}
+        viewerIdentified={self.ips.length > 0 || self.macs.length > 0}
         onRename={network.renameClient}
       />
     );

--- a/src/components/shared/ConnectAccount.tsx
+++ b/src/components/shared/ConnectAccount.tsx
@@ -57,9 +57,9 @@ function SignInConnect({
           Connect your Starlink account
         </h2>
         <p className='m-0 text-[13.5px] leading-relaxed text-ink-secondary'>
-          See your plan, data usage, service address, and every dish and router on the account —
-          read-only, straight from starlink.com. Your session stays encrypted on this device and is
-          only ever sent to Starlink.
+          See your plan, data usage, service address, and every dish and router on the account, and
+          enable supported router controls such as pausing connected devices. Your session stays
+          encrypted on this device and is only ever sent to Starlink.
         </p>
       </div>
 
@@ -128,7 +128,7 @@ function PasteConnect({ onConnected }: { onConnected: () => void }) {
       <div>
         <div className='text-[14px] font-semibold'>Connect your Starlink account</div>
         <div className='mt-0.5 text-[12.5px] leading-normal text-ink-secondary'>
-          Read-only — your account, your data. The session is written to a local{" "}
+          Adds account details and supported router controls. The session is written to a local{" "}
           <code>.starlink-cookie</code> file on this machine and only ever sent to Starlink.
         </div>
       </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -39,15 +39,19 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  /** For a dialog opened over a surface that already dims its own backdrop, where
+   *  the default scrim would stack into something much darker than one layer. */
+  overlayClassName?: string;
 }) {
   return (
     <DialogPortal data-slot='dialog-portal'>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot='dialog-content'
         className={cn(

--- a/src/lib/cloudHost.ts
+++ b/src/lib/cloudHost.ts
@@ -45,11 +45,23 @@ const sameOriginTransport: CloudTransport = async ({ path, method = "GET", body,
 
 let transport: CloudTransport = sameOriginTransport;
 let hostSignIn: CloudSignIn | undefined;
+let hostSupportsRouterClientPause = true;
 
 /** Called once by a host entry point, before the UI renders. */
-export function setCloudHost(binding: { transport?: CloudTransport; signIn?: CloudSignIn }): void {
+export function setCloudHost(binding: {
+  transport?: CloudTransport;
+  signIn?: CloudSignIn;
+  /** False when the host cannot reliably identify and protect its own client. */
+  supportsRouterClientPause?: boolean;
+}): void {
   if (binding.transport) transport = binding.transport;
   if (binding.signIn) hostSignIn = binding.signIn;
+  if (binding.supportsRouterClientPause !== undefined)
+    hostSupportsRouterClientPause = binding.supportsRouterClientPause;
+}
+
+export function supportsRouterClientPause(): boolean {
+  return hostSupportsRouterClientPause;
 }
 
 export function cloudRequest(request: CloudRequest): Promise<CloudReply> {

--- a/src/lib/routerPause.test.ts
+++ b/src/lib/routerPause.test.ts
@@ -1,19 +1,31 @@
 import { describe, expect, test, vi } from "vitest";
 import { applyRouterClientPaused, clientPauseControlAvailable } from "./routerPause";
 
+const available = {
+  clientId: 7 as number | undefined,
+  isThisDevice: false,
+  viewerIdentified: true,
+  cloudConnected: true,
+  hostSupportsPause: true,
+};
+
 describe("clientPauseControlAvailable", () => {
   test("given: no Starlink session, should: hide the device control", () => {
-    expect(clientPauseControlAvailable(7, false, false)).toBe(false);
+    expect(clientPauseControlAvailable({ ...available, cloudConnected: false })).toBe(false);
   });
 
   test("given: a host cannot identify its own client, should: hide the device control", () => {
-    expect(clientPauseControlAvailable(7, false, true, false)).toBe(false);
+    expect(clientPauseControlAvailable({ ...available, hostSupportsPause: false })).toBe(false);
+  });
+
+  test("given: an unresolved viewer identity, should: hide the control on every device", () => {
+    expect(clientPauseControlAvailable({ ...available, viewerIdentified: false })).toBe(false);
   });
 
   test("given: a connected account, should: show only for another identified device", () => {
-    expect(clientPauseControlAvailable(7, false, true)).toBe(true);
-    expect(clientPauseControlAvailable(7, true, true)).toBe(false);
-    expect(clientPauseControlAvailable(undefined, false, true)).toBe(false);
+    expect(clientPauseControlAvailable(available)).toBe(true);
+    expect(clientPauseControlAvailable({ ...available, isThisDevice: true })).toBe(false);
+    expect(clientPauseControlAvailable({ ...available, clientId: undefined })).toBe(false);
   });
 });
 

--- a/src/lib/routerPause.test.ts
+++ b/src/lib/routerPause.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, vi } from "vitest";
+import { applyRouterClientPaused, clientPauseControlAvailable } from "./routerPause";
+
+describe("clientPauseControlAvailable", () => {
+  test("given: no Starlink session, should: hide the device control", () => {
+    expect(clientPauseControlAvailable(7, false, false)).toBe(false);
+  });
+
+  test("given: a host cannot identify its own client, should: hide the device control", () => {
+    expect(clientPauseControlAvailable(7, false, true, false)).toBe(false);
+  });
+
+  test("given: a connected account, should: show only for another identified device", () => {
+    expect(clientPauseControlAvailable(7, false, true)).toBe(true);
+    expect(clientPauseControlAvailable(7, true, true)).toBe(false);
+    expect(clientPauseControlAvailable(undefined, false, true)).toBe(false);
+  });
+});
+
+describe("applyRouterClientPaused", () => {
+  test("given: Starlink accepts the update, should: make one cloud request without polling", async () => {
+    const request = vi.fn().mockResolvedValue({ status: 200, body: { ok: true } });
+
+    await applyRouterClientPaused(7, true, request);
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith({
+      path: "/cloud/device",
+      method: "POST",
+      body: { clientId: 7, paused: true },
+    });
+  });
+
+  test("given: Starlink rejects the update, should: surface its message", async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 504,
+      body: { message: "Starlink did not answer in time." },
+    });
+
+    await expect(applyRouterClientPaused(7, false, request)).rejects.toThrow(
+      "Starlink rejected the device update: Starlink did not answer in time.",
+    );
+    expect(request).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/routerPause.ts
+++ b/src/lib/routerPause.ts
@@ -1,0 +1,33 @@
+import { cloudRequest, type CloudRequest, type CloudReply } from "./cloudHost";
+
+export function clientPauseControlAvailable(
+  clientId: number | undefined,
+  isThisDevice: boolean,
+  cloudConnected: boolean,
+  hostSupportsPause = true,
+): boolean {
+  return hostSupportsPause && cloudConnected && !isThisDevice && clientId !== undefined;
+}
+
+/** Send one pause/unpause request through Starlink cloud. The existing network
+ *  roster refresh reflects the resulting router state; this path deliberately
+ *  performs no additional LAN polling. */
+export async function applyRouterClientPaused(
+  clientId: number,
+  paused: boolean,
+  request: (request: CloudRequest) => Promise<CloudReply> = cloudRequest,
+): Promise<void> {
+  const reply = await request({
+    path: "/cloud/device",
+    method: "POST",
+    body: { clientId, paused },
+  });
+  if (reply.status !== 200) {
+    const message = (reply.body as { message?: string })?.message ?? `HTTP ${reply.status}`;
+    throw new Error(`Starlink rejected the device update: ${message}`);
+  }
+}
+
+export async function setRouterClientPaused(clientId: number, paused: boolean): Promise<void> {
+  await applyRouterClientPaused(clientId, paused);
+}

--- a/src/lib/routerPause.ts
+++ b/src/lib/routerPause.ts
@@ -1,12 +1,23 @@
 import { cloudRequest, type CloudRequest, type CloudReply } from "./cloudHost";
 
-export function clientPauseControlAvailable(
-  clientId: number | undefined,
-  isThisDevice: boolean,
-  cloudConnected: boolean,
-  hostSupportsPause = true,
-): boolean {
-  return hostSupportsPause && cloudConnected && !isThisDevice && clientId !== undefined;
+/** "Not your device" and "could not tell which device you are" both arrive as
+ *  `isThisDevice: false`, so `viewerIdentified` is what keeps an unresolved
+ *  identity from offering to pause every row including the viewer's own. A paused
+ *  device cannot undo its own pause; recovery needs a second machine. */
+export function clientPauseControlAvailable(options: {
+  clientId: number | undefined;
+  isThisDevice: boolean;
+  viewerIdentified: boolean;
+  cloudConnected: boolean;
+  hostSupportsPause?: boolean;
+}): boolean {
+  return (
+    (options.hostSupportsPause ?? true) &&
+    options.cloudConnected &&
+    options.viewerIdentified &&
+    !options.isThisDevice &&
+    options.clientId !== undefined
+  );
 }
 
 /** Send one pause/unpause request through Starlink cloud. The existing network

--- a/src/lib/starlinkCloud.ts
+++ b/src/lib/starlinkCloud.ts
@@ -1,4 +1,6 @@
-// Typed client for the user's own starlink.com account data, read-only.
+// Typed client for the user's own starlink.com account data and session lifecycle.
+// Supported router mutations use the same optional session through cloudHost,
+// while their request payloads are prepared by the trusted host from LAN state.
 //
 // The UI only ever talks to /cloud/* (served by the host's cloud binding — the
 // Vite dev proxy, Electron main, the extension background worker later). It


### PR DESCRIPTION
## Summary

- add authenticated pause and unpause controls for connected router clients
- preserve the complete router client configuration and unrelated schedules when updating one device
- hide the control when no Starlink session is available or when viewing the device running Dishylink
- support the web development host and Electron desktop app; disable the control in the browser extension because Chrome cannot reliably identify and protect its own LAN client
- serialize mutations and handle expired sessions, retries, and timeouts safely

## Implementation notes

The trusted host reads the current router configuration and live client list over the LAN immediately before encoding the update. The renderer sends only the client ID and requested pause state; it cannot provide arbitrary protobuf. The encoded update is sent to Starlink's authenticated Device/Handle endpoint.

This adds no continuous router poll and does not call router get_ping.

## Why the browser extension disables pause controls

The Starlink mutation works from the extension, but the extension cannot safely identify the router client representing the computer running Chrome. Electron reads trusted operating-system network interfaces, and the web development server can resolve identity through its local host or `/api/whoami` caller address. The extension has neither path: its `/api/*` requests are internal service-worker/IndexedDB messages, and ordinary desktop Chrome extensions do not expose a reliable host LAN IP or MAC address.

Without that identity, the extension cannot guarantee that a selected client is not itself. To prevent an accidental self-pause, the extension declares the capability unsupported, hides all pause controls, and does not register its background `/cloud/device` mutation route.

## Hardware verification

| Runtime | Pause | Unpause | Signed-out control | Current-device control |
| --- | --- | --- | --- | --- |
| Desktop | Verified on a live Starlink router | Verified on a live Starlink router | Verified | Verified |
| Web development | Verified on a live Starlink router | Verified on a live Starlink router | Verified | Verified |
| Browser extension | Not available | Not available | Not applicable | Not applicable |

<img width="1212" height="973" alt="pausing" src="https://github.com/user-attachments/assets/be9f32a9-ef29-4153-a07e-9ef3d736af61" />

## Automated checks

- `npm run typecheck`
- `npm run typecheck:extension`
- `npm run lint`
- `npm test` — 560 tests passed
- `npm run format:check`
