### PR TITLE
Feat/Bypass mode control from Router settings

### DIFF
--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -621,12 +621,14 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       return { status: 200, body: { ok: true } };
     } catch (error) {
       if (error instanceof SessionExpiredError) return NOT_CONNECTED;
-      // A subnet change reconfigures the LAN carrying it, so a write that takes
-      // effect kills its own reply. How that surfaces is the host's business: a
-      // deadline where the request is left hanging, a dead socket where it is not
-      // — a service worker's fetch rejects the moment the network goes. Neither
-      // is the far end refusing, and only the far end can refuse.
-      if (update.kind === "subnet" && configWriteDispatched && !(error instanceof GrpcWebError)) {
+      // A subnet change and a bypass switch both reconfigure the LAN carrying
+      // them, so a write that takes effect kills its own reply. How that surfaces
+      // is the host's business: a deadline where the request is left hanging, a
+      // dead socket where it is not — a service worker's fetch rejects the moment
+      // the network goes. Neither is the far end refusing, and only the far end
+      // can refuse.
+      const seversItsOwnReply = update.kind === "subnet" || update.kind === "bypass";
+      if (seversItsOwnReply && configWriteDispatched && !(error instanceof GrpcWebError)) {
         return { status: 200, body: { ok: true, applied: true } };
       }
       if (error instanceof DOMException && error.name === "TimeoutError") {
@@ -652,6 +654,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       if (typeof update.subnet !== "string" || typeof update.password !== "string") return false;
       return subnetRefusal(update.subnet, update.password) === null;
     }
+    if (update?.kind === "bypass") return typeof update.enabled === "boolean";
     if (update?.kind !== "customDns") return false;
     if (!Array.isArray(update.nameservers)) return false;
     if (!update.nameservers.every((server) => typeof server === "string")) return false;

--- a/core/routerConfigUpdate.test.ts
+++ b/core/routerConfigUpdate.test.ts
@@ -98,6 +98,26 @@ describe("buildRouterConfigRequest", () => {
     expect(request.wifiSetConfig.wifiConfig).toEqual({ nameservers: [], applyNameservers: true });
   });
 
+  it("names only the bypass fields, so no other setting rides along", () => {
+    const request = buildRouterConfigRequest(TARGET, { kind: "bypass", enabled: true });
+    expect(request).toEqual({
+      targetId: TARGET,
+      wifiSetConfig: { wifiConfig: { bypassMode: true, applyBypassMode: true } },
+    });
+    expect(Object.keys(request.wifiSetConfig.wifiConfig)).toEqual([
+      "bypassMode",
+      "applyBypassMode",
+    ]);
+  });
+
+  it("sends the apply flag when switching bypass off, not just when turning it on", () => {
+    const request = buildRouterConfigRequest(TARGET, { kind: "bypass", enabled: false });
+    expect(request.wifiSetConfig.wifiConfig).toEqual({
+      bypassMode: false,
+      applyBypassMode: true,
+    });
+  });
+
   it("refuses a target that is not a router", () => {
     expect(() =>
       buildRouterConfigRequest("ut0158168c-42207c02-5946ca71", {

--- a/core/routerConfigUpdate.ts
+++ b/core/routerConfigUpdate.ts
@@ -66,6 +66,13 @@ export type RouterConfigUpdate =
        *  router reports the stored one as `•••••` and takes that string
        *  literally if it is written back, locking every device off the WiFi. */
       password: string;
+    }
+  | {
+      kind: "bypass";
+      /** On hands the LAN to a third-party router and takes the Starlink
+       *  router's own WiFi down with it, so the machine asking for this is
+       *  usually the one that loses its connection. Off is the way back. */
+      enabled: boolean;
     };
 
 /** The addresses as they will be sent, or null when any of them is not an address
@@ -203,6 +210,12 @@ export function buildRouterConfigRequest(
           applyNetworks: true,
         },
       },
+    };
+  }
+  if (update.kind === "bypass") {
+    return {
+      targetId,
+      wifiSetConfig: { wifiConfig: { bypassMode: update.enabled, applyBypassMode: true } },
     };
   }
   const nameservers = normalizeNameservers(update.nameservers);

--- a/src/components/settings/BypassSection.test.tsx
+++ b/src/components/settings/BypassSection.test.tsx
@@ -1,0 +1,196 @@
+// The row decides which value reaches a router that can take a house offline, so
+// what is held here is the decision, not the styling: that the write carries the
+// change the dialog named, and that the control still depicts the truth after it.
+//
+// The account lags a bypass write by minutes, and it can catch up at any moment —
+// including while the dialog sits open. That timing is the source of the cases
+// below, and it is why they drive `reported` by hand rather than waiting on it.
+
+import { useState } from "react";
+import { expect, describe, test, afterEach, vi } from "vitest";
+import { render, cleanup } from "vitest-browser-react";
+import { BypassSection } from "./BypassSection";
+
+afterEach(cleanup);
+
+const TRACK_INSET_PX = 3;
+
+function track(): HTMLElement {
+  return document.querySelector("[data-slide-track]") as HTMLElement;
+}
+
+function handle(): HTMLElement {
+  return document.querySelector("[data-slide-handle]") as HTMLElement;
+}
+
+function text(): string {
+  return document.body.textContent ?? "";
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = [...document.querySelectorAll("button")].find(
+    (element) => element.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no button labelled "${label}"`);
+  return found as HTMLButtonElement;
+}
+
+async function waitForText(substring: string, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (text().includes(substring)) return;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for: ${substring}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+/** Lets pending state land without waiting on anything in particular. The long
+ *  form outlasts the handle's glide, for the cases that measure where it stopped. */
+async function settle(ms = 60): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type Props = React.ComponentProps<typeof BypassSection>;
+
+function mount(overrides: Partial<Props> = {}) {
+  const onSave = vi.fn<Props["onSave"]>().mockResolvedValue(undefined);
+  const onReload = vi.fn();
+  const props: Props = {
+    reported: false,
+    routerAnswering: true,
+    disabled: false,
+    onSave,
+    onReload,
+    ...overrides,
+  };
+
+  // The account's answer is a prop here, so a holder owns it and the cases move
+  // it — that is how the lag is reproduced at the moment each one needs it.
+  let publish: (reported: boolean | null) => void = () => {};
+  function Holder() {
+    const [reported, setReported] = useState(props.reported);
+    publish = setReported;
+    return <BypassSection {...props} reported={reported} />;
+  }
+  render(<Holder />);
+
+  return { onSave, onReload, reportNow: (reported: boolean | null) => publish(reported) };
+}
+
+/** Presses the handle, crosses the whole track, and lets go. */
+function slide() {
+  const grip = handle();
+  const start = grip.getBoundingClientRect();
+  const travel = track().clientWidth - start.width - TRACK_INSET_PX * 2;
+  const from = start.left + start.width / 2;
+  const to = from + travel * 1.2;
+
+  grip.setPointerCapture = () => {};
+  grip.releasePointerCapture = () => {};
+  grip.dispatchEvent(new PointerEvent("pointerdown", { clientX: from, bubbles: true }));
+  grip.dispatchEvent(new PointerEvent("pointermove", { clientX: to, bubbles: true }));
+  grip.dispatchEvent(new PointerEvent("pointerup", { clientX: to, bubbles: true }));
+}
+
+/** Where the handle sits, as a share of the track. 0 is the left edge, 1 the right. */
+function handlePosition(): number {
+  const trackBox = track().getBoundingClientRect();
+  const handleBox = handle().getBoundingClientRect();
+  return (handleBox.left - trackBox.left) / (trackBox.width - handleBox.width);
+}
+
+describe("BypassSection", () => {
+  test("sends the change the dialog named, even when the account flips underneath it", async () => {
+    const { onSave, reportNow } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Turn on bypass mode?");
+
+    // The account catches up mid-decision — exactly the two-minute lag landing at
+    // the worst moment. The dialog must keep asking what it asked.
+    reportNow(true);
+    await settle();
+    expect(text()).toContain("Turn on bypass mode?");
+
+    button("Turn on").click();
+    await settle();
+    expect(onSave).toHaveBeenCalledWith(true);
+  });
+
+  test("leaves the handle at the end it was dragged to once the write is away", async () => {
+    mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Turn on bypass mode?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+
+    // Sampled rather than measured once: the failure this guards against is the
+    // handle returning to the start and gliding back, which a single reading
+    // taken after the glide would not see.
+    const path: number[] = [];
+    for (let sample = 0; sample < 12; sample++) {
+      await settle(35);
+      path.push(handlePosition());
+    }
+
+    // Bypass now reads as on, so the control turns around and offers the way back
+    // from where the handle already is, rather than crossing the track twice.
+    expect(Math.min(...path)).toBeGreaterThan(0.5);
+    expect(path.at(-1)).toBeGreaterThan(0.9);
+    expect(text()).toContain("Slide to turn off bypass");
+  });
+
+  test("writes nothing when the dialog is dismissed, and puts the handle back", async () => {
+    const { onSave } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Turn on bypass mode?");
+    button("Cancel").click();
+    await settle();
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(handlePosition()).toBeLessThan(0.1);
+  });
+
+  test("holds the assumed state until the account agrees, then stops saying so", async () => {
+    const { reportNow } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Turn on bypass mode?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+
+    // Assumed: the spinner stands in for the badge, because this is what was
+    // asked for rather than what is known.
+    expect(document.querySelector("[aria-label='Turning bypass on']")).not.toBeNull();
+
+    reportNow(true);
+    await settle();
+
+    expect(document.querySelector("[aria-label='Turning bypass on']")).toBeNull();
+    expect(text()).toContain("The Starlink router is disabled");
+    expect(text()).not.toContain("Sent.");
+  });
+
+  test("reads bypass as off when the router answers, whatever the account carries", async () => {
+    mount({ reported: null, routerAnswering: true });
+    await waitForText("The Starlink router is running your network");
+    expect(text()).toContain("Slide to turn on bypass");
+  });
+
+  test("refuses to guess a direction when nothing can say where bypass stands", async () => {
+    mount({ reported: null, routerAnswering: false });
+    await waitForText("Couldn't tell whether the router is bypassed");
+    expect(handle().getAttribute("aria-disabled")).toBe("true");
+  });
+
+  test("names the way back when the account cannot be reached", async () => {
+    mount({ reported: null, routerAnswering: false, disabled: true });
+    await waitForText("Connect this device to the internet");
+  });
+});

--- a/src/components/settings/BypassSection.test.tsx
+++ b/src/components/settings/BypassSection.test.tsx
@@ -92,11 +92,10 @@ function slide() {
   grip.dispatchEvent(new PointerEvent("pointerup", { clientX: to, bubbles: true }));
 }
 
-/** Where the handle sits, as a share of the track. 0 is the left edge, 1 the right. */
-function handlePosition(): number {
-  const trackBox = track().getBoundingClientRect();
-  const handleBox = handle().getBoundingClientRect();
-  return (handleBox.left - trackBox.left) / (trackBox.width - handleBox.width);
+/** How far along the track the handle has been carried, 0 to 100. Where that
+ *  puts it on screen is the primitive's own business, and its own test. */
+function travelled(): string | null {
+  return handle().getAttribute("aria-valuenow");
 }
 
 describe("BypassSection", () => {
@@ -118,7 +117,7 @@ describe("BypassSection", () => {
     expect(onSave).toHaveBeenCalledWith(true);
   });
 
-  test("leaves the handle at the end it was dragged to once the write is away", async () => {
+  test("turns the control around once the write is away, so the way back starts where the handle is", async () => {
     mount({ reported: false });
     await waitForText("Slide to turn on bypass");
 
@@ -126,24 +125,15 @@ describe("BypassSection", () => {
     await waitForText("Turn on bypass mode?");
     button("Turn on").click();
     await waitForText("Sent.");
+    await settle();
 
-    // Sampled rather than measured once: the failure this guards against is the
-    // handle returning to the start and gliding back, which a single reading
-    // taken after the glide would not see.
-    const path: number[] = [];
-    for (let sample = 0; sample < 12; sample++) {
-      await settle(35);
-      path.push(handlePosition());
-    }
-
-    // Bypass now reads as on, so the control turns around and offers the way back
-    // from where the handle already is, rather than crossing the track twice.
-    expect(Math.min(...path)).toBeGreaterThan(0.5);
-    expect(path.at(-1)).toBeGreaterThan(0.9);
+    // Bypass now reads as on, so the track runs the other way and the spent
+    // travel is cleared. Together those leave the handle at the end it reached.
     expect(text()).toContain("Slide to turn off bypass");
+    expect(travelled()).toBe("0");
   });
 
-  test("writes nothing when the dialog is dismissed, and puts the handle back", async () => {
+  test("writes nothing when the dialog is dismissed, and gives the travel back", async () => {
     const { onSave } = mount({ reported: false });
     await waitForText("Slide to turn on bypass");
 
@@ -153,7 +143,8 @@ describe("BypassSection", () => {
     await settle();
 
     expect(onSave).not.toHaveBeenCalled();
-    expect(handlePosition()).toBeLessThan(0.1);
+    expect(travelled()).toBe("0");
+    expect(text()).toContain("Slide to turn on bypass");
   });
 
   test("holds the assumed state until the account agrees, then stops saying so", async () => {

--- a/src/components/settings/BypassSection.tsx
+++ b/src/components/settings/BypassSection.tsx
@@ -1,0 +1,233 @@
+// Whether the Starlink router runs the network at all.
+//
+// The state comes from the account first, never from `wifiConfig`: a bypassed
+// router serves no gRPC on the LAN, so the router is silent for the whole time
+// the answer would be `true`. That silence is itself an answer in the other
+// direction, which is the fallback here — a router answering locally is not
+// bypassed, whatever the account's telemetry does or does not carry.
+//
+// The account is also what makes the way back reachable. The write rides the
+// cloud gateway, which needs some internet rather than Starlink's in particular,
+// so a kit with a third-party router wired in can be un-bypassed from the very
+// machine that bypassed it. With nothing else serving internet that takes another
+// device on mobile data, which is why an unreachable account says so plainly
+// instead of only greying the control out.
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SlideToConfirm } from "@/components/ui/slide-to-confirm";
+import { SpinLoader } from "../loaders/SpinLoader";
+import { SettingRow } from "./settingsChrome";
+
+const BYPASS_TIP =
+  "Advanced feature that disables the Starlink router completely, so the dish serves a third-party router instead. The Starlink WiFi goes off and the client list, custom DNS and subnet stop working. Most users should leave this off.";
+
+/** How long the account is given to report a write before the row stops waiting
+ *  on it. Measured against hardware, the flip showed up around two minutes. */
+const SETTLE_TIMEOUT_MS = 4 * 60_000;
+const SETTLE_POLL_MS = 15_000;
+
+export function BypassSection({
+  /** What the account reports, or null when its telemetry carries no controller
+   *  row to read it from. */
+  reported,
+  /** The router is answering on the LAN, which only an un-bypassed router does. */
+  routerAnswering,
+  /** No account connected, so the write has nowhere to go. */
+  disabled,
+  onSave,
+  /** Re-asks the account, which is the only thing that can confirm a write. */
+  onReload,
+}: {
+  reported: boolean | null;
+  routerAnswering: boolean;
+  disabled: boolean;
+  onSave: (enabled: boolean) => Promise<void>;
+  onReload: () => void;
+}) {
+  // The value the open dialog is offering, captured when it opened. The account
+  // can catch up while the dialog sits there, and reading the state fresh on
+  // accept would send the opposite of the change the dialog named.
+  const [offered, setOffered] = useState<boolean | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  // What the last write asked for. The row shows this in preference to what the
+  // account says, because the account keeps reporting the old value for the
+  // minutes the router takes to go down or come back — a row that waited for it
+  // would spend that time insisting the change had not happened.
+  const [awaiting, setAwaiting] = useState<boolean | null>(null);
+
+  const bypassed = awaiting ?? reported ?? (routerAnswering ? false : null);
+  // Null is not a state to write from: without knowing where it stands, the
+  // control cannot say which way it would go.
+  const target = bypassed === null ? null : !bypassed;
+  // What the control depicts. While a dialog is open it depicts what that dialog
+  // offered, so nothing shifts underneath the question being asked.
+  const shown = offered ?? target;
+
+  // The account catching up arrives as a prop change, so the wait ends during
+  // render rather than from an effect chasing it.
+  // The note is cleared rather than replaced with a confirmation: once the state
+  // has settled, the badge and the caption both say it, and a third sentence
+  // saying it again is the only thing left to read.
+  if (awaiting !== null && reported === awaiting) {
+    setAwaiting(null);
+    setNote(null);
+  }
+
+  useEffect(() => {
+    if (awaiting === null) return;
+    const poll = setInterval(onReload, SETTLE_POLL_MS);
+    // Assumed until the account contradicts it, but not forever: past this the
+    // guess has outlived any lag it was covering, and the row goes back to
+    // reporting what is actually known.
+    const giveUp = setTimeout(() => {
+      setAwaiting(null);
+      setNote("Your account still reports the old state. Reopen this panel to check again.");
+    }, SETTLE_TIMEOUT_MS);
+    return () => {
+      clearInterval(poll);
+      clearTimeout(giveUp);
+    };
+  }, [awaiting, onReload]);
+
+  const caption = disabled
+    ? // A router answering locally settles it: bypass is off, and this row is
+      // behind the same account gate as the ones above it, nothing more. Only
+      // when the router is silent can bypass be the reason, and then the way
+      // back is what the caption has to name.
+      bypassed === false
+      ? "Connect your Starlink account to use this"
+      : "Connect this device to the internet and sign in your account to use"
+    : bypassed === null
+      ? "Couldn't tell whether the router is bypassed"
+      : bypassed
+        ? "The Starlink router is disabled; a third-party router runs the network"
+        : "The Starlink router is running your network";
+
+  const applyBypass = async (value: boolean) => {
+    // Batched with the flag below, so the slider never sees both go false and
+    // snap the handle back while the write is in flight.
+    setOffered(null);
+    setSaving(true);
+    setError(null);
+    setNote(null);
+    try {
+      await onSave(value);
+      // Deliberately "sent", not "applied": a write that takes effect can kill
+      // its own reply, and a reply that arrives cleanly is only ever ACCEPTED,
+      // which the router also returns for changes it goes on to discard. The
+      // account reporting the new value is the only thing that settles it, and
+      // `awaiting` is what waits for that.
+      setNote(
+        value
+          ? "Sent. The Starlink WiFi is going down; waiting for the account to confirm."
+          : "Sent. The router is coming back up; waiting for the account to confirm.",
+      );
+      setAwaiting(value);
+    } catch (saveError) {
+      setError((saveError as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <SettingRow
+        title='Bypass mode'
+        info={BYPASS_TIP}
+        infoSeverity='danger'
+        caption={caption}
+        note={
+          <>
+            {note && (
+              <span role='status' className='block'>
+                {note}
+              </span>
+            )}
+            {error && <span className='block text-destructive'>{error}</span>}
+          </>
+        }
+      >
+        {awaiting !== null ? (
+          <SpinLoader size={15} label={awaiting ? "Turning bypass on" : "Turning bypass off"} />
+        ) : (
+          bypassed !== null && (
+            <Badge tone={bypassed ? "critical" : "neutral"}>{bypassed ? "On" : "Off"}</Badge>
+          )
+        )}
+      </SettingRow>
+
+      <div className='flex flex-col gap-2.5 pb-2'>
+        <SlideToConfirm
+          label={shown ? "Slide to turn on bypass" : "Slide to turn off bypass"}
+          busyLabel={saving ? "Sending…" : "Confirm to continue"}
+          direction={shown ? "right" : "left"}
+          tone={shown ? "danger" : "default"}
+          disabled={disabled || target === null}
+          busy={offered !== null || saving}
+          onConfirm={() => setOffered(target)}
+        />
+        {target !== null && (
+          // A tinted box is the app's colour for "something is broken"; this is a
+          // standing description of what the control does. The icon carries the
+          // weight instead, which is what it is separately severable for.
+          <Callout tone='info' icon='warning' iconSeverity={target ? "danger" : "normal"}>
+            {target
+              ? "Bypass mode will completely disable the Starlink router and its WiFi. Only a third-party router wired to the dish stay online. You can turn it back off from here as long as this device is has access to the internet."
+              : "Bypass is on, so the Starlink router is disabled and a third-party router runs your network. Turning bypass off brings the Starlink router and its WiFi back."}
+          </Callout>
+        )}
+      </div>
+
+      <Dialog open={offered !== null} onOpenChange={(open) => !open && setOffered(null)}>
+        <DialogContent
+          showCloseButton={false}
+          className='glass-panel gap-3 sm:max-w-md'
+          overlayClassName='bg-black/30 backdrop-blur-[2px]'
+        >
+          <DialogHeader>
+            <DialogTitle className='text-[19px] leading-snug'>
+              {offered ? "Turn on bypass mode?" : "Turn off bypass mode?"}
+            </DialogTitle>
+            <DialogDescription className='text-[13.5px] leading-relaxed'>
+              {offered
+                ? "The Starlink router and its WiFi will switch off. Only devices behind a third-party router wired to the dish stay online. You can turn bypass back off from here as long as this device still has internet — if nothing else provides it, you will need another device on mobile data."
+                : "The Starlink router and its WiFi come back on. Devices connected through a third-party router may need to reconnect."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className='mt-2 gap-2'>
+            <Button
+              variant='outline'
+              className='cursor-pointer sm:min-w-28'
+              disabled={saving}
+              onClick={() => setOffered(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={offered ? "destructive" : "default"}
+              className='cursor-pointer sm:min-w-28'
+              disabled={saving}
+              onClick={() => offered !== null && void applyBypass(offered)}
+            >
+              {saving ? "Sending…" : offered ? "Turn on" : "Turn off"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/settings/RouterSettingsTab.tsx
+++ b/src/components/settings/RouterSettingsTab.tsx
@@ -11,6 +11,8 @@ import { CollapsibleSection, DangerAction, SectionLabel, SettingRow } from "./se
 import { RouterAddressRow } from "./RouterAddressRow";
 import { CustomDnsSection } from "./CustomDnsSection";
 import { SubnetSection } from "./SubnetSection";
+import { BypassSection } from "./BypassSection";
+import type { CloudAccount } from "../../lib/starlinkCloud";
 import { routerAddressForSubnet } from "@core/routerConfigUpdate";
 import { routerAddressHost } from "../../lib/routerAddressHost";
 import { applyRouterConfigUpdate } from "../../lib/routerConfigUpdate";
@@ -35,6 +37,16 @@ function ssidsWithBands(wifiConfig: WifiNetworkConfigJson | null): [string, stri
   return [...byName.entries()];
 }
 
+/** The controller's bypass state, or null when the account has not said. A mesh
+ *  node reports as a router too and is never the bypassed one, so the controller
+ *  is picked the way the cloud handler picks its write target: zero hops. */
+function controllerBypassed(account: CloudAccount | null): boolean | null {
+  for (const device of Object.values(account?.deviceTelemetry ?? {})) {
+    if (device.kind === "router" && device.hops === 0) return device.isBypassed ?? null;
+  }
+  return null;
+}
+
 export function RouterSettingsTab({
   wifiConfig,
   routerReachable,
@@ -54,7 +66,11 @@ export function RouterSettingsTab({
   const [addresses, setAddresses] = useRouterAddressState();
   // The DNS and subnet writes have no local path, so the controls are disabled up
   // front rather than failing at the moment Save is pressed.
-  const accountConnected = useCloudAccount(true).status === "ready";
+  const account = useCloudAccount(true);
+  const accountConnected = account.status === "ready";
+  // Read from the account rather than the router: a bypassed router answers
+  // nothing on the LAN, so `wifiConfig` is silent exactly when the answer is yes.
+  const bypassed = controllerBypassed(account.data);
   // The account is asked only when the router itself cannot answer, which costs a
   // round trip to Starlink for something the LAN gives away.
   const lanSubnet = wifiConfig?.networks?.[0]?.ipv4 ?? null;
@@ -174,6 +190,16 @@ export function RouterSettingsTab({
             );
             if (updatedAddresses?.ok) setAddresses(updatedAddresses.addresses);
             rereadCloudSubnet();
+          }}
+        />
+        <SectionLabel>Bypass</SectionLabel>
+        <BypassSection
+          reported={bypassed}
+          routerAnswering={answering}
+          disabled={!accountConnected}
+          onReload={account.reload}
+          onSave={async (enabled) => {
+            await applyRouterConfigUpdate({ kind: "bypass", enabled });
           }}
         />
       </CollapsibleSection>

--- a/src/components/ui/action-button.ts
+++ b/src/components/ui/action-button.ts
@@ -3,7 +3,7 @@
 // surface; danger is the critical red. The fill utilities are kept per-variant
 // rather than layered so no two background rules ever race.
 const base =
-  "cursor-pointer rounded-md border-0 px-4 py-2 font-sans text-[13px] font-semibold transition-opacity duration-[120ms] enabled:hover:opacity-85 disabled:cursor-default disabled:opacity-45";
+  "cursor-pointer rounded-md border-0 px-4 py-2 font-sans text-[13px] font-semibold transition-opacity duration-[120ms] enabled:hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-45";
 
 /** A button that reads as part of a sentence: for naming a control that lives on
  *  another surface, where a solid button would break the line. */

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -30,19 +30,22 @@ const callout = cva(
   },
 );
 
-const ICON: Record<NonNullable<VariantProps<typeof callout>["tone"]>, string> = {
-  info: "ⓘ",
-  error: "⚠",
-};
+const GLYPH = {
+  note: "ⓘ",
+  warning: "⚠",
+} as const;
 
 interface CalloutProps extends VariantProps<typeof callout> {
   children: ReactNode;
   /** How hard the icon presses, independent of the box it sits in. */
   iconSeverity?: Severity;
+  /** The glyph, for a warning that is not a failure: the triangle without the
+   *  red box behind it. Defaults to the one the tone implies. */
+  icon?: keyof typeof GLYPH;
   className?: string;
 }
 
-export function Callout({ children, tone, iconSeverity, className }: CalloutProps) {
+export function Callout({ children, tone, iconSeverity, icon, className }: CalloutProps) {
   const resolvedTone = tone ?? "info";
   // A broken thing is never quieter than its box, so the error tone settles this.
   const severity = resolvedTone === "error" ? "danger" : (iconSeverity ?? "normal");
@@ -54,7 +57,9 @@ export function Callout({ children, tone, iconSeverity, className }: CalloutProp
       role={resolvedTone === "error" ? "alert" : undefined}
       className={cn(callout({ tone }), className)}
     >
-      <SeverityIcon severity={severity}>{ICON[resolvedTone]}</SeverityIcon>
+      <SeverityIcon severity={severity}>
+        {GLYPH[icon ?? (resolvedTone === "error" ? "warning" : "note")]}
+      </SeverityIcon>
       <span>{children}</span>
     </div>
   );

--- a/src/components/ui/slide-to-confirm.test.tsx
+++ b/src/components/ui/slide-to-confirm.test.tsx
@@ -142,6 +142,25 @@ describe("SlideToConfirm", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  // Measured at rest on first paint, which no transition applies to. It is the
+  // one place the resting geometry is pinned, so the callers can settle for
+  // knowing which way their track runs.
+  test("parks the handle at the end its travel starts from", async () => {
+    await mount({ direction: "left" });
+    const trackBox = track().getBoundingClientRect();
+    const handleBox = handle().getBoundingClientRect();
+    const position = (handleBox.left - trackBox.left) / (trackBox.width - handleBox.width);
+    expect(position).toBeGreaterThan(0.9);
+  });
+
+  test("parks the handle at the start when the travel runs rightward", async () => {
+    await mount({ direction: "right" });
+    const trackBox = track().getBoundingClientRect();
+    const handleBox = handle().getBoundingClientRect();
+    const position = (handleBox.left - trackBox.left) / (trackBox.width - handleBox.width);
+    expect(position).toBeLessThan(0.1);
+  });
+
   test("ignores a full drag while disabled", async () => {
     const onConfirm = await mount({ disabled: true });
     drag(1);

--- a/src/components/ui/slide-to-confirm.test.tsx
+++ b/src/components/ui/slide-to-confirm.test.tsx
@@ -1,0 +1,171 @@
+// This control guards a write that takes the network down, so what matters is
+// that a partial gesture does nothing: "fired at 90%" and "fired on a click" are
+// the failures worth holding, not the styling.
+
+import { expect, describe, test, afterEach, vi } from "vitest";
+import { render, cleanup } from "vitest-browser-react";
+import { SlideToConfirm } from "./slide-to-confirm";
+
+afterEach(cleanup);
+
+const TRACK_INSET_PX = 3;
+
+function track(): HTMLElement {
+  return document.querySelector("[data-slide-track]") as HTMLElement;
+}
+
+function handle(): HTMLElement {
+  return document.querySelector("[data-slide-handle]") as HTMLElement;
+}
+
+/** Rendering is not synchronous, so every case waits for the handle to exist.
+ *  Polls rather than sleeps, so a passing case costs a few ms. */
+async function mount(props: Partial<React.ComponentProps<typeof SlideToConfirm>> = {}) {
+  const onConfirm = vi.fn();
+  render(
+    <div style={{ width: 420 }}>
+      <SlideToConfirm
+        label='Slide to turn on bypass'
+        busyLabel='Sending…'
+        onConfirm={onConfirm}
+        {...props}
+      />
+    </div>,
+  );
+  const deadline = Date.now() + 2000;
+  while (!handle()) {
+    if (Date.now() > deadline) throw new Error("the slider never rendered");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return onConfirm;
+}
+
+let dragOrigin: number | null = null;
+afterEach(() => {
+  dragOrigin = null;
+});
+
+/** Drags `fraction` of the distance the handle can travel, still holding it. */
+function hold(fraction: number, direction: "right" | "left" = "right") {
+  const grip = handle();
+  const start = grip.getBoundingClientRect();
+  const travel = track().clientWidth - start.width - TRACK_INSET_PX * 2;
+  const origin = dragOrigin ?? start.left + start.width / 2;
+  const to = origin + travel * fraction * (direction === "right" ? 1 : -1);
+
+  if (dragOrigin === null) {
+    dragOrigin = origin;
+    grip.setPointerCapture = () => {};
+    grip.releasePointerCapture = () => {};
+    grip.dispatchEvent(new PointerEvent("pointerdown", { clientX: origin, bubbles: true }));
+  }
+  grip.dispatchEvent(new PointerEvent("pointermove", { clientX: to, bubbles: true }));
+  return to;
+}
+
+function release(at: number) {
+  handle().dispatchEvent(new PointerEvent("pointerup", { clientX: at, bubbles: true }));
+  dragOrigin = null;
+}
+
+/** A whole gesture: press, travel `fraction` of the track, let go. */
+function drag(fraction: number, direction: "right" | "left" = "right") {
+  release(hold(fraction, direction));
+}
+
+/** Each press waits for its render, the way separate key events arrive. */
+async function press(key: string) {
+  handle().dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("SlideToConfirm", () => {
+  test("does nothing on a click, which is the gesture it exists to refuse", async () => {
+    const onConfirm = await mount();
+    handle().click();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("does not let a bare press inherit the distance the last drag covered", async () => {
+    const onConfirm = await mount();
+    drag(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const grip = handle();
+    grip.dispatchEvent(new PointerEvent("pointerdown", { clientX: 0, bubbles: true }));
+    grip.dispatchEvent(new PointerEvent("pointerup", { clientX: 0, bubbles: true }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire when the drag stops just short of the end", async () => {
+    const onConfirm = await mount();
+    drag(0.95);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("fires once the handle has crossed the whole track and been let go", async () => {
+    const onConfirm = await mount();
+    drag(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire while the handle is still held at the end", async () => {
+    const onConfirm = await mount();
+    hold(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("fires on the release, not on arriving at the end", async () => {
+    const onConfirm = await mount();
+    const at = hold(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+    release(at);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("lets an overshoot travel back and be released harmlessly", async () => {
+    const onConfirm = await mount();
+    hold(1);
+    const at = hold(0.4);
+    release(at);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("snaps back after an incomplete drag, so the next attempt starts over", async () => {
+    await mount();
+    drag(0.6);
+    expect(handle().getAttribute("aria-valuenow")).toBe("0");
+  });
+
+  test("runs leftward when the change goes the other way", async () => {
+    const onConfirm = await mount({ direction: "left" });
+    drag(1, "left");
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores a full drag while disabled", async () => {
+    const onConfirm = await mount({ disabled: true });
+    drag(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("ignores a full drag while a write is already away", async () => {
+    const onConfirm = await mount({ busy: true });
+    drag(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("keeps the cursor answering when disabled, rather than going inert", async () => {
+    await mount({ disabled: true });
+    expect(getComputedStyle(track()).cursor).toBe("not-allowed");
+    expect(getComputedStyle(track()).pointerEvents).not.toBe("none");
+  });
+
+  test("takes five arrow presses, so the keyboard pays the same cost as the drag", async () => {
+    const onConfirm = await mount();
+    handle().focus();
+    for (let attempt = 0; attempt < 4; attempt++) await press("ArrowRight");
+    expect(onConfirm).not.toHaveBeenCalled();
+    await press("ArrowRight");
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/slide-to-confirm.tsx
+++ b/src/components/ui/slide-to-confirm.tsx
@@ -1,0 +1,209 @@
+// A commitment that cannot be made by accident: the handle has to cross the whole
+// track before anything fires, and releasing short of the end is a no-op, so
+// backing out needs no second control.
+//
+// The travel runs toward the state being entered — right to switch on, left to
+// switch back off — so the gesture itself says which way the change goes.
+
+import { useEffect, useRef, useState } from "react";
+import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** The handle is round, so this is its diameter: track height less both insets. */
+const HANDLE_PX = 46;
+const TRACK_INSET_PX = 3;
+/** One arrow press; the track takes five of them, so the keyboard pays the same
+ *  deliberate cost as the drag. */
+const KEY_STEP = 0.2;
+
+export function SlideToConfirm({
+  label,
+  busyLabel,
+  direction = "right",
+  tone = "default",
+  disabled = false,
+  busy = false,
+  onConfirm,
+}: {
+  label: string;
+  /** Shown once the action is away, while the caller reports it busy. */
+  busyLabel: string;
+  direction?: "right" | "left";
+  tone?: "default" | "danger";
+  disabled?: boolean;
+  busy?: boolean;
+  onConfirm: () => void;
+}) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragOrigin = useRef<number | null>(null);
+  // Read by the release, which runs before the state it would read has committed.
+  const travelled = useRef(0);
+  const [progress, setProgress] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  const locked = disabled || busy;
+  const complete = progress >= 1;
+
+  // The handle is parked back at the start once the caller stops being busy —
+  // whether the write succeeded or threw, the gesture is spent either way.
+  const [wasBusy, setWasBusy] = useState(busy);
+  if (wasBusy !== busy) {
+    setWasBusy(busy);
+    if (!busy) setProgress(0);
+  }
+
+  useEffect(() => {
+    if (!busy) travelled.current = 0;
+  }, [busy]);
+
+  const travelPx = () => {
+    const track = trackRef.current;
+    if (!track) return 1;
+    return Math.max(1, track.clientWidth - HANDLE_PX - TRACK_INSET_PX * 2);
+  };
+
+  const moveTo = (next: number) => {
+    travelled.current = Math.min(1, Math.max(0, next));
+    setProgress(travelled.current);
+  };
+
+  const commit = () => {
+    dragOrigin.current = null;
+    setDragging(false);
+    moveTo(1);
+    onConfirm();
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (locked) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragOrigin.current = event.clientX;
+    // Every gesture starts from nothing, so a press with no travel cannot inherit
+    // the distance the last one covered and fire on release.
+    travelled.current = 0;
+    setDragging(true);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragOrigin.current === null) return;
+    const travelled =
+      direction === "right"
+        ? event.clientX - dragOrigin.current
+        : dragOrigin.current - event.clientX;
+    moveTo(travelled / travelPx());
+  };
+
+  // Reaching the end arms the action; letting go there is what fires it. A hand
+  // that overshoots can travel back and release without having done anything.
+  const endDrag = () => {
+    if (locked || dragOrigin.current === null) return;
+    dragOrigin.current = null;
+    setDragging(false);
+    if (travelled.current >= 1) commit();
+    else moveTo(0);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (locked) return;
+    const forward = direction === "right" ? "ArrowRight" : "ArrowLeft";
+    const back = direction === "right" ? "ArrowLeft" : "ArrowRight";
+    // A press is its own complete gesture, so the one that lands on the end
+    // fires there — it is the keyboard's release.
+    if (event.key === forward) {
+      if (travelled.current + KEY_STEP >= 1) commit();
+      else moveTo(travelled.current + KEY_STEP);
+    } else if (event.key === back) moveTo(travelled.current - KEY_STEP);
+    else if (event.key === "Home" || event.key === "Escape") moveTo(0);
+    else return;
+    event.preventDefault();
+  };
+
+  const danger = tone === "danger";
+  // Snap back is animated; following a finger is not, or the handle lags it.
+  const glide = dragging ? "" : "transition-[left,width] duration-200 ease-out";
+  const handleOffset = direction === "right" ? progress : 1 - progress;
+
+  return (
+    <div
+      ref={trackRef}
+      data-slide-track
+      className={cn(
+        "relative h-[52px] w-full overflow-hidden rounded-full border border-hairline select-none",
+        "bg-[color-mix(in_srgb,var(--ink)_4%,var(--surface))]",
+        locked && "cursor-not-allowed opacity-45",
+      )}
+    >
+      <div
+        data-slide-fill
+        className={cn(
+          "absolute inset-y-0",
+          direction === "right" ? "left-0" : "right-0",
+          glide,
+          danger
+            ? "bg-[color-mix(in_srgb,var(--status-critical)_22%,transparent)]"
+            : "bg-[color-mix(in_srgb,var(--ink)_12%,transparent)]",
+        )}
+        style={{ width: `${progress * 100}%` }}
+      />
+
+      <span
+        className='pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-[13px] font-semibold text-ink-secondary'
+        style={{ opacity: complete || busy ? 1 : 1 - progress * 0.85 }}
+      >
+        {busy ? busyLabel : label}
+        {!busy && !complete && (
+          <span className='flex items-center gap-[3px]' aria-hidden='true'>
+            {[0, 1, 2].map((index) => (
+              <span
+                key={index}
+                className={cn(
+                  "h-[5px] w-[5px] rounded-full bg-current opacity-30",
+                  "motion-safe:animate-[slide-hint_1.4s_ease-in-out_infinite]",
+                )}
+                style={{
+                  animationDelay: `${(direction === "right" ? index : 2 - index) * 160}ms`,
+                }}
+              />
+            ))}
+          </span>
+        )}
+      </span>
+
+      <div
+        data-slide-handle
+        role='slider'
+        tabIndex={locked ? -1 : 0}
+        aria-label={label}
+        aria-disabled={locked || undefined}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(progress * 100)}
+        aria-valuetext={`${Math.round(progress * 100)}% of the way to ${label.toLowerCase()}`}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "absolute inset-y-[3px] flex items-center justify-center rounded-full",
+          "touch-none outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+          locked ? "cursor-not-allowed" : dragging ? "cursor-grabbing" : "cursor-grab",
+          danger ? "bg-[var(--status-critical)] text-white" : "bg-ink text-surface",
+          glide,
+        )}
+        style={{
+          width: HANDLE_PX,
+          left: `calc(${TRACK_INSET_PX}px + ${handleOffset} * (100% - ${HANDLE_PX + TRACK_INSET_PX * 2}px))`,
+        }}
+      >
+        {complete ? (
+          <CheckIcon className='size-[18px]' />
+        ) : direction === "right" ? (
+          <ArrowRightIcon className='size-[18px]' />
+        ) : (
+          <ArrowLeftIcon className='size-[18px]' />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -216,6 +216,20 @@ body {
   }
 }
 
+/* The travel dots on a slide-to-confirm track: a drag is the only affordance
+   that control has, so something has to say it is draggable before it is
+   touched. Staggered per dot, and reversed when the track runs leftward. */
+
+@keyframes slide-hint {
+  0%,
+  100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 0.85;
+  }
+}
+
 /* ---------- thin scrollbar (scrollbar pseudo-elements aren't Tailwind utilities) ---------- */
 
 .thin-scroll {


### PR DESCRIPTION

Adds a bypass mode control to Settings → Router → Advanced.

Bypass mode disables the Starlink router so a third-party router can run the
network. Turning it on takes the Starlink WiFi down; turning it off brings the
router and its WiFi back.

## How it works

`bypass_mode` (31) and `apply_bypass_mode` (1055) are top-level bools on
`WifiConfig`, so the write names one field and needs no read beforehand.

It rides the cloud gateway because there is no LAN path: the router answers
`PERMISSION_DENIED` to a local `wifi_set_config`. That is also what makes the
feature work at all — a bypassed router is invisible on the LAN, so the way back
has to come from the account.

## Design notes

- **Bypass state comes from account telemetry.** A bypassed router serves no
  gRPC, so `wifiConfig` is silent for exactly the window the answer would be
  `true`. A router answering on the LAN settles the other direction.
- **The control stays available while the router is unreachable**, which in
  bypass it always is.
- **The dialog captures its value when it opens.** The account can catch up while
  it sits there, and a fresh read on accept would send the opposite of the change
  the dialog named.
- **The row shows the requested state immediately, with a spinner.** The account
  lags a write by about two minutes; the guess reverts if the account still
  disagrees after four. `ACCEPTED` from this router does not mean applied, so the
  copy says "sent".
- `starlinkCloudHandler.ts` treats a dead transport as success for bypass as well
  as subnet: both reconfigure the LAN carrying the request, so a write that takes
  effect kills its own reply.