### PR TITLE
Settings panel now write dish config through the cloud

### DIFF
--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -332,3 +332,107 @@ describe("createCloudHandler pauseClient", () => {
     expect(prepared).toBe(false);
   });
 });
+
+describe("createCloudHandler updateDishConfig", () => {
+  it("given: a trusted host request, should: send framed protobuf with its cookie", async () => {
+    const request = new Uint8Array([8, 1, 18, 0]);
+    const responseMessage = new Uint8Array([10, 0]);
+    const responseFrame = new Uint8Array([0, 0, 0, 0, responseMessage.length, ...responseMessage]);
+    const captured: { url: string; init?: RequestInit } = { url: "" };
+    const doFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === AUTH_URL) return res(200);
+      captured.url = url;
+      captured.init = init;
+      return {
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => responseFrame.buffer,
+      } as unknown as Response;
+    }) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      prepareDishConfigUpdate: async (changes) => {
+        expect(changes).toEqual({ swupdateRebootHour: 15 });
+        return request;
+      },
+    });
+
+    await expect(handler.updateDishConfig({ swupdateRebootHour: 15 })).resolves.toEqual({
+      status: 200,
+      body: { ok: true },
+    });
+    expect(captured.url).toBe("https://starlink.com/api/SpaceX.API.Device.Device/Handle");
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers.cookie).toBe(SESSION);
+    expect(new Uint8Array(captured.init?.body as ArrayBufferLike)).toEqual(
+      new Uint8Array([0, 0, 0, 0, request.length, ...request]),
+    );
+  });
+
+  it("given: no session, should: return the reconnect response without preparing a request", async () => {
+    let prepared = false;
+    const handler = createCloudHandler({
+      readCookie: () => null,
+      prepareDishConfigUpdate: async () => {
+        prepared = true;
+        return new Uint8Array();
+      },
+    });
+
+    await expect(
+      handler.updateDishConfig({ swupdateThreeDayDeferralEnabled: true }),
+    ).resolves.toMatchObject({ status: 428 });
+    expect(prepared).toBe(false);
+  });
+
+  it("given: the device gateway stalls, should: abort and return a retryable timeout", async () => {
+    const doFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === AUTH_URL) return res(200);
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    }) as typeof fetch;
+    const handler = createCloudHandler({
+      fetch: doFetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceCallTimeoutMs: 5,
+      prepareDishConfigUpdate: async () => new Uint8Array(),
+    });
+
+    await expect(handler.updateDishConfig({ powerSaveMode: true })).resolves.toEqual({
+      status: 504,
+      body: {
+        error: "device_call_timeout",
+        message: "Starlink did not answer the config change in time. Try again.",
+      },
+    });
+  });
+
+  it("given: invalid or empty renderer input, should: reject it before preparing a request", async () => {
+    let prepared = false;
+    const handler = createCloudHandler({
+      readCookie: () => SESSION,
+      prepareDishConfigUpdate: async () => {
+        prepared = true;
+        return new Uint8Array();
+      },
+    });
+
+    await expect(handler.updateDishConfig({})).resolves.toMatchObject({ status: 400 });
+    await expect(handler.updateDishConfig({ swupdateRebootHour: 4 })).resolves.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      handler.updateDishConfig({ snowMeltMode: "MOSTLY" as never }),
+    ).resolves.toMatchObject({ status: 400 });
+    await expect(handler.updateDishConfig({ powerSaveDurationMinutes: -5 })).resolves.toMatchObject(
+      { status: 400 },
+    );
+    expect(prepared).toBe(false);
+  });
+});

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -8,6 +8,7 @@
 // internet and a cookie, and must not depend on the dish poller's health.
 
 import { GrpcWebError, grpcWebUnaryCall } from "../core/grpcWeb";
+import type { DishConfigJson } from "../core/dishClient";
 import type { RouterClientUpdate } from "../core/routerClientUpdate";
 
 const AUTH_URL = "https://api.starlink.com/auth-rp/auth/user";
@@ -48,6 +49,9 @@ export interface CloudHandlerOptions {
   /** Trusted host callback: reads the local router and encodes exactly one
    *  client update. Renderer-provided protobuf is never accepted. */
   prepareDeviceUpdate?: (update: RouterClientUpdate) => Promise<Uint8Array>;
+  /** Trusted host callback: reads the local dish's identity and encodes exactly
+   *  one config change. Renderer-provided protobuf is never accepted. */
+  prepareDishConfigUpdate?: (changes: DishConfigJson) => Promise<Uint8Array>;
 }
 
 /** The durable half of the session — without it a token refresh can't happen, so
@@ -132,6 +136,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
   const retryDelayMs = options.retryDelayMs ?? 150;
   const deviceCallTimeoutMs = options.deviceCallTimeoutMs ?? 15_000;
   const prepareDeviceUpdate = options.prepareDeviceUpdate;
+  const prepareDishConfigUpdate = options.prepareDishConfigUpdate;
 
   let cachedCookie: string | null = null;
   let cachedAt = 0;
@@ -436,5 +441,83 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     return mutation;
   }
 
-  return { handle, connect, disconnect, updateClient };
+  async function applyDishConfigUpdate(changes: DishConfigJson): Promise<CloudResult> {
+    if (!readCookie()) return NOT_CONNECTED;
+    try {
+      if (!prepareDishConfigUpdate)
+        return { status: 503, body: { error: "dish_config_update_unavailable" } };
+      const requestBytes = await prepareDishConfigUpdate(changes);
+      const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
+      await withFreshCookie(async (cookie) => {
+        try {
+          await grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
+            fetch: doFetch,
+            headers: { cookie },
+          });
+        } catch (error) {
+          if (error instanceof GrpcWebError && error.grpcStatus === 16)
+            throw new SessionExpiredError();
+          throw error;
+        }
+      }, abortSignal);
+      return { status: 200, body: { ok: true } };
+    } catch (error) {
+      if (error instanceof SessionExpiredError) return NOT_CONNECTED;
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        return {
+          status: 504,
+          body: {
+            error: "device_call_timeout",
+            message: "Starlink did not answer the config change in time. Try again.",
+          },
+        };
+      }
+      return {
+        status: 502,
+        body: { error: "device_call_failed", message: (error as Error).message },
+      };
+    }
+  }
+
+  // The four windows the app itself offers for swupdate_reboot_hour (see
+  // updateWindowFor in the settings UI) — the field is a uint32, but only these
+  // values are ones a renderer should ever be allowed to send.
+  const SWUPDATE_REBOOT_HOURS = [3, 9, 15, 21];
+
+  /** The renderer names dish config fields and their new values, never protobuf.
+   *  Anything outside these shapes is refused before the dish is read. */
+  function validDishConfig(changes: DishConfigJson): boolean {
+    if (changes === null || typeof changes !== "object") return false;
+    const entries = Object.entries(changes).filter(([, value]) => value !== undefined);
+    if (entries.length === 0) return false;
+    return entries.every(([field, value]) => {
+      switch (field) {
+        case "snowMeltMode":
+          return value === "AUTO" || value === "ALWAYS_ON" || value === "ALWAYS_OFF";
+        case "locationRequestMode":
+          return value === "NONE" || value === "LOCAL";
+        case "levelDishMode":
+          return value === "TILT_LIKE_NORMAL" || value === "FORCE_LEVEL";
+        case "powerSaveStartMinutes":
+          return Number.isInteger(value) && (value as number) >= 0 && (value as number) < 1_440;
+        case "powerSaveDurationMinutes":
+          return Number.isInteger(value) && (value as number) > 0 && (value as number) <= 1_440;
+        case "powerSaveMode":
+        case "swupdateThreeDayDeferralEnabled":
+          return typeof value === "boolean";
+        case "swupdateRebootHour":
+          return SWUPDATE_REBOOT_HOURS.includes(value as number);
+        default:
+          return false;
+      }
+    });
+  }
+
+  function updateDishConfig(changes: DishConfigJson): Promise<CloudResult> {
+    if (!validDishConfig(changes))
+      return Promise.resolve({ status: 400, body: { error: "bad_request" } });
+    return applyDishConfigUpdate(changes);
+  }
+
+  return { handle, connect, disconnect, updateClient, updateDishConfig };
 }

--- a/core/dishClient.ts
+++ b/core/dishClient.ts
@@ -46,6 +46,13 @@ export function setDishHost(binding: DishHost): void {
 export const ROUTER_LAN_ADDRESS = "192.168.1.1";
 export const ROUTER_LAN_HANDLE_URL = `http://${ROUTER_LAN_ADDRESS}:9001/SpaceX.API.Device.Device/Handle`;
 
+/** The dish's LAN address. A relative handle URL resolves against a browser's
+ *  own origin through its dev/Electron proxy; code that runs outside a browser
+ *  (the dev server's own process, preparing a cloud write) has no such origin
+ *  and needs this absolute one instead. */
+export const DISH_LAN_ADDRESS = "192.168.100.1";
+export const DISH_LAN_HANDLE_URL = `http://${DISH_LAN_ADDRESS}:9201/SpaceX.API.Device.Device/Handle`;
+
 // Oneof field numbers inside SpaceX.API.Device.Request (from the dish schema).
 const REQUEST_FIELD = {
   reboot: 1001,
@@ -224,8 +231,10 @@ export interface DishConfigJson {
   swupdateThreeDayDeferralEnabled?: boolean;
 }
 
-/** config field → its apply_* flag (both sides proto3 JSON names) */
-const CONFIG_APPLY_FLAG: Record<keyof DishConfigJson, string> = {
+/** config field → its apply_* flag (both sides proto3 JSON names). Exported so
+ *  a cloud-authenticated write can build the identical payload — current
+ *  firmware refuses this config write over the LAN. */
+export const CONFIG_APPLY_FLAG: Record<keyof DishConfigJson, string> = {
   snowMeltMode: "applySnowMeltMode",
   locationRequestMode: "applyLocationRequestMode",
   levelDishMode: "applyLevelDishMode",
@@ -575,24 +584,6 @@ export class DishClient {
   // ---------- schema-encoded requests (config writes and richer payloads) ----------
 
   /** Encode a full Request from proto3 JSON via the bundled schema. */
-  private async callJson(
-    requestJson: Record<string, unknown>,
-    abortSignal?: AbortSignal,
-  ): Promise<DishResponseJson> {
-    const requestMessage = fromJson(this.requestSchema, requestJson as JsonValue, {
-      registry: this.registry,
-    });
-    const responseBytes = await grpcWebUnaryCall(
-      this.handleUrl,
-      toBinary(this.requestSchema, requestMessage),
-      abortSignal,
-    );
-    const responseMessage = fromBinary(this.responseSchema, responseBytes);
-    return toJson(this.responseSchema, responseMessage, {
-      registry: this.registry,
-    }) as DishResponseJson;
-  }
-
   /** Encode a Device.Request for an authenticated host to send through the cloud
    *  gateway. This does not perform a local router write. */
   encodeRequest(requestJson: object): Uint8Array {
@@ -609,20 +600,6 @@ export class DishClient {
     );
   }
 
-  /**
-   * Apply a partial config change. Only the fields present are written — the
-   * matching apply_* flags are set automatically so untouched knobs stay put.
-   */
-  async setConfig(changes: DishConfigJson, abortSignal?: AbortSignal): Promise<void> {
-    const dishConfig: Record<string, unknown> = {};
-    for (const [field, value] of Object.entries(changes)) {
-      if (value === undefined) continue;
-      dishConfig[field] = value;
-      dishConfig[CONFIG_APPLY_FLAG[field as keyof DishConfigJson]] = true;
-    }
-    await this.callJson({ dishSetConfig: { dishConfig } }, abortSignal);
-  }
-
   /** Dish self-diagnostics: disablement code, hardware self-test, alerts. */
   async getDiagnostics(abortSignal?: AbortSignal): Promise<DishDiagnosticsJson> {
     return (await this.call(REQUEST_FIELD.getDiagnostics, abortSignal)).dishGetDiagnostics ?? {};
@@ -637,18 +614,6 @@ export class DishClient {
   async getWifiConfig(abortSignal?: AbortSignal): Promise<WifiNetworkConfigJson> {
     return (
       (await this.call(REQUEST_FIELD.wifiGetConfig, abortSignal)).wifiGetConfig?.wifiConfig ?? {}
-    );
-  }
-
-  /** Rename a client device (persists in the router) — ROUTER target. */
-  async setClientGivenName(
-    macAddress: string,
-    givenName: string,
-    abortSignal?: AbortSignal,
-  ): Promise<void> {
-    await this.callJson(
-      { wifiSetClientGivenName: { clientName: { macAddress, givenName } } },
-      abortSignal,
     );
   }
 }

--- a/core/dishConfigUpdate.test.ts
+++ b/core/dishConfigUpdate.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import type { DishClient } from "./dishClient";
+import { prepareDishConfigUpdate } from "./dishConfigUpdate";
+
+const TARGET = "ut01000000-00000000-000000ab";
+
+describe("prepareDishConfigUpdate", () => {
+  test("given: a trusted host, should: source the target from the dish and encode only the changed fields", async () => {
+    const encoded = new Uint8Array([1, 2, 3]);
+    let request: object | undefined;
+    const dish = {
+      getDeviceInfo: async () => ({ id: TARGET }),
+      encodeRequest: (value: object) => {
+        request = value;
+        return encoded;
+      },
+    } as unknown as DishClient;
+
+    await expect(prepareDishConfigUpdate(dish, { swupdateRebootHour: 15 })).resolves.toBe(encoded);
+    expect(request).toEqual({
+      targetId: TARGET,
+      dishSetConfig: {
+        dishConfig: { swupdateRebootHour: 15, applySwupdateRebootHour: true },
+      },
+    });
+  });
+
+  test("given: several fields at once, should: set the apply flag for each and skip untouched ones", async () => {
+    let request: object | undefined;
+    const dish = {
+      getDeviceInfo: async () => ({ id: TARGET }),
+      encodeRequest: (value: object) => {
+        request = value;
+        return new Uint8Array([4]);
+      },
+    } as unknown as DishClient;
+
+    await prepareDishConfigUpdate(dish, {
+      powerSaveMode: true,
+      powerSaveStartMinutes: 60,
+      powerSaveDurationMinutes: undefined,
+    });
+
+    expect(request).toEqual({
+      targetId: TARGET,
+      dishSetConfig: {
+        dishConfig: {
+          powerSaveMode: true,
+          applyPowerSaveMode: true,
+          powerSaveStartMinutes: 60,
+          applyPowerSaveStartMinutes: true,
+        },
+      },
+    });
+  });
+
+  test("given: no dish identity, should: refuse before encoding", async () => {
+    const dish = {
+      getDeviceInfo: async () => ({}),
+      encodeRequest: () => {
+        throw new Error("must not encode without a target id");
+      },
+    } as unknown as DishClient;
+
+    await expect(prepareDishConfigUpdate(dish, { powerSaveMode: false })).rejects.toThrow(
+      /identity is unavailable/,
+    );
+  });
+
+  test("given: a non-dish target id, should: refuse the write", async () => {
+    const dish = {
+      getDeviceInfo: async () => ({ id: "Router-010000000000000001B31340" }),
+      encodeRequest: () => new Uint8Array([9]),
+    } as unknown as DishClient;
+
+    await expect(prepareDishConfigUpdate(dish, { powerSaveMode: false })).rejects.toThrow(
+      /dish target id/,
+    );
+  });
+});

--- a/core/dishConfigUpdate.ts
+++ b/core/dishConfigUpdate.ts
@@ -1,0 +1,32 @@
+import { CONFIG_APPLY_FLAG, type DishClient, type DishConfigJson } from "./dishClient";
+
+export interface DishConfigRequestJson {
+  targetId: string;
+  dishSetConfig: { dishConfig: Record<string, unknown> };
+}
+
+function requestFor(targetId: string, changes: DishConfigJson): DishConfigRequestJson {
+  if (!targetId.startsWith("ut")) throw new Error("invalid dish target id");
+  const dishConfig: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(changes)) {
+    if (value === undefined) continue;
+    dishConfig[field] = value;
+    dishConfig[CONFIG_APPLY_FLAG[field as keyof DishConfigJson]] = true;
+  }
+  return { targetId, dishSetConfig: { dishConfig } };
+}
+
+/** Trusted-host preparation: source the dish's own identity directly from the
+ *  LAN immediately before encoding the cloud write, the same way router client
+ *  updates do. Unlike a client update, this touches only the fields present in
+ *  `changes` — the device merges by apply flag, so no existing state needs
+ *  reading first and no write can race an unrelated field's write. */
+export async function prepareDishConfigUpdate(
+  dish: DishClient,
+  changes: DishConfigJson,
+): Promise<Uint8Array> {
+  const deviceInfo = await dish.getDeviceInfo(AbortSignal.timeout(5_000));
+  const targetId = deviceInfo.id;
+  if (!targetId) throw new Error("Starlink dish identity is unavailable");
+  return dish.encodeRequest(requestFor(targetId, changes));
+}

--- a/dev/starlinkCloudProxy.ts
+++ b/dev/starlinkCloudProxy.ts
@@ -12,7 +12,9 @@ import { resolve } from "node:path";
 import type { Plugin } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler.ts";
-import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
+import { DishClient, DISH_LAN_HANDLE_URL, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
+import type { DishConfigJson } from "../core/dishClient.ts";
+import { prepareDishConfigUpdate } from "../core/dishConfigUpdate.ts";
 import { prepareRouterClientUpdate } from "../core/routerClientUpdate.ts";
 import type { RouterClientUpdate } from "../core/routerClientUpdate.ts";
 import { localNetworkIdentity } from "../core/hostNetworkIdentity.ts";
@@ -74,6 +76,9 @@ export function starlinkCloudProxy(): Plugin {
     name: "starlink-cloud-proxy",
     configureServer(server) {
       let routerPromise: Promise<DishClient> | null = null;
+      let dishPromise: Promise<DishClient> | null = null;
+      const protosetBytes = () =>
+        new Uint8Array(readFileSync(resolve(process.cwd(), "public/dish.protoset")));
       const handler = createCloudHandler({
         readCookie,
         writeCookie,
@@ -81,11 +86,16 @@ export function starlinkCloudProxy(): Plugin {
         prepareDeviceUpdate: async (update) => {
           routerPromise ??= DishClient.load("router", {
             handleUrl: ROUTER_LAN_HANDLE_URL,
-            protosetBytes: new Uint8Array(
-              readFileSync(resolve(process.cwd(), "public/dish.protoset")),
-            ),
+            protosetBytes: protosetBytes(),
           });
           return prepareRouterClientUpdate(await routerPromise, update, localNetworkIdentity());
+        },
+        prepareDishConfigUpdate: async (changes) => {
+          dishPromise ??= DishClient.load("dish", {
+            handleUrl: DISH_LAN_HANDLE_URL,
+            protosetBytes: protosetBytes(),
+          });
+          return prepareDishConfigUpdate(await dishPromise, changes);
         },
       });
       server.middlewares.use(async (req: IncomingMessage, res: ServerResponse, next) => {
@@ -120,6 +130,16 @@ export function starlinkCloudProxy(): Plugin {
           try {
             const update = JSON.parse((await readBody(req)) || "{}") as RouterClientUpdate;
             const result = await handler.updateClient(update);
+            return sendJson(res, result.status, result.body);
+          } catch (error) {
+            return sendJson(res, 400, { error: "bad_request", message: (error as Error).message });
+          }
+        }
+
+        if (route === "/cloud/dish-config" && req.method === "POST") {
+          try {
+            const changes = JSON.parse((await readBody(req)) || "{}") as DishConfigJson;
+            const result = await handler.updateDishConfig(changes);
             return sendJson(res, result.status, result.body);
           } catch (error) {
             return sendJson(res, 400, { error: "bad_request", message: (error as Error).message });

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -9,7 +9,9 @@ import { app, safeStorage, BrowserWindow, session } from "electron";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler";
-import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient";
+import { DishClient, DISH_LAN_HANDLE_URL, ROUTER_LAN_HANDLE_URL } from "../core/dishClient";
+import type { DishConfigJson } from "../core/dishClient";
+import { prepareDishConfigUpdate } from "../core/dishConfigUpdate";
 import { prepareRouterClientUpdate } from "../core/routerClientUpdate";
 import type { RouterClientUpdate } from "../core/routerClientUpdate";
 import { localNetworkIdentity } from "../core/hostNetworkIdentity";
@@ -56,6 +58,7 @@ export function startCloud(rendererRoot: string): void {
     ? join(rendererRoot, "dish.protoset")
     : join(app.getAppPath(), "public/dish.protoset");
   let routerPromise: Promise<DishClient> | null = null;
+  let dishPromise: Promise<DishClient> | null = null;
   handler = createCloudHandler({
     readCookie,
     writeCookie,
@@ -66,6 +69,13 @@ export function startCloud(rendererRoot: string): void {
         protosetBytes: new Uint8Array(readFileSync(protosetPath)),
       });
       return prepareRouterClientUpdate(await routerPromise, update, localNetworkIdentity());
+    },
+    prepareDishConfigUpdate: async (changes) => {
+      dishPromise ??= DishClient.load("dish", {
+        handleUrl: DISH_LAN_HANDLE_URL,
+        protosetBytes: new Uint8Array(readFileSync(protosetPath)),
+      });
+      return prepareDishConfigUpdate(await dishPromise, changes);
     },
   });
 }
@@ -101,6 +111,12 @@ export async function handleCloudRequest(request: Request): Promise<Response> {
   if (route === "/cloud/device" && request.method === "POST") {
     const update = (await request.json().catch(() => ({}))) as RouterClientUpdate;
     const { status, body } = await handler.updateClient(update);
+    return json(status, body);
+  }
+
+  if (route === "/cloud/dish-config" && request.method === "POST") {
+    const changes = (await request.json().catch(() => ({}))) as DishConfigJson;
+    const { status, body } = await handler.updateDishConfig(changes);
     return json(status, body);
   }
 

--- a/extension/lib/cloudHandler.test.ts
+++ b/extension/lib/cloudHandler.test.ts
@@ -5,12 +5,14 @@ import type { CloudResult } from "../../cloud/starlinkCloudHandler";
 // stub it so these tests exercise only handleCloudRequest's own routing — whether a
 // device update reaches updateClient at all, not what updateClient then does with it.
 const updateClient = vi.fn<(update: unknown) => Promise<CloudResult>>();
+const updateDishConfig = vi.fn<(changes: unknown) => Promise<CloudResult>>();
 vi.mock("../../cloud/starlinkCloudHandler", () => ({
   createCloudHandler: () => ({
     handle: vi.fn(),
     connect: vi.fn(),
     disconnect: vi.fn(),
     updateClient,
+    updateDishConfig,
   }),
 }));
 
@@ -35,6 +37,22 @@ describe("handleCloudRequest /cloud/device", () => {
     const reply = await handleCloudRequest({ path: "/cloud/device", method: "POST", body: update });
 
     expect(updateClient).toHaveBeenCalledWith(update);
+    expect(reply).toEqual({ status: 200, body: { ok: true } });
+  });
+});
+
+describe("handleCloudRequest /cloud/dish-config", () => {
+  it("forwards the change to the cloud handler, unlike a pause", async () => {
+    updateDishConfig.mockResolvedValueOnce({ status: 200, body: { ok: true } });
+    const changes = { swupdateRebootHour: 15 };
+
+    const reply = await handleCloudRequest({
+      path: "/cloud/dish-config",
+      method: "POST",
+      body: changes,
+    });
+
+    expect(updateDishConfig).toHaveBeenCalledWith(changes);
     expect(reply).toEqual({ status: 200, body: { ok: true } });
   });
 });

--- a/extension/lib/cloudHandler.ts
+++ b/extension/lib/cloudHandler.ts
@@ -21,10 +21,11 @@
 
 import { browser } from "wxt/browser";
 import { createCloudHandler } from "../../cloud/starlinkCloudHandler";
-import { DishClient } from "@core/dishClient";
+import { DishClient, type DishConfigJson } from "@core/dishClient";
+import { prepareDishConfigUpdate } from "@core/dishConfigUpdate";
 import { prepareRouterClientUpdate, type RouterClientUpdate } from "@core/routerClientUpdate";
 import type { CloudReply, CloudRequest } from "@/lib/cloudHost";
-import { ROUTER_HANDLE_URL } from "./endpoints";
+import { DISH_HANDLE_URL, ROUTER_HANDLE_URL } from "./endpoints";
 
 const SESSION_KEY = "cloudSession";
 
@@ -32,6 +33,7 @@ const SESSION_KEY = "cloudSession";
 // so our copy is mirrored here and reloaded before each request is served.
 let ourCookie: string | null = null;
 let routerPromise: Promise<DishClient> | null = null;
+let dishPromise: Promise<DishClient> | null = null;
 
 const cloudHandler = createCloudHandler({
   fetch: ((input: RequestInfo | URL, init?: RequestInit) =>
@@ -48,6 +50,10 @@ const cloudHandler = createCloudHandler({
   prepareDeviceUpdate: async (update) => {
     routerPromise ??= DishClient.load("router", { handleUrl: ROUTER_HANDLE_URL });
     return prepareRouterClientUpdate(await routerPromise, update);
+  },
+  prepareDishConfigUpdate: async (changes) => {
+    dishPromise ??= DishClient.load("dish", { handleUrl: DISH_HANDLE_URL });
+    return prepareDishConfigUpdate(await dishPromise, changes);
   },
 });
 
@@ -115,6 +121,13 @@ export async function handleCloudRequest(request: CloudRequest): Promise<CloudRe
     if (update?.kind !== "rename")
       return { status: 501, body: { error: "unsupported_on_extension" } };
     return cloudHandler.updateClient(update);
+  }
+
+  // Dish config carries no self-target hazard the way pausing a client does —
+  // sleep schedule, update window, and defer-updates apply to the dish as a
+  // whole, not to whichever device happens to be running the extension.
+  if (route === "/cloud/dish-config" && request.method === "POST") {
+    return cloudHandler.updateDishConfig(request.body as DishConfigJson);
   }
 
   // /cloud/session is connect (capture our copy) and disconnect (drop our copy).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,11 @@
     "": {
       "name": "dishylink",
       "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.0",
+        "@number-flow/react": "^0.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "electron-updater": "^6.8.9",
@@ -823,45 +826,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
-      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@epic-web/invariant": {
@@ -1814,6 +1778,20 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@number-flow/react": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@number-flow/react/-/react-0.6.2.tgz",
+      "integrity": "sha512-WjZuV4aA+vhRCgCF+adGLgFVVAJ8vdvq6EchRT2FiBIgElTXtDOA3YgkcMr9UHpvpS9v4H70AB5wZv0D9jc3QA==",
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.1.4",
+        "number-flow": "0.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
@@ -6787,15 +6765,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -7945,6 +7914,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -10842,6 +10817,15 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/number-flow": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/number-flow/-/number-flow-0.6.2.tgz",
+      "integrity": "sha512-MCnImG4Q5vPwhSXnov56nOuyyKn6LC+Qd7II1UiKc+ACRtug5iAtn0+CwXNxM38AC5lSowEY+oYEtZX2qMnUyw==",
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.1.4"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
@@ -11437,36 +11421,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/powershell-utils": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.6.0",
+    "@number-flow/react": "^0.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron-updater": "^6.8.9",

--- a/src/components/settings/StarlinkSettingsTab.tsx
+++ b/src/components/settings/StarlinkSettingsTab.tsx
@@ -1,10 +1,14 @@
 // Dish configuration and maintenance — the Starlink half of the settings panel.
 
 import { useState } from "react";
+import { CheckIcon, InfoIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
 import { Callout } from "@/components/ui/callout";
 import { Loading } from "@/components/ui/loading";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { actionButton } from "@/components/ui/action-button";
+import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
@@ -14,6 +18,8 @@ import {
 } from "@/components/ui/select";
 import type { DishClient, DishStatusJson, SnowMeltMode } from "@core/dishClient";
 import type { useDishSettings } from "../../hooks/useDishSettings";
+import { AccountRequiredError } from "../../lib/dishConfigUpdate";
+import { AccountRequiredNotice } from "../shared/AccountRequiredNotice";
 import {
   DangerAction,
   SectionLabel,
@@ -22,7 +28,8 @@ import {
   selectItemClass,
   triggerClass,
 } from "./settingsChrome";
-import { localTimeToUtcMinutes, utcMinutesToLocalTime } from "./sleepSchedule";
+import { formatClock12, localMinutesToUtcMinutes, utcMinutesToLocalMinutes } from "./sleepSchedule";
+import { TimePicker } from "./TimePicker";
 import { UPDATE_WINDOWS, updateWindowFor } from "./updateWindow";
 
 const SNOW_MELT_LABEL: Record<SnowMeltMode, string> = {
@@ -30,6 +37,46 @@ const SNOW_MELT_LABEL: Record<SnowMeltMode, string> = {
   ALWAYS_ON: "Always on",
   ALWAYS_OFF: "Off",
 };
+
+const SNOW_MELT_DESCRIPTION: Record<SnowMeltMode, string> = {
+  AUTO: "Automatically detect snow and heat up when needed.",
+  ALWAYS_ON:
+    "Keep warm to better resist snow build-up. This option may increase power consumption.",
+  ALWAYS_OFF: "Never use extra power to melt snow.",
+};
+
+function SnowMeltOption({ mode }: { mode: SnowMeltMode }) {
+  return (
+    <SelectPrimitive.Item
+      value={mode}
+      className={cn(
+        selectItemClass,
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-12 pl-2 outline-hidden select-none focus:bg-accent focus:text-accent-foreground",
+      )}
+    >
+      <span className='absolute right-2 flex items-center gap-1.5'>
+        <SelectPrimitive.ItemIndicator className='flex size-3.5 items-center justify-center'>
+          <CheckIcon className='size-4' />
+        </SelectPrimitive.ItemIndicator>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className='flex size-3.5 shrink-0 items-center justify-center text-muted-foreground'
+              onClick={(event) => event.stopPropagation()}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <InfoIcon className='size-3.5' />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side='left' className='max-w-56'>
+            {SNOW_MELT_DESCRIPTION[mode]}
+          </TooltipContent>
+        </Tooltip>
+      </span>
+      <SelectPrimitive.ItemText>{SNOW_MELT_LABEL[mode]}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
 
 export function StarlinkSettingsTab({
   settings,
@@ -49,8 +96,9 @@ export function StarlinkSettingsTab({
   const config = settings.config;
 
   const sleepEnabled = Boolean(config?.powerSaveMode);
-  const sleepStart = utcMinutesToLocalTime(config?.powerSaveStartMinutes ?? 0);
-  const sleepDurationH = Math.round((config?.powerSaveDurationMinutes ?? 360) / 60);
+  const sleepStartLocal = utcMinutesToLocalMinutes(config?.powerSaveStartMinutes ?? 60);
+  const sleepDurationMinutes = config?.powerSaveDurationMinutes ?? 360;
+  const wakeLocal = (sleepStartLocal + sleepDurationMinutes) % 1440;
   const updateWindow = updateWindowFor(config?.swupdateRebootHour);
 
   // Every write is fire-and-forget with the failure swallowed: the hook already
@@ -63,7 +111,15 @@ export function StarlinkSettingsTab({
       {settings.loading && <Loading message='Reading dish configuration…' />}
       {/* Same Callout the Router tab uses for its failures — the two tabs are
           siblings and their errors must not read as two different apps. */}
-      {settings.error && <Callout tone='error'>{settings.error}</Callout>}
+      {settings.error && (
+        <Callout tone='error'>
+          {settings.error instanceof AccountRequiredError ? (
+            <AccountRequiredNotice />
+          ) : (
+            settings.error.message
+          )}
+        </Callout>
+      )}
       {config && (
         <>
           <SettingRow
@@ -80,9 +136,7 @@ export function StarlinkSettingsTab({
               </SelectTrigger>
               <SelectContent className={selectContentClass}>
                 {(Object.keys(SNOW_MELT_LABEL) as SnowMeltMode[]).map((mode) => (
-                  <SelectItem key={mode} value={mode} className={selectItemClass}>
-                    {SNOW_MELT_LABEL[mode]}
-                  </SelectItem>
+                  <SnowMeltOption key={mode} mode={mode} />
                 ))}
               </SelectContent>
             </Select>
@@ -92,7 +146,7 @@ export function StarlinkSettingsTab({
             title='Sleep schedule'
             caption={
               sleepEnabled
-                ? `Dish powers down daily at ${sleepStart} for ${sleepDurationH} h`
+                ? `Dish powers down daily at ${formatClock12(sleepStartLocal)} and wakes at ${formatClock12(wakeLocal)}`
                 : "Power the dish down for part of every day"
             }
           >
@@ -105,7 +159,7 @@ export function StarlinkSettingsTab({
                     ? {
                         powerSaveMode: true,
                         powerSaveStartMinutes:
-                          config.powerSaveStartMinutes ?? localTimeToUtcMinutes("01:00"),
+                          config.powerSaveStartMinutes ?? localMinutesToUtcMinutes(60),
                         powerSaveDurationMinutes: config.powerSaveDurationMinutes || 360,
                       }
                     : { powerSaveMode: false },
@@ -116,32 +170,27 @@ export function StarlinkSettingsTab({
           {sleepEnabled && (
             <div className='flex items-center gap-2 pb-[8px] pl-0.5'>
               <span className='mt-px block text-[12px] text-muted-foreground'>from</span>
-              <input
-                type='time'
-                className='h-7 rounded-sm border border-hairline bg-transparent px-2 font-mono text-[12px] text-ink tabular-nums hover:border-input'
-                value={sleepStart}
+              <TimePicker
+                minutes={sleepStartLocal}
                 disabled={settings.saving}
-                onChange={(event) =>
-                  save({ powerSaveStartMinutes: localTimeToUtcMinutes(event.target.value) })
+                onChange={(newStartLocal) =>
+                  save({
+                    powerSaveStartMinutes: localMinutesToUtcMinutes(newStartLocal),
+                    powerSaveDurationMinutes: (wakeLocal - newStartLocal + 1440) % 1440 || 1440,
+                  })
                 }
               />
-              <span className='mt-px block text-[12px] text-muted-foreground'>for</span>
-              <Select
-                value={String(sleepDurationH)}
+              <span className='mt-px block text-[12px] text-muted-foreground'>to</span>
+              <TimePicker
+                minutes={wakeLocal}
                 disabled={settings.saving}
-                onValueChange={(hours) => save({ powerSaveDurationMinutes: Number(hours) * 60 })}
-              >
-                <SelectTrigger className={triggerClass} style={{ width: 72 }}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className={selectContentClass}>
-                  {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((hours) => (
-                    <SelectItem key={hours} value={String(hours)} className={selectItemClass}>
-                      {hours} h
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onChange={(newWakeLocal) =>
+                  save({
+                    powerSaveDurationMinutes:
+                      (newWakeLocal - sleepStartLocal + 1440) % 1440 || 1440,
+                  })
+                }
+              />
             </div>
           )}
 

--- a/src/components/settings/TimePicker.tsx
+++ b/src/components/settings/TimePicker.tsx
@@ -1,0 +1,270 @@
+import { useRef, useState } from "react";
+import NumberFlow from "@number-flow/react";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { formatClock12 } from "./sleepSchedule";
+import { triggerClass } from "./settingsChrome";
+
+const DAY_MINUTES = 1440;
+const wrap = (minutes: number): number => ((minutes % DAY_MINUTES) + DAY_MINUTES) % DAY_MINUTES;
+
+const stepBtnClass =
+  "grid h-3 w-6 place-items-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer active:scale-90";
+const digitClass = "text-[16px] font-semibold leading-none text-foreground tabular-nums";
+const pillButtonBase =
+  "cursor-pointer rounded-full px-3.5 py-1 text-[10px] font-semibold transition-opacity duration-[120ms] enabled:hover:opacity-85 disabled:cursor-default disabled:opacity-45";
+
+/** A compact trigger, matching the other settings dropdowns, that opens a
+ *  popover to dial in a time. Adjustments inside the popover are local until
+ *  Set is pressed — Cancel or dismissing the popover discards them. */
+export function TimePicker({
+  minutes,
+  onChange,
+  disabled,
+}: {
+  minutes: number;
+  onChange: (minutes: number) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(minutes);
+
+  const openWith = (next: boolean) => {
+    if (next) setDraft(minutes);
+    setOpen(next);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={openWith}>
+      <PopoverTrigger asChild>
+        <button type='button' className={triggerClass} disabled={disabled}>
+          {formatClock12(minutes)}
+          <ChevronDownIcon />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className='w-auto rounded-lg border-hairline px-3.5 py-2' align='start'>
+        <TimeDial minutes={draft} onChange={setDraft} />
+        <div className='my-1.5 h-px w-full bg-hairline' />
+        <div className='flex justify-end gap-1.5'>
+          <button
+            type='button'
+            className={cn(
+              pillButtonBase,
+              "bg-[color-mix(in_srgb,var(--ink)_8%,var(--surface))] text-foreground",
+            )}
+            onClick={() => openWith(false)}
+          >
+            Cancel
+          </button>
+          <button
+            type='button'
+            className={cn(pillButtonBase, "bg-primary text-primary-foreground")}
+            onClick={() => {
+              if (draft !== minutes) onChange(draft);
+              setOpen(false);
+            }}
+          >
+            Set
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function TimeDial({ minutes, onChange }: { minutes: number; onChange: (minutes: number) => void }) {
+  const hour24 = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  const hour12 = hour24 % 12 || 12;
+  const isPM = hour24 >= 12;
+
+  const stepHour = (delta: number) => onChange(wrap(minutes + delta * 60));
+  const stepMinute = (delta: number) => onChange(wrap(minutes + delta * 5));
+  const setPeriod = (wantPM: boolean) => {
+    if (wantPM !== isPM) onChange(wrap(minutes + 12 * 60));
+  };
+
+  const [editingHour, setEditingHour] = useState(false);
+  const [editingMinute, setEditingMinute] = useState(false);
+  const [hourInput, setHourInput] = useState("");
+  const [minuteInput, setMinuteInput] = useState("");
+  const hourInputRef = useRef<HTMLInputElement>(null);
+  const minuteInputRef = useRef<HTMLInputElement>(null);
+
+  const startEditHour = () => {
+    setHourInput(String(hour12));
+    setEditingHour(true);
+    requestAnimationFrame(() => hourInputRef.current?.select());
+  };
+  const commitHour = () => {
+    const typed = parseInt(hourInput, 10);
+    if (!Number.isNaN(typed) && typed >= 1 && typed <= 12) {
+      const nextHour24 = isPM ? (typed === 12 ? 12 : typed + 12) : typed === 12 ? 0 : typed;
+      onChange(nextHour24 * 60 + minute);
+    }
+    setEditingHour(false);
+  };
+  const startEditMinute = () => {
+    setMinuteInput(String(minute).padStart(2, "0"));
+    setEditingMinute(true);
+    requestAnimationFrame(() => minuteInputRef.current?.select());
+  };
+  const commitMinute = () => {
+    const typed = parseInt(minuteInput, 10);
+    if (!Number.isNaN(typed) && typed >= 0 && typed <= 59) onChange(hour24 * 60 + typed);
+    setEditingMinute(false);
+  };
+
+  const digitInputClass = cn(
+    digitClass,
+    "w-8 rounded-sm bg-transparent text-center outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none",
+  );
+
+  return (
+    <div className='flex items-center justify-center gap-1.5'>
+      <TimeStepper
+        label='hour'
+        onUp={() => stepHour(1)}
+        onDown={() => stepHour(-1)}
+        editing={editingHour}
+      >
+        {editingHour ? (
+          <input
+            ref={hourInputRef}
+            type='number'
+            min={1}
+            max={12}
+            value={hourInput}
+            onChange={(event) => setHourInput(event.target.value)}
+            onBlur={commitHour}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commitHour();
+              if (event.key === "Escape") setEditingHour(false);
+            }}
+            onFocus={(event) => event.target.select()}
+            className={digitInputClass}
+          />
+        ) : (
+          <button
+            type='button'
+            onClick={startEditHour}
+            title='Click to type'
+            className='grid w-8 cursor-text place-items-center rounded-sm transition-colors hover:bg-accent'
+          >
+            <NumberFlow
+              value={hour12}
+              format={{ minimumIntegerDigits: 2 }}
+              className={digitClass}
+            />
+          </button>
+        )}
+      </TimeStepper>
+
+      <span className='text-[16px] font-semibold leading-none text-muted-foreground'>:</span>
+
+      <TimeStepper
+        label='minute'
+        onUp={() => stepMinute(1)}
+        onDown={() => stepMinute(-1)}
+        editing={editingMinute}
+      >
+        {editingMinute ? (
+          <input
+            ref={minuteInputRef}
+            type='number'
+            min={0}
+            max={59}
+            value={minuteInput}
+            onChange={(event) => setMinuteInput(event.target.value)}
+            onBlur={commitMinute}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commitMinute();
+              if (event.key === "Escape") setEditingMinute(false);
+            }}
+            onFocus={(event) => event.target.select()}
+            className={digitInputClass}
+          />
+        ) : (
+          <button
+            type='button'
+            onClick={startEditMinute}
+            title='Click to type'
+            className='grid w-8 cursor-text place-items-center rounded-sm transition-colors hover:bg-accent'
+          >
+            <NumberFlow
+              value={minute}
+              format={{ minimumIntegerDigits: 2 }}
+              className={digitClass}
+            />
+          </button>
+        )}
+      </TimeStepper>
+
+      <div className='ml-1 flex flex-col items-center gap-0.5'>
+        {(
+          [
+            ["AM", false],
+            ["PM", true],
+          ] as const
+        ).map(([label, wantPM]) => {
+          const active = wantPM === isPM;
+          return (
+            <button
+              key={label}
+              type='button'
+              onClick={() => setPeriod(wantPM)}
+              className={cn(
+                "cursor-pointer rounded-[3px] px-1.5 py-0.5 text-[9px] font-semibold uppercase transition-colors",
+                active
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** A vertical hour/minute control: up chevron, the (animated or editable) digits, down chevron. */
+function TimeStepper({
+  label,
+  onUp,
+  onDown,
+  editing,
+  children,
+}: {
+  label: string;
+  onUp: () => void;
+  onDown: () => void;
+  editing: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className='flex flex-col items-center gap-0.5'>
+      <button
+        type='button'
+        onClick={onUp}
+        aria-label={`Increase ${label}`}
+        tabIndex={editing ? -1 : 0}
+        className={stepBtnClass}
+      >
+        <ChevronUpIcon className='size-3' />
+      </button>
+      {children}
+      <button
+        type='button'
+        onClick={onDown}
+        aria-label={`Decrease ${label}`}
+        tabIndex={editing ? -1 : 0}
+        className={stepBtnClass}
+      >
+        <ChevronDownIcon className='size-3' />
+      </button>
+    </div>
+  );
+}

--- a/src/components/settings/sleepSchedule.test.ts
+++ b/src/components/settings/sleepSchedule.test.ts
@@ -1,30 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { localTimeToUtcMinutes, utcMinutesToLocalTime } from "./sleepSchedule";
+import { localMinutesToUtcMinutes, utcMinutesToLocalMinutes } from "./sleepSchedule";
 
 describe("sleep schedule timezone conversion", () => {
-  it("round-trips a local time through UTC minutes unchanged", () => {
+  it("round-trips local minutes through UTC minutes unchanged", () => {
     // The pair has to be exactly inverse, or the saved hour drifts by the
     // machine's offset every time the modal is opened and saved again.
-    for (const localTime of ["00:00", "01:00", "07:30", "13:45", "23:59"]) {
-      expect(utcMinutesToLocalTime(localTimeToUtcMinutes(localTime))).toBe(localTime);
+    for (const localMinutes of [0, 60, 450, 825, 1439]) {
+      expect(utcMinutesToLocalMinutes(localMinutesToUtcMinutes(localMinutes))).toBe(localMinutes);
     }
   });
 
   it("stays inside a single day's worth of minutes", () => {
-    for (const localTime of ["00:00", "12:00", "23:59"]) {
-      const utcMinutes = localTimeToUtcMinutes(localTime);
+    for (const localMinutes of [0, 720, 1439]) {
+      const utcMinutes = localMinutesToUtcMinutes(localMinutes);
       expect(utcMinutes).toBeGreaterThanOrEqual(0);
       expect(utcMinutes).toBeLessThan(24 * 60);
     }
   });
 
-  it("formats as zero-padded HH:MM", () => {
-    expect(utcMinutesToLocalTime(localTimeToUtcMinutes("09:05"))).toMatch(/^\d{2}:\d{2}$/);
-  });
-
   it("moves by exactly one hour when the input does", () => {
-    const first = localTimeToUtcMinutes("04:00");
-    const second = localTimeToUtcMinutes("05:00");
+    const first = localMinutesToUtcMinutes(4 * 60);
+    const second = localMinutesToUtcMinutes(5 * 60);
     expect((second - first + 1440) % 1440).toBe(60);
   });
 });

--- a/src/components/settings/sleepSchedule.ts
+++ b/src/components/settings/sleepSchedule.ts
@@ -3,17 +3,24 @@
 // apart from the form because getting this backwards is silent: the control
 // still looks right, it just schedules the wrong hour.
 
-/** UTC minutes-after-midnight → a local "HH:MM" for a time input. */
-export function utcMinutesToLocalTime(utcMinutes: number): string {
+/** UTC minutes-after-midnight → local minutes-after-midnight. */
+export function utcMinutesToLocalMinutes(utcMinutes: number): number {
   const date = new Date();
   date.setUTCHours(Math.floor(utcMinutes / 60), utcMinutes % 60, 0, 0);
-  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+  return date.getHours() * 60 + date.getMinutes();
 }
 
-/** Local "HH:MM" → UTC minutes-after-midnight, as the dish expects it. */
-export function localTimeToUtcMinutes(localTime: string): number {
-  const [hours, minutes] = localTime.split(":").map(Number);
+/** Local minutes-after-midnight → UTC minutes-after-midnight, as the dish expects it. */
+export function localMinutesToUtcMinutes(localMinutes: number): number {
   const date = new Date();
-  date.setHours(hours, minutes, 0, 0);
+  date.setHours(Math.floor(localMinutes / 60), localMinutes % 60, 0, 0);
   return date.getUTCHours() * 60 + date.getUTCMinutes();
+}
+
+/** Local minutes-after-midnight → "1:00 AM", for display. */
+export function formatClock12(minutes: number): string {
+  const hour24 = Math.floor(minutes / 60);
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const meridiem = hour24 >= 12 ? "PM" : "AM";
+  return `${hour12}:${String(minutes % 60).padStart(2, "0")} ${meridiem}`;
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -47,7 +47,7 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
+  position = "popper",
   align = "center",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -25,7 +25,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
         data-slot='switch-thumb'
         className={cn(
           "pointer-events-none block size-3.5 rounded-full shadow-sm transition-transform",
-          "data-[state=checked]:translate-x-[14px] data-[state=checked]:dark:bg-card",
+          "data-[state=checked]:translate-x-[14px] data-[state=checked]:bg-card",
           "data-[state=unchecked]:translate-x-0 data-[state=unchecked]:bg-ink-secondary",
         )}
       />

--- a/src/hooks/useDishSettings.ts
+++ b/src/hooks/useDishSettings.ts
@@ -3,7 +3,7 @@
 
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { DishClient, type DishConfigJson } from "@core/dishClient";
-import { GrpcWebError } from "@core/grpcWeb";
+import { applyDishConfigUpdate } from "../lib/dishConfigUpdate";
 import {
   readDishSettings,
   setDishConfig,
@@ -15,7 +15,7 @@ import {
 export interface DishSettingsState {
   config: DishConfig | null;
   loading: boolean;
-  error: string | null;
+  error: Error | null;
   saving: boolean;
   /** Apply a partial change; resolves after the dish confirms + config reloads. */
   save: (changes: DishConfigJson) => Promise<void>;
@@ -44,7 +44,9 @@ export function useDishSettings(): DishSettingsState {
     loadConfig().catch(
       (loadError) =>
         !disposed &&
-        setDishSettingsError(`Couldn't read dish config: ${(loadError as Error).message}`),
+        setDishSettingsError(
+          new Error(`Couldn't read dish config: ${(loadError as Error).message}`),
+        ),
     );
     return () => {
       disposed = true;
@@ -56,22 +58,10 @@ export function useDishSettings(): DishSettingsState {
       setSaving(true);
       setDishSettingsError(null);
       try {
-        const dishClient = await loadDishClient();
-        await dishClient.setConfig(changes);
+        await applyDishConfigUpdate(changes);
         await loadConfig();
       } catch (saveError) {
-        // Status 7 = the firmware's LAN write lock (measured 2026-07: every
-        // write RPC on dish and router refuses LAN callers; only the official
-        // app's cloud path can write). Nothing local unlocks it — not a bug in
-        // the request, and no setting to flip.
-        if (saveError instanceof GrpcWebError && saveError.grpcStatus === 7) {
-          setDishSettingsError(
-            "The dish refused the write (permission denied). Starlink's current firmware only accepts config changes " +
-              "through its own cloud, so local tools are read-only here — use the official Starlink app to change this.",
-          );
-        } else {
-          setDishSettingsError(`Dish refused the change: ${(saveError as Error).message}`);
-        }
+        setDishSettingsError(saveError as Error);
         throw saveError;
       } finally {
         setSaving(false);

--- a/src/lib/dishConfigUpdate.test.ts
+++ b/src/lib/dishConfigUpdate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from "vitest";
+import { AccountRequiredError, applyDishConfigUpdate } from "./dishConfigUpdate";
+
+describe("applyDishConfigUpdate", () => {
+  test("given: a successful write, should: post the changes to /cloud/dish-config", async () => {
+    const request = vi.fn().mockResolvedValue({ status: 200, body: { ok: true } });
+
+    await applyDishConfigUpdate({ swupdateRebootHour: 15 }, request);
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith({
+      path: "/cloud/dish-config",
+      method: "POST",
+      body: { swupdateRebootHour: 15 },
+    });
+  });
+
+  test("given: Starlink rejects the change, should: surface its message", async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 504,
+      body: { message: "Starlink did not answer in time." },
+    });
+
+    await expect(applyDishConfigUpdate({ powerSaveMode: true }, request)).rejects.toThrow(
+      "Starlink rejected the config change: Starlink did not answer in time.",
+    );
+  });
+
+  test("given: 428, should: surface a sign-in prompt rather than a rejection", async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 428,
+      body: { error: "not_connected", message: "An authorized account is required." },
+    });
+
+    await expect(applyDishConfigUpdate({ powerSaveMode: true }, request)).rejects.toBeInstanceOf(
+      AccountRequiredError,
+    );
+  });
+});

--- a/src/lib/dishConfigUpdate.ts
+++ b/src/lib/dishConfigUpdate.ts
@@ -1,0 +1,18 @@
+import { cloudRequest, type CloudRequest, type CloudReply } from "./cloudHost";
+import { AccountRequiredError } from "./routerClientUpdate";
+import type { DishConfigJson } from "@core/dishClient";
+
+export { AccountRequiredError };
+
+/** Send a dish config change through Starlink cloud, the same path a client
+ *  rename or pause takes — LAN writes are refused by current firmware. */
+export async function applyDishConfigUpdate(
+  changes: DishConfigJson,
+  request: (request: CloudRequest) => Promise<CloudReply> = cloudRequest,
+): Promise<void> {
+  const reply = await request({ path: "/cloud/dish-config", method: "POST", body: changes });
+  if (reply.status === 200) return;
+  const message = (reply.body as { message?: string })?.message ?? `HTTP ${reply.status}`;
+  if (reply.status === 428) throw new AccountRequiredError(message);
+  throw new Error(`Starlink rejected the config change: ${message}`);
+}

--- a/src/lib/dishSettingsStore.ts
+++ b/src/lib/dishSettingsStore.ts
@@ -8,7 +8,7 @@ export type DishConfig = DishConfigJson & Record<string, unknown>;
 
 export interface DishSettingsSnapshot {
   config: DishConfig | null;
-  error: string | null;
+  error: Error | null;
 }
 
 let snapshot: DishSettingsSnapshot = { config: null, error: null };
@@ -34,7 +34,7 @@ export function setDishConfig(config: DishConfig): void {
   publish({ config, error: null });
 }
 
-export function setDishSettingsError(error: string | null): void {
+export function setDishSettingsError(error: Error | null): void {
   if (snapshot.error === error) return;
   publish({ config: snapshot.config, error });
 }


### PR DESCRIPTION
Settings panel writes (sleep schedule, update window, defer-updates) now go through Starlink's cloud, the same path rename/pause already use.

- The old code called dishClient.setConfig() directly over the LAN, which current firmware refuses (grpc status 7), so every "Save" in that panel was silently broken. 
- Fixed with the same shape as the rename work: core/dishConfigUpdate.ts (prepares the request from the dish's own LAN-read identity), a parallel updateDishConfig in cloud/starlinkCloudHandler.ts, wired into all three hosts (dev proxy, Electron, extension — including a new DISH_LAN_HANDLE_URL constant for the two that run outside a browser)