### PR TITLE
Answer host facts from main instead of guessing them in the renderer

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -28,6 +28,7 @@ import {
   type ThroughputSample,
 } from "./collector";
 import { startCloud, handleCloudRequest, signIn } from "./cloud";
+import { localNetworkIdentity } from "../core/hostNetworkIdentity";
 import { preferences, setPreference, onPreferencesChanged, type WindowBounds } from "./preferences";
 import {
   describeTransition,
@@ -496,6 +497,14 @@ function startAlertNotifications(): void {
 
 // Restricted to http(s)/mailto so a compromised renderer can't hand main an exotic
 // scheme (file:, a custom protocol) and have it opened with the OS's privileges.
+/** Facts about this host that only main can answer. */
+function registerHostHandlers(): void {
+  // get_clients answers everyone identically, so "this device" can only be settled
+  // from the host's own interfaces.
+  ipcMain.handle("get-self-identity", () => localNetworkIdentity());
+  ipcMain.handle("get-recorder-in-process", () => !devServerUrl);
+}
+
 function registerExternalLinkHandler(): void {
   ipcMain.on("open-external", (_event, url: string) => {
     if (/^(https?:\/\/|mailto:)/.test(url)) {
@@ -570,6 +579,7 @@ void app.whenReady().then(async () => {
   registerMenuBarThroughputHandler();
   registerUpdateHandler();
   registerExternalLinkHandler();
+  registerHostHandlers();
   // checkForUpdates needs app-update.yml, which only a packaged build carries.
   if (app.isPackaged) startUpdateChecks();
   createTray();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,7 @@
 
 import { contextBridge, ipcRenderer } from "electron";
 import type { NotificationState } from "../core/alertNotification";
+import type { HostNetworkIdentity } from "../core/hostNetworkIdentity";
 import {
   NOTIFICATION_STATE_CHANNEL,
   MENUBAR_THROUGHPUT_CHANNEL,
@@ -25,6 +26,8 @@ contextBridge.exposeInMainWorld("dishlink", {
   openExternal: (url: string): void => {
     ipcRenderer.send("open-external", url);
   },
+  selfIdentity: (): Promise<HostNetworkIdentity> => ipcRenderer.invoke("get-self-identity"),
+  recorderInProcess: (): Promise<boolean> => ipcRenderer.invoke("get-recorder-in-process"),
   // Opens the Starlink login window in the main process; resolves once the account
   // is connected, or with ok:false if the user closes it.
   signIn: (): Promise<{ ok: boolean; message?: string }> => ipcRenderer.invoke("starlink-signin"),

--- a/src/lib/selfIdentity.test.ts
+++ b/src/lib/selfIdentity.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { matchesSelf, type SelfIdentity } from "./selfIdentity";
+import { afterEach, describe, expect, it } from "vitest";
+import { matchesSelf, resolveSelfIdentity, type SelfIdentity } from "./selfIdentity";
 
 const self = (over: Partial<SelfIdentity> = {}): SelfIdentity => ({
   ips: [],
@@ -45,5 +45,39 @@ describe("matchesSelf", () => {
     expect(
       matchesSelf({ ipAddress: "192.168.1.45", macAddress: "5a:c9:44:55:f3:e9" }, self()),
     ).toBe(false);
+  });
+});
+
+describe("resolveSelfIdentity via the Electron bridge", () => {
+  const host = globalThis as { dishlink?: unknown };
+  afterEach(() => {
+    delete host.dishlink;
+  });
+
+  it("reads the host's own interfaces, which no /api call is needed for", async () => {
+    host.dishlink = {
+      selfIdentity: () =>
+        Promise.resolve({
+          ipAddresses: ["192.168.1.230", "::ffff:192.168.1.230", "127.0.0.1"],
+          macAddresses: ["EA:17:B5:92:E2:92"],
+        }),
+    };
+
+    await expect(resolveSelfIdentity()).resolves.toEqual({
+      // Loopback is dropped and the v4-mapped duplicate collapses to the bare v4.
+      ips: ["192.168.1.230", "192.168.1.230"],
+      macs: ["ea:17:b5:92:e2:92"],
+      describesHost: true,
+    });
+  });
+
+  it("falls through when the bridge is absent, as it is on every other host", async () => {
+    await expect(resolveSelfIdentity()).resolves.toMatchObject({ describesHost: false });
+  });
+
+  it("falls through when the bridge rejects", async () => {
+    host.dishlink = { selfIdentity: () => Promise.reject(new Error("no ipc")) };
+
+    await expect(resolveSelfIdentity()).resolves.toMatchObject({ describesHost: false });
   });
 });

--- a/src/lib/selfIdentity.ts
+++ b/src/lib/selfIdentity.ts
@@ -60,17 +60,17 @@ function clean(ips: (string | undefined)[]): string[] {
     .filter(isRoutable);
 }
 
-interface ElectronBridge {
-  getSelfIdentity?: () => Promise<{ ips?: string[]; macs?: string[] }>;
+interface DishlinkBridge {
+  selfIdentity?: () => Promise<{ ipAddresses?: string[]; macAddresses?: string[] }>;
 }
 async function fromElectron(): Promise<SelfIdentity | null> {
-  const bridge = (globalThis as { electronAPI?: ElectronBridge }).electronAPI;
-  if (!bridge?.getSelfIdentity) return null;
+  const bridge = (globalThis as { dishlink?: DishlinkBridge }).dishlink;
+  if (!bridge?.selfIdentity) return null;
   try {
-    const id = await bridge.getSelfIdentity();
+    const identity = await bridge.selfIdentity();
     return {
-      ips: clean(id.ips ?? []),
-      macs: (id.macs ?? []).map((mac) => mac.toLowerCase()),
+      ips: clean(identity.ipAddresses ?? []),
+      macs: (identity.macAddresses ?? []).map((macAddress) => macAddress.toLowerCase()),
       // Read from this process's own os.networkInterfaces(), and the desktop
       // app makes its LAN requests from that same process.
       describesHost: true,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,9 +23,9 @@ if (desktop) {
     transport: ({ path, method, body }) => desktop.cloud({ path, method, body }),
     signIn: desktop.signIn,
   });
-  // The recorder runs in the same process that serves /api here, so it cannot be
-  // down while this window is asking — see recorderRunsInHostProcess.
-  setRecorderInProcess(true);
+  // Only a build serving its own /api has the recorder in this process, where it
+  // cannot be down while this window is asking — see recorderRunsInHostProcess.
+  void desktop.recorderInProcess().then(setRecorderInProcess);
 }
 
 // Bound for every host, desktop or plain tab, since each keeps the notification

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,6 +19,8 @@ interface Window {
       method?: string;
       body?: unknown;
     }) => Promise<{ status: number; body: unknown }>;
+    selfIdentity: () => Promise<{ ipAddresses: string[]; macAddresses: string[] }>;
+    recorderInProcess: () => Promise<boolean>;
     // The throughput-readout controls — macOS menu bar or Windows taskbar —
     // exposed by the preload only on those platforms, so they are optional, and
     // the settings toggle renders only where `setMenuBarThroughput` is present.


### PR DESCRIPTION
selfIdentity looked for window.electronAPI.getSelfIdentity, which nothing provides — the preload exposes window.dishlink — so the Electron branch never ran and identity always fell through to /api/whoami. With the recorder in another process, the desktop app could not recognise its own device.

The recorder-in-process flag had the same shape: set from being the desktop app at all, when the collector only runs here if this build serves its own /api.