### PR TITLE
Orient FRAME_UT obstruction maps so Mini domes face north

### DIFF
--- a/core/dishClient.ts
+++ b/core/dishClient.ts
@@ -207,11 +207,17 @@ export interface DishLocationJson {
   source?: string;
 }
 
+/** How the obstruction grid is oriented. FRAME_EARTH is north-up; FRAME_UT
+ *  is dish-relative (bottom-center is the boresight azimuth). Mini kits on
+ *  roam typically report FRAME_UT; a Standard on a fixed site reports FRAME_EARTH. */
+export type ObstructionMapReferenceFrame = "FRAME_UNKNOWN" | "FRAME_EARTH" | "FRAME_UT";
+
 export interface DishObstructionMapJson {
   numRows?: number;
   numCols?: number;
   snr?: number[];
   maxThetaDeg?: number;
+  mapReferenceFrame?: ObstructionMapReferenceFrame;
 }
 
 // ---------- config / diagnostics shapes ----------

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { useLiveReadings } from "./hooks/useLiveReadings";
 import { formatThroughput } from "./lib/format";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { useTheme } from "./hooks/useTheme";
+import { dishModelFor } from "./lib/dishMesh";
 
 export default function App() {
   const { theme, cycleTheme } = useTheme();
@@ -51,7 +52,12 @@ export default function App() {
     telemetry.dishLocation?.lla,
   );
   const lanOnline = useLanPresence(telemetry.status, telemetry.connectionState);
-  const satellites = useSatellites(observerLocation, telemetry.obstructionMap);
+  const satellites = useSatellites(
+    observerLocation,
+    telemetry.obstructionMap,
+    dishModelFor(telemetry.status),
+    telemetry.status?.boresightAzimuthDeg ?? 0,
+  );
   useOutageNotifications(telemetry);
   const deviceAlerts = useDeviceAlerts(telemetry.status, telemetry.connectionState);
   const thermalEvents = useThermalEvents();

--- a/src/components/obstruction/obstructionFrame.test.ts
+++ b/src/components/obstruction/obstructionFrame.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { gridCellToEnu, resolveObstructionFrame, skyDirectionToGrid } from "./obstructionFrame";
+
+describe("resolveObstructionFrame", () => {
+  it("trusts an explicit earth or UT frame", () => {
+    expect(resolveObstructionFrame("FRAME_EARTH", "mini1")).toBe("FRAME_EARTH");
+    expect(resolveObstructionFrame("FRAME_UT", "rev4Standard")).toBe("FRAME_UT");
+  });
+
+  it("treats a Mini with no frame as UT, and a Standard as earth", () => {
+    expect(resolveObstructionFrame(undefined, "mini1")).toBe("FRAME_UT");
+    expect(resolveObstructionFrame(undefined, "mini2")).toBe("FRAME_UT");
+    expect(resolveObstructionFrame("FRAME_UNKNOWN", "rev4Standard")).toBe("FRAME_EARTH");
+  });
+});
+
+describe("gridCellToEnu", () => {
+  const size = 11;
+  const centre = 5;
+
+  it("reads top-center as north in the earth frame", () => {
+    const { east, north } = gridCellToEnu(0, centre, size, "FRAME_EARTH", 0);
+    expect(east).toBeCloseTo(0);
+    expect(north).toBeCloseTo(1);
+  });
+
+  it("reads bottom-center as north in the UT frame when the dish faces north", () => {
+    const { east, north } = gridCellToEnu(size - 1, centre, size, "FRAME_UT", 0);
+    expect(east).toBeCloseTo(0);
+    expect(north).toBeCloseTo(1);
+  });
+
+  it("flips a Mini-style UT map 180° versus the earth reading of the same cell", () => {
+    const earth = gridCellToEnu(0, centre, size, "FRAME_EARTH", 0);
+    const ut = gridCellToEnu(0, centre, size, "FRAME_UT", 0);
+    expect(ut.north).toBeCloseTo(-earth.north);
+    expect(ut.east).toBeCloseTo(earth.east);
+  });
+
+  it("rotates a UT map so the bottom rim follows the boresight", () => {
+    const { east, north } = gridCellToEnu(size - 1, centre, size, "FRAME_UT", 90);
+    expect(east).toBeCloseTo(1);
+    expect(north).toBeCloseTo(0);
+  });
+});
+
+describe("skyDirectionToGrid", () => {
+  const size = 11;
+  const centre = 5;
+
+  it("is the inverse of gridCellToEnu on the earth frame", () => {
+    const { east, north } = gridCellToEnu(1, 8, size, "FRAME_EARTH", 0);
+    const azimuth = (Math.atan2(east, north) * 180) / Math.PI;
+    const radial = Math.hypot(east, north);
+    const { row, col } = skyDirectionToGrid(azimuth, radial, size, "FRAME_EARTH", 0);
+    expect(row).toBe(1);
+    expect(col).toBe(8);
+  });
+
+  it("puts due north on the bottom rim of a north-facing UT map", () => {
+    const { row, col } = skyDirectionToGrid(0, 1, size, "FRAME_UT", 0);
+    expect(row).toBe(size - 1);
+    expect(col).toBe(centre);
+  });
+
+  it("puts due north on the top rim of an earth map", () => {
+    const { row, col } = skyDirectionToGrid(0, 1, size, "FRAME_EARTH", 0);
+    expect(row).toBe(0);
+    expect(col).toBe(centre);
+  });
+});

--- a/src/components/obstruction/obstructionFrame.ts
+++ b/src/components/obstruction/obstructionFrame.ts
@@ -1,0 +1,83 @@
+// How the dish's obstruction grid maps onto geographic east/north.
+//
+// The firmware labels the grid with `mapReferenceFrame`:
+//
+//   FRAME_EARTH — top-center is true north (what a Standard on a fixed site
+//                 reports). This is the convention the dome already drew.
+//   FRAME_UT    — bottom-center is the user-terminal boresight azimuth. Mini
+//                 kits on roam/mobile typically report this. Treating that
+//                 grid as earth-north puts the used sky on the south rim —
+//                 the opposite of the official Starlink app.
+//
+// When the field is missing, Mini hardware is assumed FRAME_UT and everything
+// else FRAME_EARTH, matching the kits that actually emit each frame.
+
+import type { DishModel } from "../../lib/dishMesh";
+import type { ObstructionMapReferenceFrame } from "@core/dishClient";
+
+export type ObstructionMapFrame = "FRAME_EARTH" | "FRAME_UT";
+
+export function resolveObstructionFrame(
+  reported: ObstructionMapReferenceFrame | string | undefined,
+  dishModel: DishModel,
+): ObstructionMapFrame {
+  if (reported === "FRAME_EARTH" || reported === "FRAME_UT") return reported;
+  return dishModel === "mini1" || dishModel === "mini2" ? "FRAME_UT" : "FRAME_EARTH";
+}
+
+/** Grid cell → local east/north in units of grid radius (−1…1). */
+export function gridCellToEnu(
+  row: number,
+  col: number,
+  gridSize: number,
+  frame: ObstructionMapFrame,
+  boresightAzimuthDeg: number,
+): { east: number; north: number } {
+  const centre = (gridSize - 1) / 2;
+  const eastGrid = (col - centre) / centre;
+  const northGrid = (centre - row) / centre;
+  if (frame !== "FRAME_UT") return { east: eastGrid, north: northGrid };
+
+  // After a vertical flip, +forward is the bottom of the page (boresight) and
+  // +right is still +column. Rotate that body frame by the boresight azimuth
+  // so forward lands on the real compass bearing.
+  const forward = -northGrid;
+  const right = eastGrid;
+  const azimuthRad = (boresightAzimuthDeg * Math.PI) / 180;
+  const sine = Math.sin(azimuthRad);
+  const cosine = Math.cos(azimuthRad);
+  return {
+    east: right * cosine + forward * sine,
+    north: -right * sine + forward * cosine,
+  };
+}
+
+/** Geographic az/el (as a polar fraction from zenith) → the grid cell that holds it. */
+export function skyDirectionToGrid(
+  azimuthDeg: number,
+  radialFraction: number,
+  gridSize: number,
+  frame: ObstructionMapFrame,
+  boresightAzimuthDeg: number,
+): { row: number; col: number } {
+  const centre = (gridSize - 1) / 2;
+  const azimuthRad = (azimuthDeg * Math.PI) / 180;
+  const east = Math.sin(azimuthRad) * radialFraction;
+  const north = Math.cos(azimuthRad) * radialFraction;
+  if (frame !== "FRAME_UT") {
+    return {
+      row: Math.round(centre - north * centre),
+      col: Math.round(centre + east * centre),
+    };
+  }
+
+  const boresightRad = (boresightAzimuthDeg * Math.PI) / 180;
+  const sine = Math.sin(boresightRad);
+  const cosine = Math.cos(boresightRad);
+  const right = east * cosine - north * sine;
+  const forward = east * sine + north * cosine;
+  return {
+    row: Math.round(centre + forward * centre),
+    col: Math.round(centre + right * centre),
+  };
+}

--- a/src/components/satellite/SatelliteView.tsx
+++ b/src/components/satellite/SatelliteView.tsx
@@ -112,9 +112,22 @@ export function SatelliteView({
   const survey = useMemo(
     () =>
       viewingHistory
-        ? snapshotSurvey(snapshots[scrubIndex], obstructionMap?.maxThetaDeg ?? 80, status)
+        ? snapshotSurvey(
+            snapshots[scrubIndex],
+            obstructionMap?.maxThetaDeg ?? 80,
+            status,
+            obstructionMap?.mapReferenceFrame,
+          )
         : live,
-    [viewingHistory, scrubIndex, snapshots, obstructionMap?.maxThetaDeg, status, live],
+    [
+      viewingHistory,
+      scrubIndex,
+      snapshots,
+      obstructionMap?.maxThetaDeg,
+      obstructionMap?.mapReferenceFrame,
+      status,
+      live,
+    ],
   );
 
   useEffect(() => {

--- a/src/components/satellite/skyGeometry.test.ts
+++ b/src/components/satellite/skyGeometry.test.ts
@@ -106,6 +106,22 @@ describe("buildDomePoints", () => {
     expect(after[3]).toBe(before[3]);
   });
 
+  it("places a UT-frame Mini's bottom rim on the north side of the dome", () => {
+    // A single reading on the bottom-center cell. In FRAME_UT with the dish
+    // facing north that cell is the boresight azimuth — geographic north —
+    // which is −z in the scene (x east, y up, z south).
+    const grid = survey(11, -1, { mapReferenceFrame: "FRAME_UT", boresightAzimuthDeg: 0 });
+    grid.kinds[10 * 11 + 5] = 1;
+    const points = buildDomePoints(grid);
+    let found: [number, number, number] | null = null;
+    for (let i = 0; i < points.length; i += 4) {
+      if (points[i + 3] === 1) found = [points[i], points[i + 1], points[i + 2]];
+    }
+    expect(found).not.toBeNull();
+    expect(found![0]).toBeCloseTo(0, 5); // east
+    expect(found![2]).toBeLessThan(0); // south-axis: north is negative
+  });
+
   it("spares unmapped sky that sits inside the envelope", () => {
     // A hole punched in the middle of the readings is never-observed sky the
     // trim must leave alone — it is the band overhead, not the skirt.

--- a/src/components/satellite/skyGeometry.ts
+++ b/src/components/satellite/skyGeometry.ts
@@ -10,6 +10,7 @@
 
 import { type DishModelMesh } from "./dishModels/types";
 import type { DishModel } from "../../lib/dishMesh";
+import { gridCellToEnu, type ObstructionMapFrame } from "../obstruction/obstructionFrame";
 
 export interface SkySurvey {
   gridSize: number;
@@ -18,6 +19,8 @@ export interface SkySurvey {
   kinds: Uint8Array;
   boresightAzimuthDeg: number;
   boresightElevationDeg: number;
+  /** How the grid is oriented. Defaults to earth-north when omitted (tests). */
+  mapReferenceFrame?: ObstructionMapFrame;
   /** Which kit to draw at the centre. Rides the survey because it comes from the
    *  same status reply as the boresight, and lands just as late — so the rebuild
    *  that follows a status poll picks the model up without a second channel. */
@@ -79,14 +82,18 @@ function spokeAt(east: number, north: number): number {
  */
 export function observedEnvelope(survey: SkySurvey): Float64Array | null {
   const { gridSize, kinds } = survey;
-  const centre = (gridSize - 1) / 2;
   const deepest = new Float64Array(ENVELOPE_SPOKES).fill(-1);
   let anyReading = false;
   for (let row = 0; row < gridSize; row++) {
     for (let col = 0; col < gridSize; col++) {
       if (kinds[row * gridSize + col] === 0) continue;
-      const east = (col - centre) / centre;
-      const north = (centre - row) / centre;
+      const { east, north } = gridCellToEnu(
+        row,
+        col,
+        gridSize,
+        survey.mapReferenceFrame ?? "FRAME_EARTH",
+        survey.boresightAzimuthDeg,
+      );
       const radial = Math.hypot(east, north);
       if (radial > 1) continue;
       anyReading = true;
@@ -133,14 +140,18 @@ export function observedEnvelope(survey: SkySurvey): Float64Array | null {
  */
 export function buildDomePoints(survey: SkySurvey, trimUnmapped = false) {
   const { gridSize, kinds } = survey;
-  const centre = (gridSize - 1) / 2;
   const maxTheta = (survey.maxThetaDeg * Math.PI) / 180;
   const envelope = trimUnmapped ? observedEnvelope(survey) : null;
   const out: number[] = [];
   for (let row = 0; row < gridSize; row++) {
     for (let col = 0; col < gridSize; col++) {
-      const east = (col - centre) / centre;
-      const north = (centre - row) / centre;
+      const { east, north } = gridCellToEnu(
+        row,
+        col,
+        gridSize,
+        survey.mapReferenceFrame ?? "FRAME_EARTH",
+        survey.boresightAzimuthDeg,
+      );
       const radial = Math.hypot(east, north);
       if (radial > 1) continue;
       const kind = kinds[row * gridSize + col];

--- a/src/components/satellite/skySurvey.ts
+++ b/src/components/satellite/skySurvey.ts
@@ -8,6 +8,7 @@ import type { DishObstructionMapJson, DishStatusJson } from "@core/dishClient";
 import { dishModelFor } from "../../lib/dishMesh";
 import { unpackCells, type ObstructionSnapshot } from "../../lib/obstructionSnapshots";
 import { liveKindAtCell, snapshotKindAtCell } from "../obstruction/obstructionGrid";
+import { resolveObstructionFrame } from "../obstruction/obstructionFrame";
 import type { SkySurvey } from "./skyGeometry";
 
 const KIND_CODE = { unmapped: 0, clear: 1, partial: 2, obstructed: 3 } as const;
@@ -26,13 +27,15 @@ export function liveSurvey(
       kinds[row * gridSize + col] = KIND_CODE[kindAt(row, col)];
     }
   }
+  const dishModel = dishModelFor(status);
   return {
     gridSize,
     maxThetaDeg: map.maxThetaDeg ?? 80,
     kinds,
     boresightAzimuthDeg: status?.boresightAzimuthDeg ?? 0,
     boresightElevationDeg: status?.boresightElevationDeg ?? 90,
-    dishModel: dishModelFor(status),
+    dishModel,
+    mapReferenceFrame: resolveObstructionFrame(map.mapReferenceFrame, dishModel),
   };
 }
 
@@ -41,6 +44,7 @@ export function snapshotSurvey(
   snapshot: ObstructionSnapshot,
   fallbackMaxTheta: number,
   status: DishStatusJson | null,
+  reportedFrame?: DishObstructionMapJson["mapReferenceFrame"],
 ): SkySurvey {
   const gridSize = snapshot.gridSize;
   const kindAt = snapshotKindAtCell(unpackCells(snapshot), gridSize);
@@ -50,12 +54,14 @@ export function snapshotSurvey(
       kinds[row * gridSize + col] = KIND_CODE[kindAt(row, col)];
     }
   }
+  const dishModel = dishModelFor(status);
   return {
     gridSize,
     maxThetaDeg: snapshot.maxThetaDeg ?? fallbackMaxTheta,
     kinds,
     boresightAzimuthDeg: status?.boresightAzimuthDeg ?? 0,
     boresightElevationDeg: status?.boresightElevationDeg ?? 90,
-    dishModel: dishModelFor(status),
+    dishModel,
+    mapReferenceFrame: resolveObstructionFrame(reportedFrame, dishModel),
   };
 }

--- a/src/hooks/useSatellites.ts
+++ b/src/hooks/useSatellites.ts
@@ -8,6 +8,11 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { DishObstructionMapJson } from "@core/dishClient";
+import type { DishModel } from "../lib/dishMesh";
+import {
+  resolveObstructionFrame,
+  skyDirectionToGrid,
+} from "../components/obstruction/obstructionFrame";
 import {
   loadStarlinkTles,
   StarlinkTracker,
@@ -71,29 +76,40 @@ const EMPTY_STATS: SatelliteStats = {
 };
 
 /** Is the sky cell toward this az/el clear according to the dish's map? */
-function isUnobstructed(sky: SatelliteSky, obstructionMap: DishObstructionMapJson | null): boolean {
+function isUnobstructed(
+  sky: SatelliteSky,
+  obstructionMap: DishObstructionMapJson | null,
+  dishModel: DishModel,
+  boresightAzimuthDeg: number,
+): boolean {
   const grid = obstructionMap?.snr;
   if (!grid || grid.length === 0) return true;
   const gridSize = obstructionMap.numRows ?? Math.round(Math.sqrt(grid.length));
   const maxThetaDeg = obstructionMap.maxThetaDeg ?? 80;
   const radialFraction = (90 - sky.elevationDeg) / maxThetaDeg;
   if (radialFraction > 1) return false;
-  const azimuthRad = (sky.azimuthDeg * Math.PI) / 180;
-  const gridCenter = (gridSize - 1) / 2;
-  const columnIndex = Math.round(gridCenter + Math.sin(azimuthRad) * radialFraction * gridCenter);
-  const rowIndex = Math.round(gridCenter - Math.cos(azimuthRad) * radialFraction * gridCenter);
-  const fractionUsable = grid[rowIndex * gridSize + columnIndex];
+  const frame = resolveObstructionFrame(obstructionMap.mapReferenceFrame, dishModel);
+  const { row, col } = skyDirectionToGrid(
+    sky.azimuthDeg,
+    radialFraction,
+    gridSize,
+    frame,
+    boresightAzimuthDeg,
+  );
+  const fractionUsable = grid[row * gridSize + col];
   return fractionUsable === undefined || fractionUsable < 0 || 1 - fractionUsable <= 0.05;
 }
 
 function pickServingCandidate(
   inView: SatelliteSky[],
   obstructionMap: DishObstructionMapJson | null,
+  dishModel: DishModel,
+  boresightAzimuthDeg: number,
 ): SatelliteSky | null {
   let bestUnobstructed: SatelliteSky | null = null;
   for (const sky of inView) {
     if (sky.elevationDeg < SERVING_ELEVATION_FLOOR_DEG) break; // sorted by elevation
-    if (isUnobstructed(sky, obstructionMap)) {
+    if (isUnobstructed(sky, obstructionMap, dishModel, boresightAzimuthDeg)) {
       bestUnobstructed = sky;
       break;
     }
@@ -106,6 +122,8 @@ function pickServingCandidate(
 export function useSatellites(
   observerLocation: ObserverLocation | null,
   obstructionMap: DishObstructionMapJson | null,
+  dishModel: DishModel = "unknown",
+  boresightAzimuthDeg = 0,
 ): SatelliteFeed {
   const [stats, setStats] = useState<SatelliteStats>(EMPTY_STATS);
   const [load, setLoad] = useState<EphemerisLoad>(LOADING);
@@ -113,10 +131,10 @@ export function useSatellites(
   // What the stats interval reads the current obstruction map from, so a new map
   // does not restart the tracker. Written after commit rather than while
   // rendering, which React may repeat or discard.
-  const obstructionMapRef = useRef(obstructionMap);
+  const lookupRef = useRef({ obstructionMap, dishModel, boresightAzimuthDeg });
   useEffect(() => {
-    obstructionMapRef.current = obstructionMap;
-  }, [obstructionMap]);
+    lookupRef.current = { obstructionMap, dishModel, boresightAzimuthDeg };
+  }, [obstructionMap, dishModel, boresightAzimuthDeg]);
 
   const latitude = observerLocation?.latitudeDeg;
   const longitude = observerLocation?.longitudeDeg;
@@ -152,7 +170,13 @@ export function useSatellites(
 
         const updateStats = () => {
           const inView = tracker.finePass();
-          const servingCandidate = pickServingCandidate(inView, obstructionMapRef.current);
+          const lookup = lookupRef.current;
+          const servingCandidate = pickServingCandidate(
+            inView,
+            lookup.obstructionMap,
+            lookup.dishModel,
+            lookup.boresightAzimuthDeg,
+          );
           setStats((previousStats) => ({
             ...previousStats,
             inViewCount: inView.length,


### PR DESCRIPTION
## Summary

- Fixes Mini obstruction / sky-dome orientation: Dishylink drew the used sky on the **south** rim while the official Starlink app (and a Standard kit) show it **north**.
- The obstruction-map reply already includes `mapReferenceFrame`. `FRAME_EARTH` is north-up; `FRAME_UT` (typical Mini on roam) has bottom-center as the boresight azimuth. The renderer ignored that field.
- Live dome, time-lapse, and satellite obstruction checks now share one grid→ENU conversion. A Mini with no frame reported is treated as `FRAME_UT`; an explicit `FRAME_EARTH` is left alone.

Fixes #10

## Test plan

- [x] `npx vitest run` on the new frame tests and existing dome tests
- [x] `tsc -b` and eslint on the touched files (`--max-warnings 0`)
- [x] Compared a Mini against the official phone app (dome was south before, north after)
- [ ] Confirm a Standard kit is unchanged (`FRAME_EARTH`)
- [ ] No new dish/router poll — `mapReferenceFrame` rides the existing obstruction-map reply