### PR TITLE
Feat/control router clients through the Starlink cloud account

### DIFF
--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -175,16 +175,19 @@ describe("createCloudHandler pauseClient", () => {
     let authCalls = 0;
     let deviceCalls = 0;
     const responseFrame = new Uint8Array([0, 0, 0, 0, 0]);
-    const doFetch = gateway(async () => {
-      deviceCalls++;
-      if (deviceCalls === 1) return res(401);
-      return {
-        status: 200,
-        ok: true,
-        headers: { get: () => null },
-        arrayBuffer: async () => responseFrame.buffer,
-      } as unknown as Response;
-    }, () => authCalls++);
+    const doFetch = gateway(
+      async () => {
+        deviceCalls++;
+        if (deviceCalls === 1) return res(401);
+        return {
+          status: 200,
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => responseFrame.buffer,
+        } as unknown as Response;
+      },
+      () => authCalls++,
+    );
     const handler = createCloudHandler({
       fetch: doFetch,
       readCookie: () => SESSION,

--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -438,30 +438,33 @@ describe("createCloudHandler updateDishConfig", () => {
   });
 });
 
-describe("updateRouterConfig", () => {
-  const TARGET = "Router-010000000000000001B31340";
-  const SUBNET = { kind: "subnet" as const, subnet: "192.168.2.1/24", password: "hunter2hunter2" };
+const TARGET = "Router-010000000000000001B31340";
 
-  /** Answers everything the controller lookup needs, then defers the device
-   *  gateway to `onDevice`. */
-  function gateway(onDevice: (init?: RequestInit) => Promise<Response>) {
-    return (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === AUTH_URL) return res(200);
-      if (url.includes("service-lines"))
-        return res(200, {
-          content: { results: [{ serviceLineNumber: "SL-1", accountReferenceId: "ACC-1" }] },
-        });
-      if (url.includes("/device-data/cache/v1/telemetry"))
-        return res(200, {
-          data: {
-            columnNamesByDeviceType: { r: ["DeviceId", "WifiHopsFromController"] },
-            values: [["r", TARGET, 0]],
-          },
-        });
-      return onDevice(init);
-    }) as typeof fetch;
-  }
+/** Answers everything the controller lookup needs, then defers the device
+ *  gateway to `onDevice`. */
+function gateway(onDevice: (init?: RequestInit) => Promise<Response>) {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === AUTH_URL) return res(200);
+    if (url.includes("service-lines"))
+      return res(200, {
+        content: { results: [{ serviceLineNumber: "SL-1", accountReferenceId: "ACC-1" }] },
+      });
+    if (url.includes("/device-data/cache/v1/telemetry"))
+      return res(200, {
+        data: {
+          // The legend covers the whole row, kind column included — so DeviceId
+          // is the second entry, as it is on the wire.
+          columnNamesByDeviceType: { r: ["DeviceType", "DeviceId", "WifiHopsFromController"] },
+          values: [["r", TARGET, 0]],
+        },
+      });
+    return onDevice(init);
+  }) as typeof fetch;
+}
+
+describe("updateRouterConfig", () => {
+  const SUBNET = { kind: "subnet" as const, subnet: "192.168.2.1/24", password: "hunter2hunter2" };
 
   const stall = (init?: RequestInit) =>
     new Promise<Response>((_resolve, reject) => {
@@ -578,5 +581,78 @@ describe("updateRouterConfig", () => {
       handler.updateRouterConfig({ ...SUBNET, password: "short" }),
     ).resolves.toMatchObject({ status: 400 });
     expect(prepared).toBe(false);
+  });
+});
+
+// The roster and the config read the same way the writes are sent: named by the
+// account, carried over the gateway. That is what makes them answer for a router
+// this machine cannot reach — a kit in bypass, or a viewer somewhere else.
+describe("router reads over the gateway", () => {
+  /** An empty grpc-web frame — enough for a reader that only needs its bytes. */
+  const emptyFrame = () =>
+    ({
+      status: 200,
+      ok: true,
+      headers: { get: () => null },
+      arrayBuffer: async () => new Uint8Array([0, 0, 0, 0, 0]).buffer,
+    }) as unknown as Response;
+
+  it("given: a roster read, should: ask the account's controller and serve what it reports", async () => {
+    const asked: string[] = [];
+    const handler = createCloudHandler({
+      fetch: gateway(async () => emptyFrame()),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      readRouterClients: async (targetId, callGateway) => {
+        asked.push(targetId);
+        await callGateway(new Uint8Array([1]));
+        return [{ clientId: 7, macAddress: "aa:bb:cc:00:00:00" }];
+      },
+    });
+
+    await expect(handler.handle("/cloud/router-clients")).resolves.toEqual({
+      status: 200,
+      body: { clients: [{ clientId: 7, macAddress: "aa:bb:cc:00:00:00" }] },
+    });
+    expect(asked).toEqual([TARGET]);
+  });
+
+  it("given: a config read, should: serve the block the router reports", async () => {
+    const handler = createCloudHandler({
+      fetch: gateway(async () => res(200)),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      readRouterConfig: async () => ({ countryCode: "US" }),
+    });
+
+    await expect(handler.handle("/cloud/router-config")).resolves.toEqual({
+      status: 200,
+      body: { wifiConfig: { countryCode: "US" } },
+    });
+  });
+
+  it("given: a host that binds no reader, should: say so rather than answer emptily", async () => {
+    const handler = createCloudHandler({
+      fetch: gateway(async () => res(200)),
+      readCookie: () => SESSION,
+    });
+
+    await expect(handler.handle("/cloud/router-clients")).resolves.toMatchObject({ status: 503 });
+    await expect(handler.handle("/cloud/router-config")).resolves.toMatchObject({ status: 503 });
+  });
+
+  it("given: no session, should: prompt a reconnect without reading anything", async () => {
+    let read = false;
+    const handler = createCloudHandler({
+      fetch: gateway(async () => res(200)),
+      readCookie: () => null,
+      readRouterClients: async () => {
+        read = true;
+        return [];
+      },
+    });
+
+    await expect(handler.handle("/cloud/router-clients")).resolves.toMatchObject({ status: 428 });
+    expect(read).toBe(false);
   });
 });

--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -135,24 +135,23 @@ describe("createCloudHandler pauseClient", () => {
     const responseMessage = new Uint8Array([10, 0]);
     const responseFrame = new Uint8Array([0, 0, 0, 0, responseMessage.length, ...responseMessage]);
     const captured: { url: string; init?: RequestInit } = { url: "" };
-    const doFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === AUTH_URL) return res(200);
-      captured.url = url;
-      captured.init = init;
-      return {
-        status: 200,
-        ok: true,
-        headers: { get: () => null },
-        arrayBuffer: async () => responseFrame.buffer,
-      } as unknown as Response;
-    }) as typeof fetch;
     const handler = createCloudHandler({
-      fetch: doFetch,
+      fetch: gateway(async (init, url) => {
+        captured.url = url ?? "";
+        captured.init = init;
+        return {
+          status: 200,
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => responseFrame.buffer,
+        } as unknown as Response;
+      }),
       readCookie: () => SESSION,
       retryDelayMs: 0,
-      prepareDeviceUpdate: async (update) => {
+      prepareDeviceUpdate: async (update, targetId) => {
         expect(update).toEqual({ kind: "pause", clientId: 7, paused: true });
+        // Named by the account, not by anything read off the local network.
+        expect(targetId).toBe(TARGET);
         return request;
       },
     });
@@ -176,11 +175,7 @@ describe("createCloudHandler pauseClient", () => {
     let authCalls = 0;
     let deviceCalls = 0;
     const responseFrame = new Uint8Array([0, 0, 0, 0, 0]);
-    const doFetch = (async (input: RequestInfo | URL) => {
-      if (String(input) === AUTH_URL) {
-        authCalls++;
-        return res(200);
-      }
+    const doFetch = gateway(async () => {
       deviceCalls++;
       if (deviceCalls === 1) return res(401);
       return {
@@ -189,7 +184,7 @@ describe("createCloudHandler pauseClient", () => {
         headers: { get: () => null },
         arrayBuffer: async () => responseFrame.buffer,
       } as unknown as Response;
-    }) as typeof fetch;
+    }, () => authCalls++);
     const handler = createCloudHandler({
       fetch: doFetch,
       readCookie: () => SESSION,
@@ -273,8 +268,7 @@ describe("createCloudHandler pauseClient", () => {
     const responseFrame = new Uint8Array([0, 0, 0, 0, 0]);
     let releaseFirstWrite: (() => void) | undefined;
     let deviceCalls = 0;
-    const doFetch = (async (input: RequestInfo | URL) => {
-      if (String(input) === AUTH_URL) return res(200);
+    const doFetch = gateway(async () => {
       deviceCalls++;
       if (deviceCalls === 1) {
         await new Promise<void>((resolve) => {
@@ -287,7 +281,7 @@ describe("createCloudHandler pauseClient", () => {
         headers: { get: () => null },
         arrayBuffer: async () => responseFrame.buffer,
       } as unknown as Response;
-    }) as typeof fetch;
+    });
     const prepared: number[] = [];
     const handler = createCloudHandler({
       fetch: doFetch,
@@ -441,11 +435,18 @@ describe("createCloudHandler updateDishConfig", () => {
 const TARGET = "Router-010000000000000001B31340";
 
 /** Answers everything the controller lookup needs, then defers the device
- *  gateway to `onDevice`. */
-function gateway(onDevice: (init?: RequestInit) => Promise<Response>) {
+ *  gateway to `onDevice`. `onAuth` counts token refreshes for the tests that
+ *  care how many there were. */
+function gateway(
+  onDevice: (init?: RequestInit, url?: string) => Promise<Response>,
+  onAuth?: () => void,
+) {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url === AUTH_URL) return res(200);
+    if (url === AUTH_URL) {
+      onAuth?.();
+      return res(200);
+    }
     if (url.includes("service-lines"))
       return res(200, {
         content: { results: [{ serviceLineNumber: "SL-1", accountReferenceId: "ACC-1" }] },
@@ -459,7 +460,7 @@ function gateway(onDevice: (init?: RequestInit) => Promise<Response>) {
           values: [["r", TARGET, 0]],
         },
       });
-    return onDevice(init);
+    return onDevice(init, url);
   }) as typeof fetch;
 }
 

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -22,6 +22,16 @@ const DEVICE_HANDLE = `${API}/SpaceX.API.Device.Device/Handle`;
 const REFRESH_TTL_MS = 60_000; // the Access.V1 token is short-lived; refresh at most this often
 const IDS_TTL_MS = 5 * 60_000; // account/service-line numbers change ~never; cache across routes
 
+/** The account has not named a router this write could target. Nothing is wrong
+ *  with the session or the connection: the telemetry feed is momentarily empty,
+ *  and it fills in again on its own — so this must not read as a fault. */
+export class ControllerUnknownError extends Error {
+  constructor() {
+    super("Starlink has not reported a router on this account yet");
+    this.name = "ControllerUnknownError";
+  }
+}
+
 /** The account session is gone or expired — the UI must prompt a reconnect, NOT
  *  show a generic "check your internet". Distinct from a real upstream fault. */
 export class SessionExpiredError extends Error {
@@ -101,6 +111,16 @@ export interface CloudHandlerOptions {
 /** The durable half of the session — without it a token refresh can't happen, so
  *  a session missing it is definitely not usable. */
 const SSO_COOKIE_RE = /Starlink\.Com\.Sso=/;
+
+/** Answered wherever a router has to be named, so every surface says the same
+ *  waitable thing rather than reporting an outage. */
+const NO_CONTROLLER: CloudResult = {
+  status: 503,
+  body: {
+    error: "router_not_reported",
+    message: "Starlink hasn't reported your router yet — try again in a minute.",
+  },
+};
 
 const NOT_CONNECTED: CloudResult = {
   status: 428,
@@ -369,11 +389,11 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     const routers = Object.entries(deviceTelemetryFrom(telemetry)).filter(
       ([, device]) => device.kind === "router",
     );
-    if (routers.length === 0) throw new Error("no Starlink router on this account");
+    if (routers.length === 0) throw new ControllerUnknownError();
     const controller =
       routers.find(([, device]) => device.hops === 0) ??
       (routers.length === 1 ? routers[0] : undefined);
-    if (!controller) throw new Error("could not tell which router is the controller");
+    if (!controller) throw new ControllerUnknownError();
     cachedControllerId = controller[0];
     cachedControllerIdAt = Date.now();
     return cachedControllerId;
@@ -462,6 +482,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     } catch (error) {
       // A dead session is a reconnect prompt (428), not a network fault (502).
       if (error instanceof SessionExpiredError) return NOT_CONNECTED;
+      if (error instanceof ControllerUnknownError) return NO_CONTROLLER;
       return { status: 502, body: { error: "upstream_failed", message: (error as Error).message } };
     }
   }
@@ -525,6 +546,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       return { status: 200, body: { ok: true } };
     } catch (error) {
       if (error instanceof SessionExpiredError) return NOT_CONNECTED;
+      if (error instanceof ControllerUnknownError) return NO_CONTROLLER;
       if (error instanceof DOMException && error.name === "TimeoutError") {
         return {
           status: 504,
@@ -683,6 +705,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       return { status: 200, body: { ok: true } };
     } catch (error) {
       if (error instanceof SessionExpiredError) return NOT_CONNECTED;
+      if (error instanceof ControllerUnknownError) return NO_CONTROLLER;
       // A subnet change and a bypass switch both reconfigure the LAN carrying
       // them, so a write that takes effect kills its own reply. How that surfaces
       // is the host's business: a deadline where the request is left hanging, a

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -51,9 +51,16 @@ export interface CloudHandlerOptions {
   retryDelayMs?: number;
   /** Maximum time for each remote router mutation attempt. */
   deviceCallTimeoutMs?: number;
-  /** Trusted host callback: reads the local router and encodes exactly one
-   *  client update. Renderer-provided protobuf is never accepted. */
-  prepareDeviceUpdate?: (update: RouterClientUpdate) => Promise<Uint8Array>;
+  /** Trusted host callback: reads what the write must preserve — through the same
+   *  gateway, against the target this handler resolved from the account — and
+   *  encodes exactly one client update. Renderer-provided protobuf is never
+   *  accepted. Touching no LAN is what lets a bypassed router, invisible on the
+   *  local network by definition, still have its devices paused and renamed. */
+  prepareDeviceUpdate?: (
+    update: RouterClientUpdate,
+    targetId: string,
+    callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+  ) => Promise<Uint8Array>;
   /** Trusted host callback: reads the local dish's identity and encodes exactly
    *  one config change. Renderer-provided protobuf is never accepted. */
   prepareDishConfigUpdate?: (changes: DishConfigJson) => Promise<Uint8Array>;
@@ -262,20 +269,27 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     }
   }
 
-  async function apiGet(path: string, cookie: string): Promise<unknown> {
+  async function apiGet(path: string, cookie: string, abortSignal?: AbortSignal): Promise<unknown> {
     const response = await doFetch(`${API}${path}`, {
       headers: { cookie, accept: "application/json" },
+      signal: abortSignal,
     });
     if (response.status === 401 || response.status === 403) throw new SessionExpiredError();
     if (!response.ok) throw new Error(`GET ${path} → HTTP ${response.status}`);
     return response.json();
   }
 
-  async function apiPost(path: string, cookie: string, body: unknown): Promise<unknown> {
+  async function apiPost(
+    path: string,
+    cookie: string,
+    body: unknown,
+    abortSignal?: AbortSignal,
+  ): Promise<unknown> {
     const response = await doFetch(`${API}${path}`, {
       method: "POST",
       headers: { cookie, accept: "application/json", "content-type": "application/json" },
       body: JSON.stringify(body),
+      signal: abortSignal,
     });
     if (response.status === 401 || response.status === 403) throw new SessionExpiredError();
     if (!response.ok) throw new Error(`POST ${path} → HTTP ${response.status}`);
@@ -312,11 +326,15 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
 
   /** Resolve the account number + primary service line the UI hangs everything
    *  off. Cached briefly so /cloud/account and /cloud/usage don't each re-list. */
-  async function resolveIds(cookie: string): Promise<{ acc: string; sl: string }> {
+  async function resolveIds(
+    cookie: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ acc: string; sl: string }> {
     if (cachedIds && Date.now() - cachedIdsAt < IDS_TTL_MS) return cachedIds;
     const list = (await apiGet(
       "/webagg/v2/accounts/service-lines?limit=100&page=0&isConverting=false&serviceAddressId=&onlyActive=false&searchString=&onlyNoUts=false",
       cookie,
+      abortSignal,
     )) as { content?: { results?: ServiceLineResult[] } };
     const first = list.content?.results?.[0];
     if (!first?.serviceLineNumber || !first?.accountReferenceId) {
@@ -337,14 +355,17 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
    * whole reason a bypassed kit, which answers nothing on the LAN, can still be
    * configured.
    */
-  async function resolveControllerId(cookie: string): Promise<string> {
+  async function resolveControllerId(cookie: string, abortSignal?: AbortSignal): Promise<string> {
     if (cachedControllerId && Date.now() - cachedControllerIdAt < IDS_TTL_MS) {
       return cachedControllerId;
     }
-    const { acc } = await resolveIds(cookie);
-    const telemetry = await apiPost("/device-data/cache/v1/telemetry", cookie, {
-      accountNumber: acc,
-    });
+    const { acc } = await resolveIds(cookie, abortSignal);
+    const telemetry = await apiPost(
+      "/device-data/cache/v1/telemetry",
+      cookie,
+      { accountNumber: acc },
+      abortSignal,
+    );
     const routers = Object.entries(deviceTelemetryFrom(telemetry)).filter(
       ([, device]) => device.kind === "router",
     );
@@ -369,7 +390,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
   ): Promise<T> {
     const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
     return withFreshCookie(async (cookie) => {
-      const targetId = await resolveControllerId(cookie);
+      const targetId = await resolveControllerId(cookie, abortSignal);
       return run(targetId, (requestBytes) =>
         grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
           fetch: doFetch,
@@ -491,20 +512,16 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       // mutation cannot be built from a snapshot predating an earlier write.
       if (!prepareDeviceUpdate)
         return { status: 503, body: { error: "device_update_unavailable" } };
-      const requestBytes = await prepareDeviceUpdate(update);
-      const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
-      await withFreshCookie(async (cookie) => {
+      await withRouterGateway(async (targetId, callGateway) => {
+        const requestBytes = await prepareDeviceUpdate(update, targetId, callGateway);
         try {
-          await grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
-            fetch: doFetch,
-            headers: { cookie },
-          });
+          await callGateway(requestBytes);
         } catch (error) {
           if (error instanceof GrpcWebError && error.grpcStatus === 16)
             throw new SessionExpiredError();
           throw error;
         }
-      }, abortSignal);
+      });
       return { status: 200, body: { ok: true } };
     } catch (error) {
       if (error instanceof SessionExpiredError) return NOT_CONNECTED;
@@ -647,7 +664,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
         return { status: 503, body: { error: "router_config_update_unavailable" } };
       const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
       await withFreshCookie(async (cookie) => {
-        const targetId = await resolveControllerId(cookie);
+        const targetId = await resolveControllerId(cookie, abortSignal);
         const callGateway = (requestBytes: Uint8Array) =>
           grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
             fetch: doFetch,

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -76,6 +76,19 @@ export interface CloudHandlerOptions {
     targetId: string,
     callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
   ) => Promise<string | null>;
+  /** Trusted host callback: reads the connected-device roster through the same
+   *  gateway — the one reader that answers away from home, and for a router the
+   *  LAN cannot see. */
+  readRouterClients?: (
+    targetId: string,
+    callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+  ) => Promise<unknown[]>;
+  /** Trusted host callback: reads the router's whole WiFi config through the same
+   *  gateway — SSIDs, mesh nodes, saved device names. */
+  readRouterConfig?: (
+    targetId: string,
+    callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+  ) => Promise<unknown>;
 }
 
 /** The durable half of the session — without it a token refresh can't happen, so
@@ -163,6 +176,8 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
   const prepareDishConfigUpdate = options.prepareDishConfigUpdate;
   const prepareRouterConfigUpdate = options.prepareRouterConfigUpdate;
   const readRouterSubnet = options.readRouterSubnet;
+  const readRouterClients = options.readRouterClients;
+  const readRouterConfig = options.readRouterConfig;
 
   let cachedCookie: string | null = null;
   let cachedAt = 0;
@@ -343,6 +358,27 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     return cachedControllerId;
   }
 
+  /** Run one bounded read against the account's controller: resolve the target,
+   *  hand the callback a gateway bound to a fresh token, and let a session miss
+   *  heal the way every other call here does. */
+  async function withRouterGateway<T>(
+    run: (
+      targetId: string,
+      callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+    ) => Promise<T>,
+  ): Promise<T> {
+    const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
+    return withFreshCookie(async (cookie) => {
+      const targetId = await resolveControllerId(cookie);
+      return run(targetId, (requestBytes) =>
+        grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
+          fetch: doFetch,
+          headers: { cookie },
+        }),
+      );
+    }, abortSignal);
+  }
+
   /** `route` is the path without query, e.g. "/cloud/account". */
   async function handle(route: string): Promise<CloudResult> {
     if (!readCookie()) return NOT_CONNECTED;
@@ -380,17 +416,26 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       }
       if (route === "/cloud/router-subnet") {
         if (!readRouterSubnet) return { status: 503, body: { error: "router_subnet_unavailable" } };
-        const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
-        const subnet = await withFreshCookie(async (cookie) => {
-          const targetId = await resolveControllerId(cookie);
-          return readRouterSubnet(targetId, (requestBytes) =>
-            grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
-              fetch: doFetch,
-              headers: { cookie },
-            }),
-          );
-        }, abortSignal);
+        const subnet = await withRouterGateway(readRouterSubnet);
         return { status: 200, body: { subnet } };
+      }
+      // The roster the LAN normally serves, sourced from the account instead. It
+      // is the same list — the router reports its devices to Starlink whether or
+      // not this machine can reach it — so it answers the two cases the LAN read
+      // cannot: away from home, and a router the local network cannot see.
+      if (route === "/cloud/router-clients") {
+        if (!readRouterClients)
+          return { status: 503, body: { error: "router_clients_unavailable" } };
+        const clients = await withRouterGateway(readRouterClients);
+        return { status: 200, body: { clients } };
+      }
+      // GET reads the config the writes on this route change. Names, mesh nodes,
+      // and SSIDs all live here, so a roster read from the account has somewhere
+      // to get them from.
+      if (route === "/cloud/router-config") {
+        if (!readRouterConfig) return { status: 503, body: { error: "router_config_unavailable" } };
+        const wifiConfig = await withRouterGateway(readRouterConfig);
+        return { status: 200, body: { wifiConfig } };
       }
       return { status: 404, body: { error: "unknown_cloud_route", route } };
     } catch (error) {

--- a/core/hostNetworkIdentity.ts
+++ b/core/hostNetworkIdentity.ts
@@ -5,6 +5,9 @@ import { networkInterfaces } from "node:os";
 export interface HostNetworkIdentity {
   macAddresses: string[];
   ipAddresses: string[];
+  /** The router's id for this machine, learned from the roster on the router's
+   *  own network. Unlike the addresses, it identifies this host from anywhere. */
+  clientId?: number;
 }
 
 export function localNetworkIdentity(): HostNetworkIdentity {

--- a/core/routerClientUpdate.test.ts
+++ b/core/routerClientUpdate.test.ts
@@ -4,6 +4,7 @@ import {
   buildRouterPauseRequest,
   buildRouterRenameRequest,
   prepareRouterClientUpdate,
+  readRouterClients,
 } from "./routerClientUpdate";
 
 const TARGET = "Router-010000000000000001B31340";
@@ -228,5 +229,36 @@ describe("buildRouterRenameRequest", () => {
       targetId: TARGET,
       wifiSetConfig: { wifiConfig: { applyClientConfigs: true } },
     });
+  });
+});
+
+describe("readRouterClients", () => {
+  test("given: a gateway reply, should: name the target and serve the roster it carries", async () => {
+    let request: object | undefined;
+    const codec = {
+      encodeRequest: (value: object) => {
+        request = value;
+        return new Uint8Array([9]);
+      },
+      decodeResponse: () => ({
+        wifiGetClients: { clients: [{ clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX" }] },
+      }),
+    };
+
+    await expect(readRouterClients(codec, TARGET, async () => new Uint8Array())).resolves.toEqual([
+      { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX" },
+    ]);
+    expect(request).toEqual({ targetId: TARGET, wifiGetClients: {} });
+  });
+
+  test("given: a router reporting nobody, should: answer with an empty roster", async () => {
+    const codec = {
+      encodeRequest: () => new Uint8Array([9]),
+      decodeResponse: () => ({}),
+    };
+
+    await expect(readRouterClients(codec, TARGET, async () => new Uint8Array())).resolves.toEqual(
+      [],
+    );
   });
 });

--- a/core/routerClientUpdate.test.ts
+++ b/core/routerClientUpdate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { DishClient } from "./dishClient";
+import type { WifiClientJson } from "./dishClient";
 import {
   buildRouterPauseRequest,
   buildRouterRenameRequest,
@@ -21,6 +21,42 @@ const config = {
     { clientId: 8, macAddress: "dd:ee:ff:XX:XX:XX", groupId: "family" },
   ],
 };
+
+/**
+ * A router reachable only the way the real one is: through a gateway.
+ *
+ * `encodeRequest` tags each read with a byte, the gateway echoes it, and
+ * `decodeResponse` answers with the config or the roster accordingly — so a
+ * preparation that skips a read cannot accidentally be served one. The write it
+ * finally encodes is captured rather than sent.
+ */
+function gatewayRouter({
+  clients = [],
+}: {
+  /** A function throws where the roster must never be asked for. */
+  clients?: WifiClientJson[] | (() => never);
+} = {}) {
+  const encoded = new Uint8Array([1, 2, 3]);
+  const captured: { request?: object } = {};
+  const codec = {
+    encodeRequest: (value: object) => {
+      const json = value as Record<string, unknown>;
+      if ("wifiGetConfig" in json) return new Uint8Array([1]);
+      if ("wifiGetClients" in json) return new Uint8Array([2]);
+      captured.request = json;
+      return encoded;
+    },
+    decodeResponse: (responseBytes: Uint8Array) =>
+      responseBytes[0] === 1
+        ? { wifiGetConfig: { wifiConfig: config } }
+        : {
+            wifiGetClients: {
+              clients: typeof clients === "function" ? clients() : clients,
+            },
+          },
+  };
+  return { codec, callGateway: async (requestBytes: Uint8Array) => requestBytes, captured, encoded };
+}
 
 describe("buildRouterPauseRequest", () => {
   test("given: a client with another schedule, should: add permanent pause without losing data", () => {
@@ -82,25 +118,20 @@ describe("buildRouterPauseRequest", () => {
     expect(() => buildRouterPauseRequest("ut-dish", config, 7, true)).toThrow(/router target/);
   });
 
-  test("given: a trusted host, should: source and encode the request from router reads", async () => {
-    const encoded = new Uint8Array([1, 2, 3]);
-    let request: object | undefined;
-    const router = {
-      getWifiConfig: async () => config,
-      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
-      getWifiClients: async () => [
-        { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", givenName: "Tablet" },
-      ],
-      encodeRequest: (value: object) => {
-        request = value;
-        return encoded;
-      },
-    } as unknown as DishClient;
+  test("given: a trusted host, should: source and encode the request from gateway reads", async () => {
+    const router = gatewayRouter({
+      clients: [{ clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", givenName: "Tablet" }],
+    });
 
     await expect(
-      prepareRouterClientUpdate(router, { kind: "pause", clientId: 7, paused: true }),
-    ).resolves.toBe(encoded);
-    expect(request).toMatchObject({
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: true },
+        TARGET,
+        router.callGateway,
+      ),
+    ).resolves.toBe(router.encoded);
+    expect(router.captured.request).toMatchObject({
       targetId: TARGET,
       wifiSetConfig: {
         wifiConfig: {
@@ -121,38 +152,66 @@ describe("buildRouterPauseRequest", () => {
   });
 
   test("given: the target is the host itself, should: refuse to pause but allow unpause", async () => {
-    const router = {
-      getWifiConfig: async () => config,
-      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
-      getWifiClients: async () => [
-        { clientId: 7, macAddress: "AA:BB:CC:XX:XX:XX", ipAddress: "192.168.1.5" },
-      ],
-      encodeRequest: () => new Uint8Array([9]),
-    } as unknown as DishClient;
+    const router = gatewayRouter({
+      clients: [{ clientId: 7, macAddress: "AA:BB:CC:XX:XX:XX", ipAddress: "192.168.1.5" }],
+    });
     const host = { macAddresses: ["aa:bb:cc:XX:XX:XX"], ipAddresses: [] };
 
     await expect(
-      prepareRouterClientUpdate(router, { kind: "pause", clientId: 7, paused: true }, host),
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: true },
+        TARGET,
+        router.callGateway,
+        host,
+      ),
     ).rejects.toThrow(/Refusing/);
     await expect(
-      prepareRouterClientUpdate(router, { kind: "pause", clientId: 7, paused: false }, host),
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: false },
+        TARGET,
+        router.callGateway,
+        host,
+      ),
     ).resolves.toBeInstanceOf(Uint8Array);
   });
 
   test("given: the host matches only by address, should: still refuse the pause", async () => {
-    const router = {
-      getWifiConfig: async () => config,
-      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
-      getWifiClients: async () => [
-        { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" },
-      ],
-      encodeRequest: () => new Uint8Array([9]),
-    } as unknown as DishClient;
+    const router = gatewayRouter({
+      clients: [{ clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" }],
+    });
     const host = { macAddresses: [], ipAddresses: ["192.168.1.5"] };
 
     await expect(
-      prepareRouterClientUpdate(router, { kind: "pause", clientId: 7, paused: true }, host),
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: true },
+        TARGET,
+        router.callGateway,
+        host,
+      ),
     ).rejects.toThrow(/Refusing/);
+  });
+
+  test("given: a viewer off the router's network, should: leave the address guard silent", async () => {
+    // Nothing on the roster can match a host that is somewhere else entirely, so
+    // this guard has nothing to say there — the device the user named for
+    // themselves is what refuses a remote self-pause, before this is reached.
+    const router = gatewayRouter({
+      clients: [{ clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" }],
+    });
+    const elsewhere = { macAddresses: ["de:ad:be:ef:00:01"], ipAddresses: ["10.20.30.40"] };
+
+    await expect(
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: true },
+        TARGET,
+        router.callGateway,
+        elsewhere,
+      ),
+    ).resolves.toBe(router.encoded);
   });
 });
 
@@ -205,27 +264,21 @@ describe("buildRouterRenameRequest", () => {
   });
 
   test("given: an offline device, should: prepare without needing the live roster", async () => {
-    let request: object | undefined;
-    const router = {
-      getWifiConfig: async () => config,
-      getRouterStatus: async () => ({ deviceInfo: { id: TARGET } }),
-      getWifiClients: async () => {
+    const router = gatewayRouter({
+      clients: () => {
         throw new Error("the roster must not be needed to rename a saved device");
       },
-      encodeRequest: (value: object) => {
-        request = value;
-        return new Uint8Array([4]);
-      },
-    } as unknown as DishClient;
+    });
 
     await expect(
-      prepareRouterClientUpdate(router, {
-        kind: "rename",
-        clientId: 7,
-        givenName: "Studio Tablet",
-      }),
-    ).resolves.toEqual(new Uint8Array([4]));
-    expect(request).toMatchObject({
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "rename", clientId: 7, givenName: "Studio Tablet" },
+        TARGET,
+        router.callGateway,
+      ),
+    ).resolves.toBe(router.encoded);
+    expect(router.captured.request).toMatchObject({
       targetId: TARGET,
       wifiSetConfig: { wifiConfig: { applyClientConfigs: true } },
     });

--- a/core/routerClientUpdate.test.ts
+++ b/core/routerClientUpdate.test.ts
@@ -55,7 +55,12 @@ function gatewayRouter({
             },
           },
   };
-  return { codec, callGateway: async (requestBytes: Uint8Array) => requestBytes, captured, encoded };
+  return {
+    codec,
+    callGateway: async (requestBytes: Uint8Array) => requestBytes,
+    captured,
+    encoded,
+  };
 }
 
 describe("buildRouterPauseRequest", () => {
@@ -196,8 +201,7 @@ describe("buildRouterPauseRequest", () => {
 
   test("given: a viewer off the router's network, should: leave the address guard silent", async () => {
     // Nothing on the roster can match a host that is somewhere else entirely, so
-    // this guard has nothing to say there — the device the user named for
-    // themselves is what refuses a remote self-pause, before this is reached.
+    // an identity carrying only addresses has nothing to say there.
     const router = gatewayRouter({
       clients: [{ clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" }],
     });
@@ -212,6 +216,56 @@ describe("buildRouterPauseRequest", () => {
         elsewhere,
       ),
     ).resolves.toBe(router.encoded);
+  });
+
+  test("given: a remembered clientId, should: refuse a self-pause from off the network", async () => {
+    const router = gatewayRouter({
+      clients: [
+        { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" },
+        { clientId: 8, macAddress: "dd:ee:ff:XX:XX:XX", ipAddress: "192.168.1.6" },
+      ],
+    });
+    const elsewhere = {
+      macAddresses: ["de:ad:be:ef:00:01"],
+      ipAddresses: ["10.20.30.40"],
+      clientId: 7,
+    };
+
+    await expect(
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: true },
+        TARGET,
+        router.callGateway,
+        elsewhere,
+      ),
+    ).rejects.toThrow(/Refusing/);
+    await expect(
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 8, paused: true },
+        TARGET,
+        router.callGateway,
+        elsewhere,
+      ),
+    ).resolves.toBe(router.encoded);
+  });
+
+  test("given: a remembered id the router has since renumbered, should: still refuse by address", async () => {
+    const router = gatewayRouter({
+      clients: [{ clientId: 9, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" }],
+    });
+    const host = { macAddresses: ["aa:bb:cc:XX:XX:XX"], ipAddresses: ["192.168.1.5"], clientId: 7 };
+
+    await expect(
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 9, paused: true },
+        TARGET,
+        router.callGateway,
+        host,
+      ),
+    ).rejects.toThrow(/Refusing/);
   });
 });
 

--- a/core/routerClientUpdate.ts
+++ b/core/routerClientUpdate.ts
@@ -1,10 +1,6 @@
-import type {
-  DishClient,
-  WifiClientConfigJson,
-  WifiClientJson,
-  WifiNetworkConfigJson,
-} from "./dishClient";
+import type { WifiClientConfigJson, WifiClientJson, WifiNetworkConfigJson } from "./dishClient";
 import type { HostNetworkIdentity } from "./hostNetworkIdentity";
+import { readRouterWifiConfig } from "./routerConfigUpdate";
 
 const PERMANENT_GROUP = "_permanent";
 const WEEK_MINUTES = 7 * 24 * 60;
@@ -104,8 +100,15 @@ export function buildRouterRenameRequest(
  *  usable with any codec rather than only the client dialling the LAN. */
 interface RouterCodec {
   encodeRequest(requestJson: object): Uint8Array;
-  decodeResponse(responseBytes: Uint8Array): { wifiGetClients?: { clients?: WifiClientJson[] } };
+  decodeResponse(responseBytes: Uint8Array): {
+    wifiGetClients?: { clients?: WifiClientJson[] };
+    wifiGetConfig?: { wifiConfig?: WifiNetworkConfigJson };
+  };
 }
+
+/** One encoded request out to the router and its reply back, through whatever
+ *  path the caller has. */
+type CallGateway = (requestBytes: Uint8Array) => Promise<Uint8Array>;
 
 /**
  * The devices the router currently reports, over the caller's gateway instead of
@@ -119,7 +122,7 @@ interface RouterCodec {
 export async function readRouterClients(
   codec: RouterCodec,
   targetId: string,
-  callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+  callGateway: CallGateway,
 ): Promise<WifiClientJson[]> {
   const reply = codec.decodeResponse(
     await callGateway(codec.encodeRequest({ targetId, wifiGetClients: {} })),
@@ -139,24 +142,32 @@ export function clientIsHost(client: WifiClientJson, host: HostNetworkIdentity):
   );
 }
 
-/** Trusted-host preparation: source target, config, and client identity directly
- *  from the local router immediately before encoding the cloud write.
+/**
+ * Trusted-host preparation: read the config and the roster this write has to be
+ * built from, then encode it — everything over the caller's gateway.
  *
- *  A device that pauses itself cannot undo it — the official Starlink app hides
- *  the control for the device it runs on, so recovery needs a second machine.
- *  `hostIdentity` refuses that write here because the UI guard is bypassable.
- *  Renaming carries no such risk and is not guarded. */
+ * Nothing here touches the LAN. The write cannot go that way — current firmware
+ * answers a LAN write with grpc status 7 — and sourcing its inputs there would
+ * confine pausing and renaming to a machine sitting on the router's own network,
+ * which a kit in bypass does not have.
+ *
+ * A device that pauses itself cannot undo it — the official Starlink app hides
+ * the control for the device it runs on, so recovery needs a second machine.
+ * `hostIdentity` refuses that write here because the UI guard is bypassable. It
+ * can only speak for a host on the same network as the roster it is matching
+ * against; a viewer somewhere else matches nothing, and the device that viewer
+ * named for itself is what guards it there (the extension enforces exactly that
+ * before this is reached). Renaming carries no such risk and is not guarded.
+ */
 export async function prepareRouterClientUpdate(
-  router: DishClient,
+  codec: RouterCodec,
   update: RouterClientUpdate,
+  targetId: string,
+  callGateway: CallGateway,
   hostIdentity?: HostNetworkIdentity,
 ): Promise<Uint8Array> {
-  const [config, status] = await Promise.all([
-    router.getWifiConfig(AbortSignal.timeout(5_000)),
-    router.getRouterStatus(AbortSignal.timeout(5_000)),
-  ]);
-  const targetId = status.deviceInfo?.id;
-  if (!targetId) throw new Error("Starlink router identity is unavailable");
+  const config = await readRouterWifiConfig(codec, targetId, callGateway);
+  if (!config) throw new Error("Starlink router reported no configuration");
 
   if (update.kind === "rename") {
     // A device with a saved entry needs no roster, which is what lets an offline
@@ -166,22 +177,22 @@ export async function prepareRouterClientUpdate(
     );
     const liveClient = saved
       ? undefined
-      : (await router.getWifiClients(AbortSignal.timeout(5_000))).find(
+      : (await readRouterClients(codec, targetId, callGateway)).find(
           (client) => client.clientId === update.clientId,
         );
-    return router.encodeRequest(
+    return codec.encodeRequest(
       buildRouterRenameRequest(targetId, config, update.clientId, update.givenName, liveClient),
     );
   }
 
   // Pause needs the live roster: it keys on clientId, which only exists while the
   // device is associated, and the host guard matches on the addresses it reports.
-  const clients = await router.getWifiClients(AbortSignal.timeout(5_000));
+  const clients = await readRouterClients(codec, targetId, callGateway);
   const liveClient = clients.find((client) => client.clientId === update.clientId);
   if (!liveClient) throw new Error("Device is no longer connected to the router");
   if (update.paused && hostIdentity && clientIsHost(liveClient, hostIdentity))
     throw new Error("Refusing to pause the device Dishylink is running on");
-  return router.encodeRequest(
+  return codec.encodeRequest(
     buildRouterPauseRequest(targetId, config, update.clientId, update.paused, liveClient),
   );
 }

--- a/core/routerClientUpdate.ts
+++ b/core/routerClientUpdate.ts
@@ -100,6 +100,33 @@ export function buildRouterRenameRequest(
   );
 }
 
+/** The bit of DishClient a gateway read needs, named structurally so this stays
+ *  usable with any codec rather than only the client dialling the LAN. */
+interface RouterCodec {
+  encodeRequest(requestJson: object): Uint8Array;
+  decodeResponse(responseBytes: Uint8Array): { wifiGetClients?: { clients?: WifiClientJson[] } };
+}
+
+/**
+ * The devices the router currently reports, over the caller's gateway instead of
+ * the LAN.
+ *
+ * The roster is the same one the LAN serves — same clientIds, same masked MACs,
+ * same byte counters — so everything joined on it downstream still joins. What
+ * differs is reach: this answers for a router the local network cannot see, and
+ * from a machine that is not on that network at all.
+ */
+export async function readRouterClients(
+  codec: RouterCodec,
+  targetId: string,
+  callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+): Promise<WifiClientJson[]> {
+  const reply = codec.decodeResponse(
+    await callGateway(codec.encodeRequest({ targetId, wifiGetClients: {} })),
+  );
+  return reply.wifiGetClients?.clients ?? [];
+}
+
 /** True when this router client entry is the machine preparing the request.
  *  Both sides are normalised here so no caller has to pre-lowercase. */
 export function clientIsHost(client: WifiClientJson, host: HostNetworkIdentity): boolean {

--- a/core/routerClientUpdate.ts
+++ b/core/routerClientUpdate.ts
@@ -133,6 +133,9 @@ export async function readRouterClients(
 /** True when this router client entry is the machine preparing the request.
  *  Both sides are normalised here so no caller has to pre-lowercase. */
 export function clientIsHost(client: WifiClientJson, host: HostNetworkIdentity): boolean {
+  // Either signal is enough: a kept id is stale for one roster read after a router
+  // reset renumbers every client, and the addresses cover that gap.
+  if (host.clientId !== undefined && client.clientId === host.clientId) return true;
   const macAddress = client.macAddress?.toLowerCase();
   if (macAddress && host.macAddresses.some((candidate) => candidate.toLowerCase() === macAddress))
     return true;
@@ -151,15 +154,14 @@ export function clientIsHost(client: WifiClientJson, host: HostNetworkIdentity):
  * confine pausing and renaming to a machine sitting on the router's own network,
  * which a kit in bypass does not have.
  *
- * A device that pauses itself cannot undo it — the official Starlink app hides
- * the control for the device it runs on, so recovery needs a second machine.
- * `hostIdentity` refuses that write here because the UI guard is bypassable, but
- * it only speaks for a host sharing the roster's network: this firmware masks the
- * low octets of every MAC it reports, so the match is by address alone, and a
- * viewer somewhere else matches nothing. A host that lets the user name their own
- * device covers that case before this is reached — the extension refuses any
- * pause aimed at the named one — and a host without that naming leaves a remote
- * self-pause unguarded. Renaming carries no such risk and is not guarded.
+ * A device that pauses itself cannot undo it: the official Starlink app hides the
+ * control for the device it runs on, so recovery needs a second machine.
+ * `hostIdentity` refuses that write here because the UI guard is bypassable. A
+ * `clientId` in it settles the question from anywhere. Without one the match is by
+ * address alone, since this firmware masks the low octets of every MAC it reports,
+ * and an address speaks only for a host on the network that issued it. A host that
+ * supplies neither leaves a remote self-pause unguarded. Renaming carries no such
+ * risk and is not guarded.
  */
 export async function prepareRouterClientUpdate(
   codec: RouterCodec,

--- a/core/routerClientUpdate.ts
+++ b/core/routerClientUpdate.ts
@@ -153,11 +153,13 @@ export function clientIsHost(client: WifiClientJson, host: HostNetworkIdentity):
  *
  * A device that pauses itself cannot undo it — the official Starlink app hides
  * the control for the device it runs on, so recovery needs a second machine.
- * `hostIdentity` refuses that write here because the UI guard is bypassable. It
- * can only speak for a host on the same network as the roster it is matching
- * against; a viewer somewhere else matches nothing, and the device that viewer
- * named for itself is what guards it there (the extension enforces exactly that
- * before this is reached). Renaming carries no such risk and is not guarded.
+ * `hostIdentity` refuses that write here because the UI guard is bypassable, but
+ * it only speaks for a host sharing the roster's network: this firmware masks the
+ * low octets of every MAC it reports, so the match is by address alone, and a
+ * viewer somewhere else matches nothing. A host that lets the user name their own
+ * device covers that case before this is reached — the extension refuses any
+ * pause aimed at the named one — and a host without that naming leaves a remote
+ * self-pause unguarded. Renaming carries no such risk and is not guarded.
  */
 export async function prepareRouterClientUpdate(
   codec: RouterCodec,

--- a/core/routerConfigUpdate.ts
+++ b/core/routerConfigUpdate.ts
@@ -11,6 +11,7 @@
 // mode has no reachable router on the local network at all, and its target comes
 // from the account.
 
+import type { WifiNetworkConfigJson } from "./dishClient";
 import { normalizeIpAddress } from "./ipAddress";
 
 /** The most the router's own app offers: one primary and three backups. */
@@ -138,13 +139,32 @@ export function subnetRefusal(subnet: string, password: string): string | null {
   return null;
 }
 
-/** The bit of DishClient this needs, named structurally so core keeps no
- *  dependency on the client itself. */
+/** The bit of DishClient this needs, named structurally so any codec can serve
+ *  it rather than the client alone. */
 interface RouterCodec {
   encodeRequest(requestJson: object): Uint8Array;
   decodeResponse(responseBytes: Uint8Array): {
     wifiGetConfig?: { wifiConfig?: { networks?: unknown[] } };
   };
+}
+
+/**
+ * The router's whole WiFi configuration, over the caller's gateway.
+ *
+ * The same block the LAN serves — SSIDs, mesh nodes, saved device names — for a
+ * router the local network cannot reach. Null when the reply carries none.
+ */
+export async function readRouterWifiConfig(
+  codec: RouterCodec,
+  targetId: string,
+  callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
+): Promise<WifiNetworkConfigJson | null> {
+  const reply = codec.decodeResponse(
+    await callGateway(codec.encodeRequest({ targetId, wifiGetConfig: {} })),
+  );
+  // The codec is described loosely on purpose — only the write path here reads
+  // into the reply — so the shape is named once, at this boundary.
+  return (reply.wifiGetConfig?.wifiConfig as WifiNetworkConfigJson | undefined) ?? null;
 }
 
 /**
@@ -168,10 +188,8 @@ async function readRouterNetworks(
   targetId: string,
   callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
 ): Promise<Json[]> {
-  const reply = codec.decodeResponse(
-    await callGateway(codec.encodeRequest({ targetId, wifiGetConfig: {} })),
-  );
-  return (reply.wifiGetConfig?.wifiConfig?.networks as Json[] | undefined) ?? [];
+  const config = await readRouterWifiConfig(codec, targetId, callGateway);
+  return (config?.networks as Json[] | undefined) ?? [];
 }
 
 /**

--- a/dev/starlinkCloudProxy.ts
+++ b/dev/starlinkCloudProxy.ts
@@ -97,8 +97,14 @@ export function starlinkCloudProxy(): Plugin {
         readCookie,
         writeCookie,
         clearCookie,
-        prepareDeviceUpdate: async (update) =>
-          prepareRouterClientUpdate(await loadRouter(), update, localNetworkIdentity()),
+        prepareDeviceUpdate: async (update, targetId, callGateway) =>
+          prepareRouterClientUpdate(
+            await loadRouter(),
+            update,
+            targetId,
+            callGateway,
+            localNetworkIdentity(),
+          ),
         prepareDishConfigUpdate: async (changes) => {
           dishPromise ??= DishClient.load("dish", {
             handleUrl: DISH_LAN_HANDLE_URL,

--- a/dev/starlinkCloudProxy.ts
+++ b/dev/starlinkCloudProxy.ts
@@ -19,9 +19,10 @@ import {
   buildRouterConfigRequest,
   readCurrentNetworks,
   readCurrentSubnet,
+  readRouterWifiConfig,
   type RouterConfigUpdate,
 } from "../core/routerConfigUpdate.ts";
-import { prepareRouterClientUpdate } from "../core/routerClientUpdate.ts";
+import { prepareRouterClientUpdate, readRouterClients } from "../core/routerClientUpdate.ts";
 import type { RouterClientUpdate } from "../core/routerClientUpdate.ts";
 import { localNetworkIdentity } from "../core/hostNetworkIdentity.ts";
 
@@ -85,17 +86,19 @@ export function starlinkCloudProxy(): Plugin {
       let dishPromise: Promise<DishClient> | null = null;
       const protosetBytes = () =>
         new Uint8Array(readFileSync(resolve(process.cwd(), "public/dish.protoset")));
+      // Every router callback needs the same client, and the gateway ones need it
+      // only as a codec — loading it dials nothing.
+      const loadRouter = () =>
+        (routerPromise ??= DishClient.load("router", {
+          handleUrl: ROUTER_LAN_HANDLE_URL,
+          protosetBytes: protosetBytes(),
+        }));
       const handler = createCloudHandler({
         readCookie,
         writeCookie,
         clearCookie,
-        prepareDeviceUpdate: async (update) => {
-          routerPromise ??= DishClient.load("router", {
-            handleUrl: ROUTER_LAN_HANDLE_URL,
-            protosetBytes: protosetBytes(),
-          });
-          return prepareRouterClientUpdate(await routerPromise, update, localNetworkIdentity());
-        },
+        prepareDeviceUpdate: async (update) =>
+          prepareRouterClientUpdate(await loadRouter(), update, localNetworkIdentity()),
         prepareDishConfigUpdate: async (changes) => {
           dishPromise ??= DishClient.load("dish", {
             handleUrl: DISH_LAN_HANDLE_URL,
@@ -106,21 +109,16 @@ export function starlinkCloudProxy(): Plugin {
         // Encoding only — the client is never dialled here, so this works on a
         // kit whose router answers nothing on the LAN.
         prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
-          routerPromise ??= DishClient.load("router", {
-            handleUrl: ROUTER_LAN_HANDLE_URL,
-            protosetBytes: protosetBytes(),
-          });
-          const client = await routerPromise;
+          const client = await loadRouter();
           const networks = await readCurrentNetworks(update, client, targetId, callGateway);
           return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
         },
-        readRouterSubnet: async (targetId, callGateway) => {
-          routerPromise ??= DishClient.load("router", {
-            handleUrl: ROUTER_LAN_HANDLE_URL,
-            protosetBytes: protosetBytes(),
-          });
-          return readCurrentSubnet(await routerPromise, targetId, callGateway);
-        },
+        readRouterSubnet: async (targetId, callGateway) =>
+          readCurrentSubnet(await loadRouter(), targetId, callGateway),
+        readRouterClients: async (targetId, callGateway) =>
+          readRouterClients(await loadRouter(), targetId, callGateway),
+        readRouterConfig: async (targetId, callGateway) =>
+          readRouterWifiConfig(await loadRouter(), targetId, callGateway),
       });
       server.middlewares.use(async (req: IncomingMessage, res: ServerResponse, next) => {
         const url = req.url ?? "";

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -77,8 +77,14 @@ export function startCloud(rendererRoot: string): void {
     readCookie,
     writeCookie,
     clearCookie,
-    prepareDeviceUpdate: async (update) =>
-      prepareRouterClientUpdate(await loadRouter(), update, localNetworkIdentity()),
+    prepareDeviceUpdate: async (update, targetId, callGateway) =>
+      prepareRouterClientUpdate(
+        await loadRouter(),
+        update,
+        targetId,
+        callGateway,
+        localNetworkIdentity(),
+      ),
     prepareDishConfigUpdate: async (changes) => {
       dishPromise ??= DishClient.load("dish", {
         handleUrl: DISH_LAN_HANDLE_URL,

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -16,9 +16,10 @@ import {
   buildRouterConfigRequest,
   readCurrentNetworks,
   readCurrentSubnet,
+  readRouterWifiConfig,
   type RouterConfigUpdate,
 } from "../core/routerConfigUpdate";
-import { prepareRouterClientUpdate } from "../core/routerClientUpdate";
+import { prepareRouterClientUpdate, readRouterClients } from "../core/routerClientUpdate";
 import type { RouterClientUpdate } from "../core/routerClientUpdate";
 import { localNetworkIdentity } from "../core/hostNetworkIdentity";
 
@@ -65,17 +66,19 @@ export function startCloud(rendererRoot: string): void {
     : join(app.getAppPath(), "public/dish.protoset");
   let routerPromise: Promise<DishClient> | null = null;
   let dishPromise: Promise<DishClient> | null = null;
+  // Every router callback needs the same client, and the gateway ones need it
+  // only as a codec — loading it dials nothing.
+  const loadRouter = () =>
+    (routerPromise ??= DishClient.load("router", {
+      handleUrl: ROUTER_LAN_HANDLE_URL,
+      protosetBytes: new Uint8Array(readFileSync(protosetPath)),
+    }));
   handler = createCloudHandler({
     readCookie,
     writeCookie,
     clearCookie,
-    prepareDeviceUpdate: async (update) => {
-      routerPromise ??= DishClient.load("router", {
-        handleUrl: ROUTER_LAN_HANDLE_URL,
-        protosetBytes: new Uint8Array(readFileSync(protosetPath)),
-      });
-      return prepareRouterClientUpdate(await routerPromise, update, localNetworkIdentity());
-    },
+    prepareDeviceUpdate: async (update) =>
+      prepareRouterClientUpdate(await loadRouter(), update, localNetworkIdentity()),
     prepareDishConfigUpdate: async (changes) => {
       dishPromise ??= DishClient.load("dish", {
         handleUrl: DISH_LAN_HANDLE_URL,
@@ -87,21 +90,16 @@ export function startCloud(rendererRoot: string): void {
     // whose router answers nothing on the LAN. A subnet change reads the current
     // networks through the caller's gateway, which has the same reach.
     prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
-      routerPromise ??= DishClient.load("router", {
-        handleUrl: ROUTER_LAN_HANDLE_URL,
-        protosetBytes: new Uint8Array(readFileSync(protosetPath)),
-      });
-      const client = await routerPromise;
+      const client = await loadRouter();
       const networks = await readCurrentNetworks(update, client, targetId, callGateway);
       return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
     },
-    readRouterSubnet: async (targetId, callGateway) => {
-      routerPromise ??= DishClient.load("router", {
-        handleUrl: ROUTER_LAN_HANDLE_URL,
-        protosetBytes: new Uint8Array(readFileSync(protosetPath)),
-      });
-      return readCurrentSubnet(await routerPromise, targetId, callGateway);
-    },
+    readRouterSubnet: async (targetId, callGateway) =>
+      readCurrentSubnet(await loadRouter(), targetId, callGateway),
+    readRouterClients: async (targetId, callGateway) =>
+      readRouterClients(await loadRouter(), targetId, callGateway),
+    readRouterConfig: async (targetId, callGateway) =>
+      readRouterWifiConfig(await loadRouter(), targetId, callGateway),
   });
 }
 

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -21,7 +21,7 @@ import {
 } from "../core/routerConfigUpdate";
 import { prepareRouterClientUpdate, readRouterClients } from "../core/routerClientUpdate";
 import type { RouterClientUpdate } from "../core/routerClientUpdate";
-import { localNetworkIdentity } from "../core/hostNetworkIdentity";
+import { hostIdentity } from "./selfDevice";
 
 const LOGIN_URL = "https://www.starlink.com/account";
 // The login window gets its own session, so signing out can wipe its Starlink
@@ -78,13 +78,7 @@ export function startCloud(rendererRoot: string): void {
     writeCookie,
     clearCookie,
     prepareDeviceUpdate: async (update, targetId, callGateway) =>
-      prepareRouterClientUpdate(
-        await loadRouter(),
-        update,
-        targetId,
-        callGateway,
-        localNetworkIdentity(),
-      ),
+      prepareRouterClientUpdate(await loadRouter(), update, targetId, callGateway, hostIdentity()),
     prepareDishConfigUpdate: async (changes) => {
       dishPromise ??= DishClient.load("dish", {
         handleUrl: DISH_LAN_HANDLE_URL,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -28,7 +28,7 @@ import {
   type ThroughputSample,
 } from "./collector";
 import { startCloud, handleCloudRequest, signIn } from "./cloud";
-import { localNetworkIdentity } from "../core/hostNetworkIdentity";
+import { hostIdentity, rememberSelfDevice } from "./selfDevice";
 import { normalizeIpAddress, type RouterAddress } from "../core/ipAddress";
 import { ROUTER_LAN_ADDRESS } from "../core/dishClient";
 import { preferences, setPreference, onPreferencesChanged, type WindowBounds } from "./preferences";
@@ -502,8 +502,13 @@ function startAlertNotifications(): void {
 /** Facts about this host that only main can answer. */
 function registerHostHandlers(): void {
   // get_clients answers everyone identically, so "this device" can only be settled
-  // from the host's own interfaces.
-  ipcMain.handle("get-self-identity", () => localNetworkIdentity());
+  // from the host's own interfaces, plus the roster entry a window on the router's
+  // network has since matched to them.
+  ipcMain.handle("get-self-identity", () => hostIdentity());
+  // Written whenever the window resolves this machine on a roster read over the LAN.
+  ipcMain.handle("remember-self-device", (_event, clientId: unknown) => {
+    if (typeof clientId === "number") rememberSelfDevice(clientId);
+  });
   ipcMain.handle("get-recorder-in-process", () => !devServerUrl);
   ipcMain.handle("get-router-address", () => routerAddress());
   // An address that does not parse is rejected here rather than stored and

--- a/electron/preferences.ts
+++ b/electron/preferences.ts
@@ -61,6 +61,13 @@ export interface Preferences {
    * process dials the router with no window open.
    */
   routerAddress: string | null;
+
+  /**
+   * The router's clientId for this machine, or null until the window has seen
+   * itself on the roster. What the self-pause refusal matches on when the write
+   * is made from off the router's network, where an address match means nothing.
+   */
+  selfClientId: number | null;
 }
 
 const DEFAULTS: Preferences = {
@@ -68,7 +75,15 @@ const DEFAULTS: Preferences = {
   menuBarThroughput: false,
   windowBounds: null,
   routerAddress: null,
+  selfClientId: null,
 };
+
+/** A clientId is a uint32 the router issued, so anything else on disk is not one. */
+function storedClientId(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 0xffff_ffff
+    ? value
+    : null;
+}
 
 function isWindowBounds(value: unknown): value is WindowBounds {
   if (typeof value !== "object" || value === null) return false;
@@ -107,6 +122,7 @@ export function preferences(): Preferences {
         typeof parsed.menuBarThroughput === "boolean" ? parsed.menuBarThroughput : false,
       windowBounds: isWindowBounds(parsed.windowBounds) ? parsed.windowBounds : null,
       routerAddress: storedAddress(parsed.routerAddress),
+      selfClientId: storedClientId(parsed.selfClientId),
     };
   } catch {
     // No file yet, or unreadable. Either way the defaults are the answer.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -28,6 +28,10 @@ contextBridge.exposeInMainWorld("dishlink", {
     ipcRenderer.send("open-external", url);
   },
   selfIdentity: (): Promise<HostNetworkIdentity> => ipcRenderer.invoke("get-self-identity"),
+  // The roster entry this machine matched over the LAN, kept by main so the
+  // self-pause refusal there still knows this device off that network.
+  rememberSelfDevice: (clientId: number): Promise<void> =>
+    ipcRenderer.invoke("remember-self-device", clientId),
   recorderInProcess: (): Promise<boolean> => ipcRenderer.invoke("get-recorder-in-process"),
   // Where this process dials the router. Main owns it because the recorder there
   // dials with no window open.

--- a/electron/selfDevice.test.ts
+++ b/electron/selfDevice.test.ts
@@ -1,0 +1,71 @@
+// The join the self-pause guard depends on: what the window recorded has to
+// reach `prepareRouterClientUpdate` as part of this host's identity.
+
+import { describe, expect, test, vi } from "vitest";
+import { prepareRouterClientUpdate } from "../core/routerClientUpdate";
+
+const stored: { selfClientId: number | null } = { selfClientId: null };
+
+vi.mock("./preferences", () => ({
+  preferences: () => stored,
+  setPreference: (key: "selfClientId", value: number | null) => {
+    stored[key] = value;
+  },
+}));
+
+const { hostIdentity, rememberSelfDevice } = await import("./selfDevice");
+
+const TARGET = "Router-010000000000000001B31340";
+const roster = [{ clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" }];
+
+/** A router reachable only through a gateway, as the real one is off the LAN. */
+function gatewayRouter() {
+  const encoded = new Uint8Array([9]);
+  return {
+    encoded,
+    codec: {
+      encodeRequest: (value: object) =>
+        "wifiGetConfig" in value
+          ? new Uint8Array([1])
+          : "wifiGetClients" in value
+            ? new Uint8Array([2])
+            : encoded,
+      decodeResponse: (bytes: Uint8Array) =>
+        bytes[0] === 1
+          ? { wifiGetConfig: { wifiConfig: { clientConfigs: [{ clientId: 7 }] } } }
+          : { wifiGetClients: { clients: roster } },
+    },
+    callGateway: async (bytes: Uint8Array) => bytes,
+  };
+}
+
+describe("hostIdentity", () => {
+  test("given: nothing recorded yet, should: carry addresses alone", () => {
+    stored.selfClientId = null;
+
+    expect(hostIdentity().clientId).toBeUndefined();
+  });
+
+  test("given: an id the window recorded, should: refuse that device from off the network", async () => {
+    rememberSelfDevice(7);
+    const router = gatewayRouter();
+
+    expect(hostIdentity().clientId).toBe(7);
+    await expect(
+      prepareRouterClientUpdate(
+        router.codec,
+        { kind: "pause", clientId: 7, paused: true },
+        TARGET,
+        router.callGateway,
+        hostIdentity(),
+      ),
+    ).rejects.toThrow(/Refusing/);
+  });
+
+  test("given: an id outside a uint32, should: keep what is stored", () => {
+    rememberSelfDevice(7);
+    rememberSelfDevice(-1);
+
+    expect(hostIdentity().clientId).toBe(7);
+  });
+});

--- a/electron/selfDevice.ts
+++ b/electron/selfDevice.ts
@@ -1,0 +1,24 @@
+// Who this machine is on the router's roster, for the surfaces that must not act
+// on it: the pause refusal in core/routerClientUpdate, and the window's own
+// "This device" flag.
+//
+// The id is reported by the window and is only as trustworthy as it is; the
+// addresses beside it are read in this process.
+
+import { localNetworkIdentity, type HostNetworkIdentity } from "../core/hostNetworkIdentity";
+import { preferences, setPreference } from "./preferences";
+
+export function hostIdentity(): HostNetworkIdentity {
+  const clientId = preferences().selfClientId;
+  return {
+    ...localNetworkIdentity(),
+    ...(clientId === null ? {} : { clientId }),
+  };
+}
+
+/** A router reset renumbers every client, so the newest LAN answer replaces what
+ *  is stored rather than being discarded in its favour. */
+export function rememberSelfDevice(clientId: number): void {
+  if (!Number.isInteger(clientId) || clientId < 0 || clientId > 0xffff_ffff) return;
+  if (preferences().selfClientId !== clientId) setPreference("selfClientId", clientId);
+}

--- a/extension/lib/cloudHandler.ts
+++ b/extension/lib/cloudHandler.ts
@@ -27,9 +27,14 @@ import {
   buildRouterConfigRequest,
   readCurrentNetworks,
   readCurrentSubnet,
+  readRouterWifiConfig,
   type RouterConfigUpdate,
 } from "@core/routerConfigUpdate";
-import { prepareRouterClientUpdate, type RouterClientUpdate } from "@core/routerClientUpdate";
+import {
+  prepareRouterClientUpdate,
+  readRouterClients,
+  type RouterClientUpdate,
+} from "@core/routerClientUpdate";
 import type { CloudReply, CloudRequest } from "@/lib/cloudHost";
 import { dishHandleUrl, routerHandleUrl } from "./endpoints";
 import { loadSelfDeviceClientId } from "./selfDevice";
@@ -46,6 +51,17 @@ let dishPromise: Promise<DishClient> | null = null;
 let cachedRouterUrl = "";
 let cachedDishUrl = "";
 
+/** The router client every router callback needs, reloaded whenever the address
+ *  changes. The gateway callbacks need it only as a codec — loading dials nothing. */
+function loadRouter(): Promise<DishClient> {
+  const routerUrl = routerHandleUrl();
+  if (routerUrl !== cachedRouterUrl) {
+    cachedRouterUrl = routerUrl;
+    routerPromise = null;
+  }
+  return (routerPromise ??= DishClient.load("router", { handleUrl: routerUrl }));
+}
+
 const cloudHandler = createCloudHandler({
   fetch: ((input: RequestInfo | URL, init?: RequestInit) =>
     fetch(input, { ...init, credentials: "include" })) as typeof fetch,
@@ -58,35 +74,18 @@ const cloudHandler = createCloudHandler({
     ourCookie = null;
     void browser.storage.local.remove(SESSION_KEY);
   },
-  prepareDeviceUpdate: async (update) => {
-    const routerUrl = routerHandleUrl();
-    if (routerUrl !== cachedRouterUrl) {
-      cachedRouterUrl = routerUrl;
-      routerPromise = null;
-    }
-    routerPromise ??= DishClient.load("router", { handleUrl: routerUrl });
-    return prepareRouterClientUpdate(await routerPromise, update);
-  },
+  prepareDeviceUpdate: async (update) => prepareRouterClientUpdate(await loadRouter(), update),
   prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
-    const routerUrl = routerHandleUrl();
-    if (routerUrl !== cachedRouterUrl) {
-      cachedRouterUrl = routerUrl;
-      routerPromise = null;
-    }
-    routerPromise ??= DishClient.load("router", { handleUrl: routerUrl });
-    const client = await routerPromise;
+    const client = await loadRouter();
     const networks = await readCurrentNetworks(update, client, targetId, callGateway);
     return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
   },
-  readRouterSubnet: async (targetId, callGateway) => {
-    const routerUrl = routerHandleUrl();
-    if (routerUrl !== cachedRouterUrl) {
-      cachedRouterUrl = routerUrl;
-      routerPromise = null;
-    }
-    routerPromise ??= DishClient.load("router", { handleUrl: routerUrl });
-    return readCurrentSubnet(await routerPromise, targetId, callGateway);
-  },
+  readRouterSubnet: async (targetId, callGateway) =>
+    readCurrentSubnet(await loadRouter(), targetId, callGateway),
+  readRouterClients: async (targetId, callGateway) =>
+    readRouterClients(await loadRouter(), targetId, callGateway),
+  readRouterConfig: async (targetId, callGateway) =>
+    readRouterWifiConfig(await loadRouter(), targetId, callGateway),
   prepareDishConfigUpdate: async (changes) => {
     const dishUrl = dishHandleUrl();
     if (dishUrl !== cachedDishUrl) {

--- a/extension/lib/cloudHandler.ts
+++ b/extension/lib/cloudHandler.ts
@@ -74,7 +74,8 @@ const cloudHandler = createCloudHandler({
     ourCookie = null;
     void browser.storage.local.remove(SESSION_KEY);
   },
-  prepareDeviceUpdate: async (update) => prepareRouterClientUpdate(await loadRouter(), update),
+  prepareDeviceUpdate: async (update, targetId, callGateway) =>
+    prepareRouterClientUpdate(await loadRouter(), update, targetId, callGateway),
   prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
     const client = await loadRouter();
     const networks = await readCurrentNetworks(update, client, targetId, callGateway);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,6 +208,7 @@ export default function App() {
           clients={routerNetwork.clients}
           initialTab={settingsTab}
           routerReachable={routerNetwork.routerReachable}
+          routerViaAccount={routerNetwork.clientsSource === "cloud"}
           routerUnreachable={routerUnreachable}
           onRouterConfigChanged={routerNetwork.refreshConfig}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,7 +208,7 @@ export default function App() {
           clients={routerNetwork.clients}
           initialTab={settingsTab}
           routerReachable={routerNetwork.routerReachable}
-          routerViaAccount={routerNetwork.clientsSource === "cloud"}
+          routerViaAccount={routerNetwork.wifiConfigViaAccount}
           routerUnreachable={routerUnreachable}
           onRouterConfigChanged={routerNetwork.refreshConfig}
         />

--- a/src/components/network/AccountRosterOffer.tsx
+++ b/src/components/network/AccountRosterOffer.tsx
@@ -1,0 +1,41 @@
+// The offer to read the device roster through the Starlink account while the LAN
+// cannot answer. Only the roster is asked for: the router's config is read from
+// the account on its own, so the settings that show it never go dark waiting for
+// a click here.
+
+import { Button } from "../ui/button";
+import { SpinLoader } from "../loaders/SpinLoader";
+
+export function AccountRosterOffer({
+  status,
+  error,
+  onConnect,
+}: {
+  status: "idle" | "loading" | "failed";
+  error: string | null;
+  onConnect: () => void;
+}) {
+  return (
+    <div className='mt-3.5 flex flex-col items-center gap-1.5'>
+      <Button
+        className='min-w-[13rem] cursor-pointer rounded-full px-5 disabled:opacity-100'
+        disabled={status === "loading"}
+        onClick={onConnect}
+      >
+        {status === "loading" ? (
+          <>
+            <SpinLoader variant='segment' size={16} label='Connecting' />
+            Connecting…
+          </>
+        ) : (
+          "Connect through Cloud"
+        )}
+      </Button>
+      <span
+        className={error ? "text-[11.5px] text-destructive" : "text-[11.5px] text-muted-foreground"}
+      >
+        {error ?? "Your devices, read from your Starlink account until the router answers again."}
+      </span>
+    </div>
+  );
+}

--- a/src/components/network/DeviceDetail.tsx
+++ b/src/components/network/DeviceDetail.tsx
@@ -44,6 +44,7 @@ export function DeviceDetail({
   client,
   history,
   rates,
+  liveRatesAvailable,
   total,
   upstreamName,
   isThisDevice,
@@ -53,6 +54,10 @@ export function DeviceDetail({
   client: WifiClientJson;
   /** Live per-MAC rates from the hook's byte-delta tracker. */
   rates: Map<string, ThroughputRates>;
+  /** Whether that tracker is still being fed. It runs on the LAN, so a roster
+   *  sourced from the account has no current entry in it — only whatever it held
+   *  when the router last answered, which would be shown as if it were live. */
+  liveRatesAvailable: boolean;
   history: TelemetrySample[];
   /** This device's monthly usage from the historian's odometer, if it has one. */
   total?: ClientUsageTotal;
@@ -112,9 +117,10 @@ export function DeviceDetail({
   const name = displayName(client);
   // Byte-delta rate, so the headline number matches a speed test instead of the
   // router's 60-second average of it. Falls back until the second reading lands.
-  const liveRate = client.macAddress
-    ? rates.get(usageKey(client.clientId, client.macAddress))
-    : undefined;
+  const liveRate =
+    liveRatesAvailable && client.macAddress
+      ? rates.get(usageKey(client.clientId, client.macAddress))
+      : undefined;
   const downMbps = liveRate?.downMbps ?? throughputMbps(client.rxStats);
   const upMbps = liveRate?.upMbps ?? throughputMbps(client.txStats);
 

--- a/src/components/network/DeviceDetail.tsx
+++ b/src/components/network/DeviceDetail.tsx
@@ -16,8 +16,9 @@ import { DeviceSignalIcon } from "../../assets/icons/DeviceSignalIcon";
 import { DeviceThroughput } from "./DeviceThroughput";
 import { buildDeviceFacts } from "./deviceFacts";
 import { deviceRowSubtitle } from "./deviceRowSubtitle";
-import { displayName, signalQuality } from "./networkFormat";
+import { displayName, pauseSettleTimeoutMs, signalQuality } from "./networkFormat";
 import { Button } from "../ui/button";
+import { SpinLoader } from "../loaders/SpinLoader";
 import {
   AccountRequiredError,
   clientPauseControlAvailable,
@@ -34,17 +35,14 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 
-// The router's client roster is what says whether a pause landed, and it is polled
-// on its own 5s cadence. Holding the control pending until that roster agrees is
-// what keeps the label from flicking back through its old value in between. The
-// timeout is the backstop for a write the gateway accepts but never applies.
-const PAUSE_SETTLE_TIMEOUT_MS = 20_000;
-
 export function DeviceDetail({
   client,
   history,
   rates,
   liveRatesAvailable,
+  historianAnswering,
+  routerReachable,
+  rosterRefreshMs,
   total,
   upstreamName,
   isThisDevice,
@@ -58,6 +56,13 @@ export function DeviceDetail({
    *  sourced from the account has no current entry in it — only whatever it held
    *  when the router last answered, which would be shown as if it were live. */
   liveRatesAvailable: boolean;
+  /** The historian feeds the charts and the router feeds the roster, so an empty
+   *  chart has to name whichever of the two is silent. */
+  historianAnswering: boolean | null;
+  routerReachable: boolean | null;
+  /** How often the roster on screen is re-read, which is how long a pause can
+   *  take to be confirmed. */
+  rosterRefreshMs: number;
   history: TelemetrySample[];
   /** This device's monthly usage from the historian's odometer, if it has one. */
   total?: ClientUsageTotal;
@@ -95,11 +100,11 @@ export function DeviceDetail({
       setPauseError(
         new Error("The router has not applied this yet. Give it a moment, then try again."),
       );
-    }, PAUSE_SETTLE_TIMEOUT_MS);
+    }, pauseSettleTimeoutMs(rosterRefreshMs));
     return () => {
       window.clearTimeout(timer);
     };
-  }, [pendingPaused]);
+  }, [pendingPaused, rosterRefreshMs]);
 
   const applyPaused = async (next: boolean) => {
     if (client.clientId === undefined || pauseBusy || !showPauseControl) return;
@@ -121,8 +126,10 @@ export function DeviceDetail({
     liveRatesAvailable && client.macAddress
       ? rates.get(usageKey(client.clientId, client.macAddress))
       : undefined;
-  const downMbps = liveRate?.downMbps ?? throughputMbps(client.rxStats);
-  const upMbps = liveRate?.upMbps ?? throughputMbps(client.txStats);
+  const downMbps = liveRatesAvailable
+    ? (liveRate?.downMbps ?? throughputMbps(client.rxStats))
+    : null;
+  const upMbps = liveRatesAvailable ? (liveRate?.upMbps ?? throughputMbps(client.txStats)) : null;
 
   const facts = buildDeviceFacts({
     client,
@@ -175,20 +182,24 @@ export function DeviceDetail({
             <Button
               variant={paused ? "outline" : "secondary"}
               size='sm'
-              className='cursor-pointer disabled:cursor-not-allowed'
+              className='min-w-[5.5rem] cursor-pointer disabled:cursor-not-allowed disabled:opacity-100'
               disabled={pauseBusy}
               onClick={() => {
                 if (paused) void applyPaused(false);
                 else setConfirmingPause(true);
               }}
             >
-              {pauseBusy
-                ? pendingPaused
-                  ? "Pausing…"
-                  : "Unpausing…"
-                : paused
-                  ? "Unpause"
-                  : "Pause"}
+              {pauseBusy ? (
+                <SpinLoader
+                  variant='segment'
+                  size={16}
+                  label={pendingPaused ? "Pausing" : "Unpausing"}
+                />
+              ) : paused ? (
+                "Unpause"
+              ) : (
+                "Pause"
+              )}
             </Button>
           )}
         </div>
@@ -252,7 +263,13 @@ export function DeviceDetail({
 
       <DeviceFactsList facts={facts} />
 
-      <DeviceThroughput history={history} downMbps={downMbps} upMbps={upMbps} />
+      <DeviceThroughput
+        history={history}
+        downMbps={downMbps}
+        upMbps={upMbps}
+        historianAnswering={historianAnswering}
+        routerReachable={routerReachable}
+      />
     </div>
   );
 }

--- a/src/components/network/DeviceThroughput.tsx
+++ b/src/components/network/DeviceThroughput.tsx
@@ -26,11 +26,16 @@ export function DeviceThroughput({
   history,
   downMbps,
   upMbps,
+  historianAnswering,
+  routerReachable,
 }: {
   history: TelemetrySample[];
-  /** Live headline rates, shown above each chart. */
-  downMbps: number;
-  upMbps: number;
+  /** Live headline rates. Null where nothing is measuring them, which is not the
+   *  same as measuring zero. */
+  downMbps: number | null;
+  upMbps: number | null;
+  historianAnswering: boolean | null;
+  routerReachable: boolean | null;
 }) {
   const [windowMinutes, setWindowMinutes] = useState(15);
   const nowMs = useNow();
@@ -39,35 +44,46 @@ export function DeviceThroughput({
     () => windowTail(history, windowMinutes, nowMs),
     [history, windowMinutes, nowMs],
   );
+  const canDrawCharts = history.length >= 2 && chartHistory.length >= 2;
+  // Keyed on having nothing to show rather than on either feed's last answer, so
+  // one missed poll does not blink the tip out.
+  const recordingStopped =
+    !canDrawCharts && (historianAnswering === false || routerReachable === false);
 
   return (
     <>
       <SectionHeading title='Throughput'>
-        <InfoDot tip='How much data this device is transferring right now. Stream a video and watch it jump.' />
-        <SegmentedControl
-          options={WINDOW_OPTIONS}
-          value={String(windowMinutes)}
-          onChange={(minutes) => setWindowMinutes(Number(minutes))}
-          label='Chart time window'
-          className='ml-auto'
-        />
+        {!recordingStopped && (
+          <InfoDot tip='How much data this device is transferring right now. Stream a video and watch it jump.' />
+        )}
+        {history.length >= 2 && (
+          <SegmentedControl
+            options={WINDOW_OPTIONS}
+            value={String(windowMinutes)}
+            onChange={(minutes) => setWindowMinutes(Number(minutes))}
+            label='Chart time window'
+            className='ml-auto'
+          />
+        )}
       </SectionHeading>
-      {history.length < 2 ? (
+      {!canDrawCharts ? (
         <div className='text-[11.5px] font-medium text-muted-foreground py-3.5'>
-          Collecting live throughput… charts fill in as the router is polled (every 5 s).
+          {history.length < 2
+            ? noHistoryMessage(historianAnswering, routerReachable)
+            : outsideWindowMessage(windowMinutes)}
         </div>
       ) : (
         <>
           <DirectionChart
             label='Download'
-            liveBps={downMbps * 1_000_000}
+            liveBps={downMbps === null ? null : downMbps * 1_000_000}
             series={DOWNLOAD_SERIES}
             samples={chartHistory}
             windowMinutes={windowMinutes}
           />
           <DirectionChart
             label='Upload'
-            liveBps={upMbps * 1_000_000}
+            liveBps={upMbps === null ? null : upMbps * 1_000_000}
             series={UPLOAD_SERIES}
             samples={chartHistory}
             windowMinutes={windowMinutes}
@@ -78,6 +94,35 @@ export function DeviceThroughput({
   );
 }
 
+function outsideWindowMessage(windowMinutes: number): string {
+  const longestWindowMinutes = Number(WINDOW_OPTIONS[WINDOW_OPTIONS.length - 1].value);
+  const windowSpanLabel =
+    windowMinutes < 60
+      ? `${windowMinutes} minutes`
+      : `${windowMinutes / 60} hour${windowMinutes === 60 ? "" : "s"}`;
+  return windowMinutes >= longestWindowMinutes
+    ? `Nothing recorded for this device in the last ${windowSpanLabel}.`
+    : `Nothing recorded for this device in the last ${windowSpanLabel}. Its earlier readings are kept, so a longer window still has them.`;
+}
+
+function noHistoryMessage(
+  historianAnswering: boolean | null,
+  routerReachable: boolean | null,
+): string {
+  const noRecorder = historianAnswering === false;
+  const noRouter = routerReachable === false;
+  if (noRecorder && noRouter) {
+    return "No throughput history. The history recorder isn't running, and the router on your network can't be reached.";
+  }
+  if (noRecorder) {
+    return "No throughput history. The history recorder isn't running, so nothing is being recorded.";
+  }
+  if (noRouter) {
+    return "No throughput history. Per-device rates are read from the router on your network, which can't be reached right now.";
+  }
+  return "Collecting live throughput… charts fill in as the router is polled (every 5 s).";
+}
+
 function DirectionChart({
   label,
   liveBps,
@@ -86,7 +131,7 @@ function DirectionChart({
   windowMinutes,
 }: {
   label: string;
-  liveBps: number;
+  liveBps: number | null;
   series: ChartSeries[];
   samples: TelemetrySample[];
   windowMinutes: number;
@@ -96,7 +141,7 @@ function DirectionChart({
       <div className='mb-0.5 flex items-baseline justify-between'>
         <span className='text-[11.5px] font-medium text-muted-foreground'>{label}</span>
         <span className='font-mono tabular-nums text-[13px] text-right text-foreground [overflow-wrap:anywhere]'>
-          {formatThroughputLabel(liveBps)}
+          {liveBps === null ? "—" : formatThroughputLabel(liveBps)}
         </span>
       </div>
       <TelemetryChart

--- a/src/components/network/NetworkPanel.cloud.test.tsx
+++ b/src/components/network/NetworkPanel.cloud.test.tsx
@@ -231,6 +231,31 @@ test("given: the router answering again, should: bring the note back for the nex
   });
 });
 
+test("given: a roster on screen that has stopped refreshing, should: say so over the list", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  await render(
+    <NetworkPanel
+      network={{
+        ...network,
+        accountRosterStatus: "failed",
+        accountRosterError: "Couldn't reach your Starlink account.",
+      }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  await vi.waitFor(() => expect(document.body.textContent).toContain("Nanoleaf"), {
+    timeout: 8_000,
+  });
+  const text = document.body.textContent ?? "";
+  expect(text).toContain("Couldn't reach your Starlink account.");
+  // The caption must not keep promising a refresh that is not happening.
+  expect(text).toContain("no longer refreshing");
+  expect(text).not.toContain("refreshed every 20 s");
+});
+
 test("given: an account read that cannot leave this device, should: say so rather than sit there", async () => {
   setCloudHost({
     transport: async ({ path }) =>

--- a/src/components/network/NetworkPanel.cloud.test.tsx
+++ b/src/components/network/NetworkPanel.cloud.test.tsx
@@ -23,6 +23,11 @@ const network: RouterNetwork = {
   wifiConfig: null,
   routerReachable: false,
   clientsSource: "cloud",
+  historianAnswering: true,
+  readRosterViaAccount: () => {},
+  accountRosterStatus: "idle",
+  accountRosterError: null,
+  wifiConfigViaAccount: false,
   renameClient: async () => {},
   throughputHistory: new Map(),
   rates: new Map(),
@@ -51,6 +56,232 @@ test("given: a roster from the account, should: show the devices and name where 
   // The diagnosis is carried into that note rather than replacing the list.
   expect(text).toContain("The router isn't answering on this network.");
   expect(document.querySelector('[data-slot="callout"][data-tone="error"]')).toBeNull();
+});
+
+test("given: a device with no recorded series, should: name what is silent rather than promise a chart", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  const renderedPanel = await render(
+    <NetworkPanel
+      network={{ ...network, historianAnswering: false }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  await renderedPanel.getByText("Nanoleaf").click();
+
+  await vi.waitFor(() =>
+    expect(document.body.textContent).toContain("The history recorder isn't running"),
+  );
+  const text = document.body.textContent ?? "";
+  expect(text).toContain("the router on your network can't be reached");
+  expect(text).not.toContain("Collecting live throughput");
+});
+
+test("given: recorded readings older than the window, should: say so rather than draw a blank chart", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+  const twoHoursAgo = Date.now() - 2 * 60 * 60_000;
+  const sample = (timestampMs: number) => ({
+    timestampMs,
+    latencyMs: null,
+    dropRate: 0,
+    downlinkBps: 2_000_000,
+    uplinkBps: 100_000,
+    powerW: 0,
+    routerLatencyMs: null,
+    routerPingSuccessPercent: null,
+  });
+
+  const renderedPanel = await render(
+    <NetworkPanel
+      network={{
+        ...network,
+        historianAnswering: true,
+        throughputHistory: new Map([["7", [sample(twoHoursAgo), sample(twoHoursAgo + 1_000)]]]),
+      }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  await renderedPanel.getByText("Nanoleaf").click();
+
+  await vi.waitFor(() =>
+    expect(document.body.textContent).toContain("Nothing recorded for this device"),
+  );
+  const text = document.body.textContent ?? "";
+  expect(text).toContain("a longer window still has them");
+  expect(text).not.toContain("Collecting live throughput");
+  // The window picker is what acts on that, so it has to still be there.
+  expect(document.body.textContent).toContain("6H");
+});
+
+test("given: a live router whose recorder is down, should: blame the recorder alone", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  const renderedPanel = await render(
+    <NetworkPanel
+      network={{
+        ...network,
+        clientsSource: "lan",
+        routerReachable: true,
+        historianAnswering: false,
+      }}
+      unreachable={null}
+      onClose={() => {}}
+    />,
+  );
+
+  await renderedPanel.getByText("Nanoleaf").click();
+
+  await vi.waitFor(() =>
+    expect(document.body.textContent).toContain("so nothing is being recorded"),
+  );
+  expect(document.body.textContent ?? "").not.toContain("can't be reached");
+});
+
+test("given: a silent router and a connected account, should: offer the account read rather than take it", async () => {
+  setCloudHost({
+    transport: async ({ path }) =>
+      path === "/cloud/account"
+        ? { status: 200, body: { accountNumber: "ACC-1", serviceLines: [] } }
+        : { status: 404, body: {} },
+  });
+  const asked: number[] = [];
+
+  const renderedPanel = await render(
+    <NetworkPanel
+      network={{
+        ...network,
+        clients: [],
+        clientsSource: null,
+        readRosterViaAccount: () => asked.push(1),
+      }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  const offer = renderedPanel.getByText("Connect through Cloud");
+  await vi.waitFor(() => expect(offer.query()).not.toBeNull(), { timeout: 8_000 });
+  await offer.click();
+
+  expect(asked).toHaveLength(1);
+});
+
+test("given: the router still being checked, should: say so at once rather than wait out the silence", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  await render(
+    <NetworkPanel
+      network={{ ...network, clients: [], clientsSource: null }}
+      unreachable={{ cause: "checking", message: "Checking the router…" }}
+      onClose={() => {}}
+    />,
+  );
+
+  await vi.waitFor(() => expect(document.body.textContent).toContain("Checking the router"), {
+    timeout: 8_000,
+  });
+});
+
+test("given: a reader done with the account note, should: keep it dismissed across openings", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  const first = await render(
+    <NetworkPanel network={network} unreachable={unreachable} onClose={() => {}} />,
+  );
+  await vi.waitFor(() => expect(document.body.textContent).toContain("come from your Starlink"), {
+    timeout: 8_000,
+  });
+  await first.getByRole("button", { name: "Dismiss this note" }).click();
+  expect(document.body.textContent ?? "").not.toContain("come from your Starlink account");
+
+  await first.unmount();
+  await render(<NetworkPanel network={network} unreachable={unreachable} onClose={() => {}} />);
+
+  await vi.waitFor(() => expect(document.body.textContent).toContain("Nanoleaf"), {
+    timeout: 8_000,
+  });
+  expect(document.body.textContent ?? "").not.toContain("come from your Starlink account");
+  // The devices themselves are not what was waved away.
+  expect(document.body.textContent).toContain("via your Starlink account");
+});
+
+test("given: the router answering again, should: bring the note back for the next outage", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  const onLan = await render(
+    <NetworkPanel
+      network={{ ...network, clientsSource: "lan", routerReachable: true }}
+      unreachable={null}
+      onClose={() => {}}
+    />,
+  );
+  await vi.waitFor(() => expect(document.body.textContent).toContain("Nanoleaf"), {
+    timeout: 8_000,
+  });
+  await onLan.unmount();
+
+  await render(<NetworkPanel network={network} unreachable={unreachable} onClose={() => {}} />);
+
+  await vi.waitFor(() => expect(document.body.textContent).toContain("come from your Starlink"), {
+    timeout: 8_000,
+  });
+});
+
+test("given: an account read that cannot leave this device, should: say so rather than sit there", async () => {
+  setCloudHost({
+    transport: async ({ path }) =>
+      path === "/cloud/account"
+        ? { status: 200, body: { accountNumber: "ACC-1", serviceLines: [] } }
+        : { status: 404, body: {} },
+  });
+
+  await render(
+    <NetworkPanel
+      network={{
+        ...network,
+        clients: [],
+        clientsSource: null,
+        accountRosterStatus: "failed",
+        accountRosterError: "Couldn't reach your Starlink account.",
+      }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  await vi.waitFor(() =>
+    expect(document.body.textContent).toContain("Couldn't reach your Starlink account."),
+  );
+});
+
+test("given: an account read in flight, should: hold the control and show it working", async () => {
+  setCloudHost({
+    transport: async ({ path }) =>
+      path === "/cloud/account"
+        ? { status: 200, body: { accountNumber: "ACC-1", serviceLines: [] } }
+        : { status: 404, body: {} },
+  });
+
+  const renderedPanel = await render(
+    <NetworkPanel
+      network={{
+        ...network,
+        clients: [],
+        clientsSource: null,
+        accountRosterStatus: "loading",
+      }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  const working = renderedPanel.getByRole("status", { name: "Connecting" });
+  await vi.waitFor(() => expect(working.query()).not.toBeNull(), { timeout: 8_000 });
+  expect(renderedPanel.getByRole("button", { name: /Connecting/ }).query()).toBeDisabled();
 });
 
 test("given: the same silence with no account roster, should: show the error instead", async () => {

--- a/src/components/network/NetworkPanel.cloud.test.tsx
+++ b/src/components/network/NetworkPanel.cloud.test.tsx
@@ -253,7 +253,7 @@ test("given: a roster on screen that has stopped refreshing, should: say so over
   expect(text).toContain("Couldn't reach your Starlink account.");
   // The caption must not keep promising a refresh that is not happening.
   expect(text).toContain("no longer refreshing");
-  expect(text).not.toContain("refreshed every 20 s");
+  expect(text).not.toContain("refreshed every");
 });
 
 test("given: an account read that cannot leave this device, should: say so rather than sit there", async () => {

--- a/src/components/network/NetworkPanel.cloud.test.tsx
+++ b/src/components/network/NetworkPanel.cloud.test.tsx
@@ -1,0 +1,71 @@
+// What the panel shows when the roster came from the account: the devices, said
+// plainly to be from there — not the unreachable-router error that would
+// otherwise stand in their place.
+
+import { expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { NetworkPanel } from "./NetworkPanel";
+import type { RouterNetwork } from "../../hooks/useRouterNetwork";
+import { setCloudHost } from "../../lib/cloudHost";
+
+vi.mock("../../lib/routerStatusFeed", () => ({ subscribeRouterStatus: () => () => {} }));
+
+const network: RouterNetwork = {
+  clients: [
+    {
+      clientId: 7,
+      macAddress: "aa:bb:cc:XX:XX:XX",
+      givenName: "Nanoleaf",
+      ipAddress: "192.168.1.57",
+      role: "CLIENT",
+    },
+  ],
+  wifiConfig: null,
+  routerReachable: false,
+  clientsSource: "cloud",
+  renameClient: async () => {},
+  throughputHistory: new Map(),
+  rates: new Map(),
+  ratesAtRoster: new Map(),
+  totals: new Map(),
+  routerStatus: null,
+  refreshConfig: () => {},
+};
+
+const unreachable = {
+  cause: "differentNetwork" as const,
+  message: "The router isn't answering on this network.",
+};
+
+test("given: a roster from the account, should: show the devices and name where they came from", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  render(<NetworkPanel network={network} unreachable={unreachable} onClose={() => {}} />);
+
+  await vi.waitFor(() => expect(document.body.textContent).toContain("Nanoleaf"), {
+    timeout: 8_000,
+  });
+  const text = document.body.textContent ?? "";
+  expect(text).toContain("come from your Starlink account");
+  expect(text).toContain("via your Starlink account");
+  // The diagnosis is carried into that note rather than replacing the list.
+  expect(text).toContain("The router isn't answering on this network.");
+  expect(document.querySelector('[data-slot="callout"][data-tone="error"]')).toBeNull();
+});
+
+test("given: the same silence with no account roster, should: show the error instead", async () => {
+  setCloudHost({ transport: async () => ({ status: 428, body: {} }) });
+
+  render(
+    <NetworkPanel
+      network={{ ...network, clients: [], clientsSource: null }}
+      unreachable={unreachable}
+      onClose={() => {}}
+    />,
+  );
+
+  await vi.waitFor(
+    () => expect(document.querySelector('[data-slot="callout"][data-tone="error"]')).not.toBeNull(),
+    { timeout: 8_000 },
+  );
+});

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -147,6 +147,7 @@ function NetworkPanelBody({
       <DeviceDetail
         client={selected}
         rates={network.rates}
+        liveRatesAvailable={!viaCloud}
         total={network.totals.get(usageKey(selected.clientId, selected.macAddress))}
         history={
           network.throughputHistory.get(usageKey(selected.clientId, selected.macAddress)) || []

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -226,7 +226,8 @@ function NetworkPanelBody({
           }}
         >
           {unreachable ? `${unreachable.message} ` : ""}These devices come from your Starlink
-          account, so they refresh every 20&nbsp;s and carry no live throughput.
+          account, so they refresh every {CLOUD_CLIENTS_POLL_MS / 1000}&nbsp;s and carry no live
+          throughput.
         </Callout>
       )}
 
@@ -240,8 +241,8 @@ function NetworkPanelBody({
               viaCloud
                 ? network.accountRosterError
                   ? "via your Starlink account, no longer refreshing"
-                  : "via your Starlink account, refreshed every 20 s"
-                : "live from the router, refreshed every 5 s"
+                  : `via your Starlink account, refreshed every ${CLOUD_CLIENTS_POLL_MS / 1000} s`
+                : `live from the router, refreshed every ${CLIENTS_POLL_MS / 1000} s`
             }`}
           >
             {sortedDevices.map((client, index) => (

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -4,14 +4,25 @@
 // This file is the router: it owns the tab, resolves `selectedKey` to a node or
 // a device, and hands off. The rows and both detail views live beside it.
 
-import { useMemo, useState } from "react";
-import type { RouterNetwork } from "../../hooks/useRouterNetwork";
+import { useEffect, useMemo, useState } from "react";
+import {
+  CLIENTS_POLL_MS,
+  CLOUD_CLIENTS_POLL_MS,
+  type RouterNetwork,
+} from "../../hooks/useRouterNetwork";
 import { useRadioTemps } from "../../hooks/useRadioTemps";
 import { useSelfIdentity } from "../../hooks/useSelfIdentity";
+import { useRememberSelfDevice } from "../../hooks/useRememberSelfDevice";
 import { matchesSelf, selfIdentified } from "../../lib/selfIdentity";
 import { selfDeviceHost } from "../../lib/selfDeviceHost";
+import {
+  accountRosterNoticeDismissed,
+  setAccountRosterNoticeDismissed,
+} from "../../lib/accountRosterNotice";
 import { requestPanel } from "../../hooks/usePanelRouting";
 import { useCloudAccount } from "../../hooks/useCloudAccount";
+import { AccountRequiredNotice } from "../shared/AccountRequiredNotice";
+import { AccountRosterOffer } from "./AccountRosterOffer";
 import { inlineLinkButton } from "../ui/action-button";
 import type { RouterUnreachable } from "../../lib/routerDiagnosis";
 import { DetailsModal } from "../ui/details-modal";
@@ -79,6 +90,7 @@ function NetworkPanelBody({
   const radio = useRadioTemps();
   // The viewer's own address(es), to flag "This device" in the list.
   const { self, resolved: selfResolved } = useSelfIdentity();
+  useRememberSelfDevice(network.clients, network.clientsSource, self);
   // The odometer's records, for the split-record question below the device list.
   // The rows themselves come from the router and know nothing about stored totals.
   const { totals, mergeCandidates, writeError, answerMerge } = useClientTotals();
@@ -90,6 +102,13 @@ function NetworkPanelBody({
 
   /** The LAN is silent and the account is answering in its place. */
   const viaCloud = network.clientsSource === "cloud";
+  const [noticeDismissed, setNoticeDismissed] = useState(accountRosterNoticeDismissed);
+  // The router answering again retires the dismissal, so the next outage is
+  // surfaced as the fresh event it is rather than inheriting an older answer.
+  if (noticeDismissed && network.clientsSource === "lan") setNoticeDismissed(false);
+  useEffect(() => {
+    if (network.clientsSource === "lan") setAccountRosterNoticeDismissed(false);
+  }, [network.clientsSource]);
 
   const devices = useMemo(() => network.clients.filter(isClientDevice), [network.clients]);
   // The viewer's own device pins to the top (like the app), then by throughput.
@@ -118,7 +137,22 @@ function NetworkPanelBody({
   // it IS this list, from the one reader that still reaches the router. So the
   // silence is explained above the devices rather than shown instead of them.
   if (unreachable && !viaCloud) {
-    return <Callout tone='error'>{unreachable.message}</Callout>;
+    return (
+      <div>
+        <Callout tone='error'>{unreachable.message}</Callout>
+        {needsAccount ? (
+          <div className='mt-3 text-[12.5px] text-muted-foreground'>
+            <AccountRequiredNotice />
+          </div>
+        ) : (
+          <AccountRosterOffer
+            status={network.accountRosterStatus}
+            error={network.accountRosterError}
+            onConnect={network.readRosterViaAccount}
+          />
+        )}
+      </div>
+    );
   }
 
   const nodes = buildNodeRoster(network.clients, network.wifiConfig);
@@ -148,6 +182,9 @@ function NetworkPanelBody({
         client={selected}
         rates={network.rates}
         liveRatesAvailable={!viaCloud}
+        historianAnswering={network.historianAnswering}
+        routerReachable={network.routerReachable}
+        rosterRefreshMs={viaCloud ? CLOUD_CLIENTS_POLL_MS : CLIENTS_POLL_MS}
         total={network.totals.get(usageKey(selected.clientId, selected.macAddress))}
         history={
           network.throughputHistory.get(usageKey(selected.clientId, selected.macAddress)) || []
@@ -178,8 +215,16 @@ function NetworkPanelBody({
 
       {/* Above both tabs: everything under them is coming from the account, not
           from the router on this network. */}
-      {viaCloud && (
-        <Callout tone='info' className='mb-2.5'>
+      {viaCloud && !noticeDismissed && (
+        <Callout
+          tone='info'
+          className='mb-2.5'
+          dismissLabel='Dismiss this note'
+          onDismiss={() => {
+            setAccountRosterNoticeDismissed(true);
+            setNoticeDismissed(true);
+          }}
+        >
           {unreachable ? `${unreachable.message} ` : ""}These devices come from your Starlink
           account, so they refresh every 20&nbsp;s and carry no live throughput.
         </Callout>

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -88,6 +88,9 @@ function NetworkPanelBody({
   const needsAccount = cloudStatus !== "loading" && cloudStatus !== "ready";
   const needsSelfDevice = selfDeviceHost() !== null && selfResolved && !selfIdentified(self);
 
+  /** The LAN is silent and the account is answering in its place. */
+  const viaCloud = network.clientsSource === "cloud";
+
   const devices = useMemo(() => network.clients.filter(isClientDevice), [network.clients]);
   // The viewer's own device pins to the top (like the app), then by throughput.
   //
@@ -110,7 +113,11 @@ function NetworkPanelBody({
   }
   // Branch on the diagnosis rather than on `routerReachable` again: it is
   // derived from that same flag, so this cannot render an empty callout.
-  if (unreachable) {
+  //
+  // A roster read through the account is not a degraded stand-in for this list —
+  // it IS this list, from the one reader that still reaches the router. So the
+  // silence is explained above the devices rather than shown instead of them.
+  if (unreachable && !viaCloud) {
     return <Callout tone='error'>{unreachable.message}</Callout>;
   }
 
@@ -168,10 +175,23 @@ function NetworkPanelBody({
         ]}
       />
 
+      {/* Above both tabs: everything under them is coming from the account, not
+          from the router on this network. */}
+      {viaCloud && (
+        <Callout tone='info' className='mb-2.5'>
+          {unreachable ? `${unreachable.message} ` : ""}These devices come from your Starlink
+          account, so they refresh every 20&nbsp;s and carry no live throughput.
+        </Callout>
+      )}
+
       {tab === "connected" && (
         <>
           <ListSection
-            caption={`${devices.length} device${devices.length === 1 ? "" : "s"} · live from the router, refreshed every 5 s`}
+            caption={`${devices.length} device${devices.length === 1 ? "" : "s"} · ${
+              viaCloud
+                ? "via your Starlink account, refreshed every 20 s"
+                : "live from the router, refreshed every 5 s"
+            }`}
           >
             {sortedDevices.map((client, index) => (
               <DeviceRow

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -232,10 +232,15 @@ function NetworkPanelBody({
 
       {tab === "connected" && (
         <>
+          {viaCloud && network.accountRosterError && (
+            <div className='mb-2 text-[11.5px] text-destructive'>{network.accountRosterError}</div>
+          )}
           <ListSection
             caption={`${devices.length} device${devices.length === 1 ? "" : "s"} · ${
               viaCloud
-                ? "via your Starlink account, refreshed every 20 s"
+                ? network.accountRosterError
+                  ? "via your Starlink account, no longer refreshing"
+                  : "via your Starlink account, refreshed every 20 s"
                 : "live from the router, refreshed every 5 s"
             }`}
           >

--- a/src/components/network/networkFormat.test.ts
+++ b/src/components/network/networkFormat.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { pauseSettleTimeoutMs } from "./networkFormat";
+import { CLIENTS_POLL_MS, CLOUD_CLIENTS_POLL_MS } from "../../hooks/useRouterNetwork";
+
+describe("pauseSettleTimeoutMs", () => {
+  it("outlasts two reads of the roster that has to confirm the write", () => {
+    expect(pauseSettleTimeoutMs(CLOUD_CLIENTS_POLL_MS)).toBeGreaterThan(CLOUD_CLIENTS_POLL_MS * 2);
+  });
+
+  it("holds the floor where the roster is fast enough not to need it", () => {
+    expect(pauseSettleTimeoutMs(CLIENTS_POLL_MS)).toBe(20_000);
+  });
+});

--- a/src/components/network/networkFormat.ts
+++ b/src/components/network/networkFormat.ts
@@ -25,6 +25,13 @@ export const WINDOW_OPTIONS = [
   { label: "6H", value: "360" },
 ];
 
+/** How long to hold a pause control pending before calling the write unapplied.
+ *  The roster is what confirms it landed, so a deadline shorter than the roster's
+ *  own cadence reports a failure the very next read denies. */
+export function pauseSettleTimeoutMs(rosterRefreshMs: number): number {
+  return Math.max(20_000, rosterRefreshMs * 2 + 5_000);
+}
+
 export function bandLabel(client: WifiClientJson): string {
   const iface = client.iface ?? "";
   if (iface === "ETH") return "Ethernet";

--- a/src/components/settings/RouterSettingsTab.tsx
+++ b/src/components/settings/RouterSettingsTab.tsx
@@ -50,11 +50,16 @@ function controllerBypassed(account: CloudAccount | null): boolean | null {
 export function RouterSettingsTab({
   wifiConfig,
   routerReachable,
+  viaAccount,
   unreachable,
   onConfigChanged,
 }: {
   wifiConfig: WifiNetworkConfigJson | null;
   routerReachable: boolean | null;
+  /** Whether `wifiConfig` was read through the account because the LAN could not
+   *  serve it. What it says is the same either way; what still cannot be done
+   *  from here is anything that dials the router directly. */
+  viaAccount: boolean;
   /** Why the router is silent, when it is. Null while it is answering. */
   unreachable: RouterUnreachable | null;
   /** For a write that leaves the router up, which nothing else would re-read.
@@ -71,16 +76,20 @@ export function RouterSettingsTab({
   // Read from the account rather than the router: a bypassed router answers
   // nothing on the LAN, so `wifiConfig` is silent exactly when the answer is yes.
   const bypassed = controllerBypassed(account.data);
-  // The account is asked only when the router itself cannot answer, which costs a
-  // round trip to Starlink for something the LAN gives away.
-  const lanSubnet = wifiConfig?.networks?.[0]?.ipv4 ?? null;
+  // Whichever read landed already carries it; the dedicated subnet route is only
+  // for when neither did.
+  const configSubnet = wifiConfig?.networks?.[0]?.ipv4 ?? null;
   const { data: cloudSubnet, reload: rereadCloudSubnet } = useCloudRouterSubnet(
-    accountConnected && lanSubnet === null,
+    accountConnected && configSubnet === null,
   );
   // Only the rows that ask the router something wait on it. The address is how a
   // silent router gets found again, so it stays live through every state below.
   const answering = routerReachable !== null && !unreachable && wifiConfig !== null;
-  const showDns = answering && !wifiConfig?.customDnsDisabled;
+  // What the config says is worth showing however it arrived — and the writes
+  // beside it go through the account, not the LAN, so they were never waiting on
+  // the router to answer here in the first place.
+  const configKnown = wifiConfig !== null && (answering || viaAccount);
+  const showDns = configKnown && !wifiConfig?.customDnsDisabled;
 
   return (
     <>
@@ -89,7 +98,7 @@ export function RouterSettingsTab({
           derived from that same flag, so this cannot render an empty callout. */}
       {unreachable && <Callout tone='error'>{unreachable.message}</Callout>}
 
-      {answering && (
+      {configKnown && (
         <>
           <SectionLabel>Networks</SectionLabel>
           {ssids.map(([ssid, bands]) => (
@@ -179,7 +188,7 @@ export function RouterSettingsTab({
         )}
         <SectionLabel>Network</SectionLabel>
         <SubnetSection
-          currentSubnet={lanSubnet ?? cloudSubnet}
+          currentSubnet={configSubnet ?? cloudSubnet}
           disabled={!accountConnected}
           onSave={async (subnet, password) => {
             await applyRouterConfigUpdate({ kind: "subnet", password, subnet });

--- a/src/components/settings/RouterSettingsTab.tsx
+++ b/src/components/settings/RouterSettingsTab.tsx
@@ -97,6 +97,14 @@ export function RouterSettingsTab({
       {/* Branch on the diagnosis rather than on `routerReachable` again: it is
           derived from that same flag, so this cannot render an empty callout. */}
       {unreachable && <Callout tone='error'>{unreachable.message}</Callout>}
+      {/* Populated sections under that error would otherwise read as if the
+          router were answering after all. */}
+      {viaAccount && (
+        <Callout tone='info' className='mt-2.5'>
+          What follows is read through your Starlink account. Anything that dials the router
+          directly — a reboot — stays unavailable until it answers here.
+        </Callout>
+      )}
 
       {configKnown && (
         <>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -25,6 +25,8 @@ interface SettingsModalProps {
   wifiConfig: WifiNetworkConfigJson | null;
   clients: WifiClientJson[];
   routerReachable: boolean | null;
+  /** Whether the router's config was read through the account rather than the LAN. */
+  routerViaAccount: boolean;
   routerUnreachable: RouterUnreachable | null;
   /** Ask the poller to re-read the router config after a write changed it. */
   onRouterConfigChanged: () => void;
@@ -39,6 +41,7 @@ export function SettingsModal({
   wifiConfig,
   clients,
   routerReachable,
+  routerViaAccount,
   routerUnreachable,
   onRouterConfigChanged,
   initialTab = "starlink",
@@ -137,6 +140,7 @@ export function SettingsModal({
               <RouterSettingsTab
                 wifiConfig={wifiConfig}
                 routerReachable={routerReachable}
+                viaAccount={routerViaAccount}
                 unreachable={routerUnreachable}
                 onConfigChanged={onRouterConfigChanged}
               />

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -42,10 +42,22 @@ interface CalloutProps extends VariantProps<typeof callout> {
   /** The glyph, for a warning that is not a failure: the triangle without the
    *  red box behind it. Defaults to the one the tone implies. */
   icon?: keyof typeof GLYPH;
+  /** Given only where the reader can be done with this for good. A message they
+   *  still need is not dismissible. */
+  onDismiss?: () => void;
+  dismissLabel?: string;
   className?: string;
 }
 
-export function Callout({ children, tone, iconSeverity, icon, className }: CalloutProps) {
+export function Callout({
+  children,
+  tone,
+  iconSeverity,
+  icon,
+  onDismiss,
+  dismissLabel = "Dismiss",
+  className,
+}: CalloutProps) {
   const resolvedTone = tone ?? "info";
   // A broken thing is never quieter than its box, so the error tone settles this.
   const severity = resolvedTone === "error" ? "danger" : (iconSeverity ?? "normal");
@@ -61,6 +73,16 @@ export function Callout({ children, tone, iconSeverity, icon, className }: Callo
         {GLYPH[icon ?? (resolvedTone === "error" ? "warning" : "note")]}
       </SeverityIcon>
       <span>{children}</span>
+      {onDismiss && (
+        <button
+          type='button'
+          aria-label={dismissLabel}
+          onClick={onDismiss}
+          className='-my-0.5 -mr-1 ml-auto inline-flex h-[22px] w-[22px] flex-none cursor-pointer items-center justify-center rounded-[999px] border-0 bg-transparent text-[11px] text-ink-secondary/70 hover:bg-[color-mix(in_srgb,var(--ink)_7%,transparent)] hover:text-ink'
+        >
+          ✕
+        </button>
+      )}
     </div>
   );
 }

--- a/src/hooks/useRememberSelfDevice.test.tsx
+++ b/src/hooks/useRememberSelfDevice.test.tsx
@@ -1,0 +1,58 @@
+// The id is learned from a LAN roster and only from a LAN roster, because that is
+// the only reading where this machine's own addresses mean anything.
+
+import { afterEach, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { useRememberSelfDevice } from "./useRememberSelfDevice";
+import type { SelfIdentity } from "../lib/selfIdentity";
+
+const bridgeHost = globalThis as { dishlink?: unknown };
+afterEach(() => {
+  delete bridgeHost.dishlink;
+});
+
+function remembered(): number[] {
+  const calls: number[] = [];
+  bridgeHost.dishlink = {
+    rememberSelfDevice: (clientId: number) => {
+      calls.push(clientId);
+      return Promise.resolve();
+    },
+  };
+  return calls;
+}
+
+const roster = [
+  { clientId: 7, macAddress: "aa:bb:cc:XX:XX:XX", ipAddress: "192.168.1.5" },
+  { clientId: 8, macAddress: "dd:ee:ff:XX:XX:XX", ipAddress: "192.168.1.6" },
+];
+
+const self: SelfIdentity = { ips: ["192.168.1.6"], macs: [], describesHost: true };
+
+function Probe({ source }: { source: "lan" | "cloud" }) {
+  useRememberSelfDevice(roster, source, self);
+  return <span>probe</span>;
+}
+
+test("given: a LAN roster carrying this machine, should: hand its id to the host", async () => {
+  const calls = remembered();
+
+  await render(<Probe source='lan' />);
+
+  await vi.waitFor(() => expect(calls).toEqual([8]));
+});
+
+test("given: the same roster read through the account, should: record nothing", async () => {
+  const calls = remembered();
+
+  await render(<Probe source='cloud' />);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(calls).toEqual([]);
+});
+
+test("given: no host to tell, should: leave the roster alone rather than throw", async () => {
+  await render(<Probe source='lan' />);
+
+  expect(document.body.textContent).toContain("probe");
+});

--- a/src/hooks/useRememberSelfDevice.ts
+++ b/src/hooks/useRememberSelfDevice.ts
@@ -1,0 +1,23 @@
+// Records which roster entry this machine is, while the LAN can still prove it.
+// Off the router's network there is no address to match on, so the self-pause
+// refusal in the host process depends on that answer having been kept.
+
+import { useEffect, useRef } from "react";
+import type { WifiClientJson } from "@core/dishClient";
+import { matchesSelfByAddress, rememberSelfDevice, type SelfIdentity } from "../lib/selfIdentity";
+
+export function useRememberSelfDevice(
+  clients: WifiClientJson[],
+  clientsSource: "lan" | "cloud" | null,
+  self: SelfIdentity,
+): void {
+  const lastRecordedClientId = useRef<number | null>(null);
+  useEffect(() => {
+    // Only a LAN roster pairs with this machine's own addresses.
+    if (clientsSource !== "lan") return;
+    const own = clients.find((client) => matchesSelfByAddress(client, self));
+    if (own?.clientId === undefined || own.clientId === lastRecordedClientId.current) return;
+    lastRecordedClientId.current = own.clientId;
+    rememberSelfDevice(own.clientId);
+  }, [clients, clientsSource, self]);
+}

--- a/src/hooks/useRouterNetwork.test.tsx
+++ b/src/hooks/useRouterNetwork.test.tsx
@@ -1,0 +1,96 @@
+// The fallback the user actually sees: the LAN router says nothing, and the
+// roster arrives from the account instead — labelled as such, with the live
+// per-device rates withheld because nothing is feeding them.
+//
+// In real Chromium rather than the node project because the hook renders: the
+// effects, their cleanup, and the state they publish are the behaviour under
+// test, and only a real commit exercises them in order.
+
+import { expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { useRouterNetwork } from "./useRouterNetwork";
+import { setCloudHost } from "../lib/cloudHost";
+
+// A router that answers nothing, which is what a bypassed kit — or a viewer on
+// another network — has in front of it.
+vi.mock("@core/dishClient", () => ({
+  DishClient: {
+    load: async () => ({
+      getWifiClients: async () => {
+        throw new Error("router unreachable");
+      },
+      getWifiConfig: async () => {
+        throw new Error("router unreachable");
+      },
+    }),
+  },
+}));
+
+// The shared status poll is a separate feed with its own timer; it has nothing
+// to say about where the roster came from.
+vi.mock("../lib/routerStatusFeed", () => ({ subscribeRouterStatus: () => () => {} }));
+
+const CLOUD_ROSTER = [
+  {
+    clientId: 7,
+    macAddress: "aa:bb:cc:XX:XX:XX",
+    givenName: "Nanoleaf",
+    ipAddress: "192.168.1.57",
+  },
+];
+
+function Probe() {
+  const network = useRouterNetwork(true);
+  return (
+    <div>
+      <span data-testid='source'>{network.clientsSource ?? "none"}</span>
+      <span data-testid='reachable'>{String(network.routerReachable)}</span>
+      <span data-testid='names'>{network.clients.map((c) => c.givenName).join(",")}</span>
+      <span data-testid='country'>{network.wifiConfig?.countryCode ?? "-"}</span>
+    </div>
+  );
+}
+
+const read = (id: string) => document.querySelector(`[data-testid="${id}"]`)?.textContent;
+
+test("given: a silent LAN router and a connected account, should: serve the roster from the account", async () => {
+  const asked: string[] = [];
+  setCloudHost({
+    transport: async ({ path }) => {
+      asked.push(path);
+      if (path === "/cloud/router-clients") return { status: 200, body: { clients: CLOUD_ROSTER } };
+      if (path === "/cloud/router-config")
+        return { status: 200, body: { wifiConfig: { countryCode: "US" } } };
+      return { status: 404, body: {} };
+    },
+  });
+
+  render(<Probe />);
+
+  await vi.waitFor(() => expect(read("source")).toBe("cloud"), { timeout: 8_000 });
+  // The LAN verdict stays honest — the roster is standing in for it, not
+  // pretending the router came back.
+  expect(read("reachable")).toBe("false");
+  expect(read("names")).toBe("Nanoleaf");
+  // Config rides along, so the names and mesh the panels read are not left empty.
+  await vi.waitFor(() => expect(read("country")).toBe("US"), { timeout: 8_000 });
+  // Once per stretch of fallback, not once per roster poll.
+  expect(asked.filter((path) => path === "/cloud/router-config")).toHaveLength(1);
+});
+
+test("given: no account session, should: leave the roster empty rather than retry blindly", async () => {
+  let asks = 0;
+  setCloudHost({
+    transport: async () => {
+      asks++;
+      return { status: 428, body: { error: "not_connected" } };
+    },
+  });
+
+  render(<Probe />);
+
+  await vi.waitFor(() => expect(read("reachable")).toBe("false"), { timeout: 8_000 });
+  await vi.waitFor(() => expect(asks).toBeGreaterThan(0), { timeout: 8_000 });
+  expect(read("source")).toBe("none");
+  expect(read("names")).toBe("");
+});

--- a/src/hooks/useRouterNetwork.test.tsx
+++ b/src/hooks/useRouterNetwork.test.tsx
@@ -6,6 +6,7 @@
 // effects, their cleanup, and the state they publish are the behaviour under
 // test, and only a real commit exercises them in order.
 
+import { useEffect } from "react";
 import { expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { useRouterNetwork } from "./useRouterNetwork";
@@ -39,8 +40,12 @@ const CLOUD_ROSTER = [
   },
 ];
 
-function Probe() {
+function Probe({ askForAccountRoster = true }: { askForAccountRoster?: boolean } = {}) {
   const network = useRouterNetwork(true);
+  const { readRosterViaAccount } = network;
+  useEffect(() => {
+    if (askForAccountRoster) readRosterViaAccount();
+  }, [askForAccountRoster, readRosterViaAccount]);
   return (
     <div>
       <span data-testid='source'>{network.clientsSource ?? "none"}</span>
@@ -76,6 +81,27 @@ test("given: a silent LAN router and a connected account, should: serve the rost
   await vi.waitFor(() => expect(read("country")).toBe("US"), { timeout: 8_000 });
   // Once per stretch of fallback, not once per roster poll.
   expect(asked.filter((path) => path === "/cloud/router-config")).toHaveLength(1);
+});
+
+test("given: a silent LAN nobody has asked to work around, should: read the config but not the roster", async () => {
+  const asked: string[] = [];
+  setCloudHost({
+    transport: async ({ path }) => {
+      asked.push(path);
+      if (path === "/cloud/router-clients") return { status: 200, body: { clients: CLOUD_ROSTER } };
+      if (path === "/cloud/router-config")
+        return { status: 200, body: { wifiConfig: { countryCode: "US" } } };
+      return { status: 404, body: {} };
+    },
+  });
+
+  render(<Probe askForAccountRoster={false} />);
+
+  // The settings reading these never asked for anything and must not go dark.
+  await vi.waitFor(() => expect(read("country")).toBe("US"), { timeout: 8_000 });
+  expect(asked).not.toContain("/cloud/router-clients");
+  expect(read("source")).toBe("none");
+  expect(read("names")).toBe("");
 });
 
 test("given: no account session, should: leave the roster empty rather than retry blindly", async () => {

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -44,12 +44,12 @@ const SAMPLES_POLL_MS = 1_000;
 /**
  * How often the roster is asked of the account, once the LAN cannot answer.
  *
- * Far slower than the LAN's 5s on purpose: each poll is a round trip to
- * starlink.com and back down to the router, and it exists to keep a list of
- * devices readable — not to drive anything live. The 1 Hz per-device throughput
- * stays LAN-only for the same reason.
+ * Slower than the LAN's 5s: each poll is a round trip to starlink.com and back
+ * down to the router, and it exists to keep a list of devices readable, not to
+ * drive anything live. The 1 Hz per-device throughput stays LAN-only for the
+ * same reason. It runs only while a router-backed panel is open.
  */
-export const CLOUD_CLIENTS_POLL_MS = 20_000;
+export const CLOUD_CLIENTS_POLL_MS = 15_000;
 
 /** How many 1 Hz tails between asks for the monthly totals. They are a list of
  *  every device, and a month's odometer does not move meaningfully inside a

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -2,6 +2,11 @@
 // dish, /router proxy) for the connected-client list plus the WiFi config
 // (SSIDs, mesh nodes, saved device names). Polled only while a router-backed
 // surface (Network panel or Settings modal) is open.
+//
+// When that endpoint is silent — a kit in bypass, a viewer somewhere else — the
+// same two reads are made through the user's Starlink account instead, which
+// reaches the router without going near this network. Slower, and without the
+// per-device throughput, but the roster is the roster.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -14,8 +19,14 @@ import type { ThroughputRates } from "@core/throughputTracker";
 import type { TelemetrySample } from "@core/telemetry";
 import { usageKey, type ClientUsageTotal } from "@core/clientUsage";
 import { apiRequest } from "../lib/apiHost";
+import { subscribeCloudSession } from "../lib/cloudHost";
 import { setRouterClientName } from "../lib/routerClientUpdate";
 import { subscribeRouterStatus } from "../lib/routerStatusFeed";
+import {
+  CloudNotConnectedError,
+  fetchCloudRouterClients,
+  fetchCloudRouterConfig,
+} from "../lib/starlinkCloud";
 
 // Roster only — names, signal, addresses, link rates. These change on the order
 // of minutes, so there is nothing to gain from asking faster.
@@ -29,6 +40,16 @@ const CLIENTS_POLL_MS = 5_000;
 
 /** Tail of the historian's 1 Hz window — small, incremental, purely local. */
 const SAMPLES_POLL_MS = 1_000;
+
+/**
+ * How often the roster is asked of the account, once the LAN cannot answer.
+ *
+ * Far slower than the LAN's 5s on purpose: each poll is a round trip to
+ * starlink.com and back down to the router, and it exists to keep a list of
+ * devices readable — not to drive anything live. The 1 Hz per-device throughput
+ * stays LAN-only for the same reason.
+ */
+const CLOUD_CLIENTS_POLL_MS = 20_000;
 
 /** How many 1 Hz tails between asks for the monthly totals. They are a list of
  *  every device, and a month's odometer does not move meaningfully inside a
@@ -216,6 +237,15 @@ export interface RouterNetwork {
   clients: WifiClientJson[];
   wifiConfig: WifiNetworkConfigJson | null;
   routerReachable: boolean | null; // null = still probing
+  /**
+   * Where the roster on screen came from, or null before either source has
+   * answered.
+   *
+   * "cloud" is not a lesser copy of the same thing — it is the same list read
+   * through the account — but it arrives every 20s and carries no per-device
+   * throughput series, so a surface showing rates has to say which it is holding.
+   */
+  clientsSource: "lan" | "cloud" | null;
   /** Rename a device on the router (persists across reconnects). */
   renameClient: (clientId: number, givenName: string) => Promise<void>;
   /** Rolling per-MAC throughput samples (down/up in bps) built from each poll. */
@@ -242,6 +272,10 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
   const [clients, setClients] = useState<WifiClientJson[]>([]);
   const [wifiConfig, setWifiConfig] = useState<WifiNetworkConfigJson | null>(null);
   const [routerReachable, setRouterReachable] = useState<boolean | null>(null);
+  const [clientsSource, setClientsSource] = useState<"lan" | "cloud" | null>(null);
+  /** Bumped on connect/disconnect, so a fallback that gave up for want of a
+   *  session starts again the moment there is one. */
+  const [cloudSession, setCloudSession] = useState(0);
   const [throughputHistory, setThroughputHistory] = useState<Map<string, TelemetrySample[]>>(
     new Map(),
   );
@@ -305,6 +339,7 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
             const clientList = await routerClient.getWifiClients(AbortSignal.timeout(4_000));
             if (disposed) return;
             setClients(clientList);
+            setClientsSource("lan");
             // Captured with the roster, not read later: the pair is what an
             // ordering is taken from, and rates replace their map rather than
             // mutating it, so this stays the set that arrived with this roster.
@@ -408,6 +443,57 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
     return subscribeRouterStatus((snapshot) => setRouterStatus(snapshot.status));
   }, [active]);
 
+  useEffect(() => subscribeCloudSession(() => setCloudSession((count) => count + 1)), []);
+
+  /**
+   * Read the roster through the account while the LAN cannot serve it.
+   *
+   * The router reports its devices to Starlink whether or not this machine can
+   * reach it, so the two cases the LAN read simply cannot cover — a kit in
+   * bypass, and a viewer away from the network — are answered here. Runs only
+   * while the LAN is silent: the local read is faster, free, and carries the
+   * throughput this one does not.
+   */
+  useEffect(() => {
+    if (!active || routerReachable !== false) return;
+    let disposed = false;
+    let inFlight = false;
+    let configRead = false;
+    let timerId = 0;
+
+    const poll = async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const roster = await fetchCloudRouterClients();
+        if (disposed) return;
+        setClients(roster);
+        setClientsSource("cloud");
+        // Once per stretch of cloud fallback, not per poll: names, SSIDs and mesh
+        // nodes change when the user changes them, and each read is a second trip
+        // through the account. `refreshConfig` covers a change made from here.
+        if (!configRead) {
+          configRead = true;
+          const config = await fetchCloudRouterConfig().catch(() => null);
+          if (!disposed && config) setWifiConfig(config);
+        }
+      } catch (error) {
+        // No session to ask with — stop rather than retry something only a
+        // sign-in can fix. Connecting one bumps `cloudSession` and re-runs this.
+        if (error instanceof CloudNotConnectedError) window.clearInterval(timerId);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    void poll();
+    timerId = window.setInterval(() => void poll(), CLOUD_CLIENTS_POLL_MS);
+    return () => {
+      disposed = true;
+      window.clearInterval(timerId);
+    };
+  }, [active, routerReachable, cloudSession]);
+
   const renameClient = useCallback(async (clientId: number, givenName: string) => {
     // Current firmware answers every LAN write with grpc status 7, so this goes
     // through the account session like the other router writes — see LOCAL-API.md.
@@ -418,12 +504,23 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
     );
   }, []);
 
-  const refreshConfig = useCallback(() => readConfigRef.current(), []);
+  const refreshConfig = useCallback(() => {
+    // Re-read from whatever is actually serving this roster: the LAN reader is
+    // silent in exactly the case the fallback exists for.
+    if (clientsSource === "cloud") {
+      void fetchCloudRouterConfig()
+        .then((config) => config && setWifiConfig(config))
+        .catch(() => {});
+      return;
+    }
+    readConfigRef.current();
+  }, [clientsSource]);
 
   return {
     clients,
     wifiConfig,
     routerReachable,
+    clientsSource,
     renameClient,
     throughputHistory,
     rates,

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -36,7 +36,7 @@ import {
 // the browser meant two pollers hitting the router every second and two
 // independent trackers, each able to land on the router's stats-refresh boundary
 // differently. One recorder, read by every tab, is both cheaper and consistent.
-const CLIENTS_POLL_MS = 5_000;
+export const CLIENTS_POLL_MS = 5_000;
 
 /** Tail of the historian's 1 Hz window — small, incremental, purely local. */
 const SAMPLES_POLL_MS = 1_000;
@@ -49,7 +49,7 @@ const SAMPLES_POLL_MS = 1_000;
  * devices readable — not to drive anything live. The 1 Hz per-device throughput
  * stays LAN-only for the same reason.
  */
-const CLOUD_CLIENTS_POLL_MS = 20_000;
+export const CLOUD_CLIENTS_POLL_MS = 20_000;
 
 /** How many 1 Hz tails between asks for the monthly totals. They are a list of
  *  every device, and a month's odometer does not move meaningfully inside a
@@ -246,6 +246,21 @@ export interface RouterNetwork {
    * throughput series, so a surface showing rates has to say which it is holding.
    */
   clientsSource: "lan" | "cloud" | null;
+  /** Start reading the roster through the account. Lasts one outage: the LAN
+   *  answering ends it, so the next silence asks again. */
+  readRosterViaAccount: () => void;
+  /** Whether the config on screen was read through the account because the LAN
+   *  could not serve it. Independent of `clientsSource`: the config is fetched
+   *  whenever the LAN is silent, the roster only when asked for. */
+  wifiConfigViaAccount: boolean;
+  /** How that read is going, for the control that asked for it. */
+  accountRosterStatus: "idle" | "loading" | "failed";
+  /** Why it failed, in words for the user. Null unless it did. */
+  accountRosterError: string | null;
+  /** Whether the historian answered its last tail, null before the first one. It
+   *  serves the series and the router serves the roster, so this is not
+   *  `routerReachable`. */
+  historianAnswering: boolean | null;
   /** Rename a device on the router (persists across reconnects). */
   renameClient: (clientId: number, givenName: string) => Promise<void>;
   /** Rolling per-MAC throughput samples (down/up in bps) built from each poll. */
@@ -273,6 +288,10 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
   const [wifiConfig, setWifiConfig] = useState<WifiNetworkConfigJson | null>(null);
   const [routerReachable, setRouterReachable] = useState<boolean | null>(null);
   const [clientsSource, setClientsSource] = useState<"lan" | "cloud" | null>(null);
+  const [historianAnswering, setHistorianAnswering] = useState<boolean | null>(null);
+  const [accountRosterRequested, setAccountRosterRequested] = useState(false);
+  const [accountRosterError, setAccountRosterError] = useState<string | null>(null);
+  const [wifiConfigViaAccount, setWifiConfigViaAccount] = useState(false);
   /** Bumped on connect/disconnect, so a fallback that gave up for want of a
    *  session starts again the moment there is one. */
   const [cloudSession, setCloudSession] = useState(0);
@@ -328,7 +347,11 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
         const readConfig = () => {
           routerClient
             .getWifiConfig(AbortSignal.timeout(4_000))
-            .then((config) => !disposed && setWifiConfig(config))
+            .then((config) => {
+              if (disposed) return;
+              setWifiConfig(config);
+              setWifiConfigViaAccount(false);
+            })
             .catch(() => {});
         };
         readConfigRef.current = readConfig;
@@ -340,6 +363,8 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
             if (disposed) return;
             setClients(clientList);
             setClientsSource("lan");
+            setAccountRosterRequested(false);
+            setAccountRosterError(null);
             // Captured with the roster, not read later: the pair is what an
             // ordering is taken from, and rates replace their map rather than
             // mutating it, so this stays the set that arrived with this roster.
@@ -374,7 +399,9 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
               `/api/clients?samples=1${wantTotals ? "&totals=1" : ""}${since ? `&since=${since}` : "&hours=6"}`,
               { signal: AbortSignal.timeout(4_000) },
             );
-            if (!response.ok || disposed) return;
+            if (disposed) return;
+            setHistorianAnswering(response.ok);
+            if (!response.ok) return;
             const payload = (await response.json()) as {
               samples?: ClientSampleJson[];
               totals?: ClientUsageTotal[];
@@ -416,6 +443,7 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
             setThroughputHistory(new Map(history));
           } catch {
             // Historian down: the roster still renders, just without a series.
+            if (!disposed) setHistorianAnswering(false);
           } finally {
             tailInFlight = false;
           }
@@ -451,14 +479,13 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
    * The router reports its devices to Starlink whether or not this machine can
    * reach it, so the two cases the LAN read simply cannot cover — a kit in
    * bypass, and a viewer away from the network — are answered here. Runs only
-   * while the LAN is silent: the local read is faster, free, and carries the
-   * throughput this one does not.
+   * while the LAN is silent and only once asked: the local read is faster, free,
+   * and carries the throughput this one does not.
    */
   useEffect(() => {
-    if (!active || routerReachable !== false) return;
+    if (!active || routerReachable !== false || !accountRosterRequested) return;
     let disposed = false;
     let inFlight = false;
-    let configRead = false;
     let timerId = 0;
 
     const poll = async () => {
@@ -469,18 +496,19 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
         if (disposed) return;
         setClients(roster);
         setClientsSource("cloud");
-        // Once per stretch of cloud fallback, not per poll: names, SSIDs and mesh
-        // nodes change when the user changes them, and each read is a second trip
-        // through the account. `refreshConfig` covers a change made from here.
-        if (!configRead) {
-          configRead = true;
-          const config = await fetchCloudRouterConfig().catch(() => null);
-          if (!disposed && config) setWifiConfig(config);
-        }
+        setAccountRosterError(null);
       } catch (error) {
+        if (disposed) return;
         // No session to ask with — stop rather than retry something only a
         // sign-in can fix. Connecting one bumps `cloudSession` and re-runs this.
-        if (error instanceof CloudNotConnectedError) window.clearInterval(timerId);
+        if (error instanceof CloudNotConnectedError) {
+          window.clearInterval(timerId);
+          setAccountRosterError("Connect your Starlink account first.");
+        } else {
+          setAccountRosterError(
+            "Couldn't reach your Starlink account. Check this device's internet connection.",
+          );
+        }
       } finally {
         inFlight = false;
       }
@@ -492,7 +520,44 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
       disposed = true;
       window.clearInterval(timerId);
     };
+  }, [active, routerReachable, cloudSession, accountRosterRequested]);
+
+  /**
+   * Read the router's config through the account while the LAN cannot serve it.
+   *
+   * Unasked, unlike the roster: nothing here is swapped out from under a reader
+   * mid-glance. The surfaces showing it (SSIDs, mesh nodes, the subnet) are the
+   * same facts from either source, and they are simply absent without it. Once
+   * per stretch of silence, since each read is a trip through the account and a
+   * change made from here re-reads through `refreshConfig`.
+   */
+  useEffect(() => {
+    if (!active || routerReachable !== false) return;
+    let disposed = false;
+    void fetchCloudRouterConfig()
+      .then((config) => {
+        if (disposed || !config) return;
+        setWifiConfig(config);
+        setWifiConfigViaAccount(true);
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+    };
   }, [active, routerReachable, cloudSession]);
+
+  const readRosterViaAccount = useCallback(() => {
+    setAccountRosterError(null);
+    setAccountRosterRequested(true);
+  }, []);
+
+  const accountRosterStatus = !accountRosterRequested
+    ? "idle"
+    : accountRosterError
+      ? "failed"
+      : clientsSource === "cloud"
+        ? "idle"
+        : "loading";
 
   const renameClient = useCallback(async (clientId: number, givenName: string) => {
     // Current firmware answers every LAN write with grpc status 7, so this goes
@@ -521,6 +586,11 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
     wifiConfig,
     routerReachable,
     clientsSource,
+    historianAnswering,
+    readRosterViaAccount,
+    accountRosterStatus,
+    accountRosterError,
+    wifiConfigViaAccount,
     renameClient,
     throughputHistory,
     rates,

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -534,15 +534,24 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
   useEffect(() => {
     if (!active || routerReachable !== false) return;
     let disposed = false;
-    void fetchCloudRouterConfig()
-      .then((config) => {
-        if (disposed || !config) return;
-        setWifiConfig(config);
-        setWifiConfigViaAccount(true);
-      })
-      .catch(() => {});
+    let timerId = 0;
+
+    // Retried until one read lands, then left alone. A single attempt would
+    // leave the settings that show this empty for the rest of an outage that
+    // began while the account happened to be out of reach.
+    const read = async () => {
+      const config = await fetchCloudRouterConfig().catch(() => null);
+      if (disposed || !config) return;
+      setWifiConfig(config);
+      setWifiConfigViaAccount(true);
+      window.clearInterval(timerId);
+    };
+
+    void read();
+    timerId = window.setInterval(() => void read(), CLOUD_CLIENTS_POLL_MS);
     return () => {
       disposed = true;
+      window.clearInterval(timerId);
     };
   }, [active, routerReachable, cloudSession]);
 

--- a/src/lib/accountRosterNotice.ts
+++ b/src/lib/accountRosterNotice.ts
@@ -1,0 +1,21 @@
+// Whether the reader has waved away the note explaining that these devices came
+// from their Starlink account.
+//
+// A kit left in bypass is in that state for good, so the explanation is news
+// once and furniture forever after. Kept in localStorage rather than dish config
+// for the same reason the toolbar choice is: it describes this install's
+// reading, not the kit.
+
+const STORAGE_KEY = "dishylink-account-roster-notice-dismissed";
+
+export function accountRosterNoticeDismissed(): boolean {
+  return typeof localStorage !== "undefined" && localStorage.getItem(STORAGE_KEY) === "1";
+}
+
+/** Cleared when the router answers again, so the next outage is surfaced as the
+ *  fresh event it is rather than inheriting an answer given about an older one. */
+export function setAccountRosterNoticeDismissed(dismissed: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  if (dismissed) localStorage.setItem(STORAGE_KEY, "1");
+  else localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/lib/routerDiagnosis.ts
+++ b/src/lib/routerDiagnosis.ts
@@ -126,16 +126,16 @@ function messagesFor(routerAddress: string): Record<RouterUnreachableCause, stri
       `Another device on this network is using ${routerAddress}, the address the Starlink ` +
       `router answers on, so the router is hidden behind it. To fix it, connect to your ` +
       `Starlink WiFi, give the other router a different address (like ` +
-      `${suggestedAlternative(routerAddress)}), or set the router address below to wherever ` +
+      `${suggestedAlternative(routerAddress)}), or point Dishylink's router address at wherever ` +
       `your Starlink router actually is.`,
     configuredAddressSilent:
-      `Nothing answered at ${routerAddress}, the address set below, but the dish reports your ` +
-      `Starlink router is running. It is most likely at a different address. Check the one set ` +
-      `below, or clear it to go back to the default.`,
+      `Nothing answered at ${routerAddress}, the address Dishylink is set to use, but the dish ` +
+      `reports your Starlink router is running. It is most likely at a different address. ` +
+      `Check that setting, or clear it to go back to the default.`,
     differentNetwork:
       `Your Starlink router is running, but this device isn't on the network ${routerAddress} ` +
-      `belongs to. Connect to your Starlink WiFi, or if the router's subnet was changed, set the ` +
-      `router address below to where it is now.`,
+      `belongs to. Connect to your Starlink WiFi, or if the router's subnet was changed, point ` +
+      `Dishylink's router address at where it is now.`,
     noRouter:
       `The dish isn't reporting a Starlink router — it's in bypass mode, or the router is off. ` +
       `WiFi and connected devices come from the router, so there's nothing to show here. ` +
@@ -143,7 +143,7 @@ function messagesFor(routerAddress: string): Record<RouterUnreachableCause, stri
     unknown:
       `Couldn't reach the Starlink router at ${routerAddress}. Another device may be using ` +
       `that address, the router may be in bypass mode or on a different network, or it may be ` +
-      `at an address other than the one set below.`,
+      `at an address other than the one Dishylink is set to use.`,
     checking:
       `Couldn't reach the Starlink router at ${routerAddress}. Working out why; most short ` +
       `silences are the router restarting.`,

--- a/src/lib/selfIdentity.test.ts
+++ b/src/lib/selfIdentity.test.ts
@@ -57,11 +57,22 @@ describe("matchesSelf", () => {
     expect(matchesSelf({ clientId: 12 }, self({ clientId: 12 }))).toBe(true);
   });
 
-  it("given a named clientId, matches nothing else, however the addresses line up", () => {
+  it("given a clientId, still matches this machine's own addresses", () => {
+    // A kept clientId is one roster read out of date after a router reset hands
+    // the number to some other device, and the addresses are what cover that.
     expect(
       matchesSelf(
         { clientId: 13, ipAddress: "192.168.1.45", macAddress: "5a:c9:44:55:f3:e9" },
         self({ clientId: 12, ips: ["192.168.1.45"], macs: ["5a:c9:44:55:f3:e9"] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("given a clientId and addresses, matches a device answering to neither", () => {
+    expect(
+      matchesSelf(
+        { clientId: 13, ipAddress: "192.168.1.99" },
+        self({ clientId: 12, ips: ["192.168.1.45"] }),
       ),
     ).toBe(false);
   });
@@ -125,6 +136,21 @@ describe("resolveSelfIdentity via the Electron bridge", () => {
       macs: ["ea:17:b5:92:e2:92"],
       describesHost: true,
     });
+  });
+
+  it("carries the roster id the host has kept, which is what answers off the network", async () => {
+    host.dishlink = {
+      selfIdentity: () =>
+        Promise.resolve({ ipAddresses: ["10.20.30.40"], macAddresses: [], clientId: 7 }),
+    };
+
+    const identity = await resolveSelfIdentity();
+
+    expect(identity.clientId).toBe(7);
+    // The id answers even where the address cannot: the roster lists this device
+    // on the router's subnet, which is not the one this machine is sitting on.
+    expect(matchesSelf({ clientId: 7, ipAddress: "192.168.1.5" }, identity)).toBe(true);
+    expect(matchesSelf({ clientId: 8, ipAddress: "192.168.1.6" }, identity)).toBe(false);
   });
 
   it("falls through when the bridge is absent, as it is on every other host", async () => {

--- a/src/lib/selfIdentity.ts
+++ b/src/lib/selfIdentity.ts
@@ -79,7 +79,12 @@ async function fromHostChoice(): Promise<SelfIdentity | null> {
 }
 
 interface DishlinkBridge {
-  selfIdentity?: () => Promise<{ ipAddresses?: string[]; macAddresses?: string[] }>;
+  selfIdentity?: () => Promise<{
+    ipAddresses?: string[];
+    macAddresses?: string[];
+    clientId?: number;
+  }>;
+  rememberSelfDevice?: (clientId: number) => Promise<void>;
 }
 async function fromElectron(): Promise<SelfIdentity | null> {
   const bridge = (globalThis as { dishlink?: DishlinkBridge }).dishlink;
@@ -89,6 +94,7 @@ async function fromElectron(): Promise<SelfIdentity | null> {
     return {
       ips: clean(identity.ipAddresses ?? []),
       macs: (identity.macAddresses ?? []).map((macAddress) => macAddress.toLowerCase()),
+      clientId: identity.clientId,
       // Read from this process's own os.networkInterfaces(), and the desktop
       // app makes its LAN requests from that same process.
       describesHost: true,
@@ -129,17 +135,35 @@ export function selfIdentified(self: SelfIdentity): boolean {
   return self.clientId !== undefined || self.ips.length > 0 || self.macs.length > 0;
 }
 
-/** True when this client entry is the device viewing the dashboard. A named
- *  clientId settles it alone; otherwise MAC wins when present (Electron), then v4,
- *  then v6 — Starlink hands out IPv6, so a v6-connected viewer must still resolve. */
+/** True when this client entry is the device viewing the dashboard. Either signal
+ *  is enough: a clientId identifies this device from anywhere, and the addresses
+ *  still identify it on the router's own network, where a clientId kept from
+ *  before a router reset would name whichever device inherited the number. */
 export function matchesSelf(
   client: { clientId?: number; macAddress?: string; ipAddress?: string; ipv6Addresses?: string[] },
   self: SelfIdentity,
 ): boolean {
-  if (self.clientId !== undefined) return client.clientId === self.clientId;
+  if (self.clientId !== undefined && client.clientId === self.clientId) return true;
+  return matchesSelfByAddress(client, self);
+}
+
+/** The address half of `matchesSelf` alone. A caller learning which entry this
+ *  device is cannot use the clientId branch to find it, and an address match only
+ *  means anything on the network that issued the address. */
+export function matchesSelfByAddress(
+  client: { macAddress?: string; ipAddress?: string; ipv6Addresses?: string[] },
+  self: SelfIdentity,
+): boolean {
   const mac = client.macAddress?.toLowerCase();
   if (mac && self.macs.includes(mac)) return true;
   const v4 = client.ipAddress ? normalizeIp(client.ipAddress) : undefined;
   if (v4 && self.ips.includes(v4)) return true;
   return (client.ipv6Addresses ?? []).some((addr) => self.ips.includes(normalizeIp(addr)));
+}
+
+/** Hand this device's roster id to the host that writes pauses, where there is
+ *  one. Nothing to do on a host that resolves the viewer some other way. */
+export function rememberSelfDevice(clientId: number): void {
+  const bridge = (globalThis as { dishlink?: DishlinkBridge }).dishlink;
+  void bridge?.rememberSelfDevice?.(clientId);
 }

--- a/src/lib/starlinkCloud.ts
+++ b/src/lib/starlinkCloud.ts
@@ -9,6 +9,7 @@
 // from the historian: this needs internet + the account session, nothing about
 // the local dish.
 
+import type { WifiClientJson, WifiNetworkConfigJson } from "@core/dishClient";
 import { cloudRequest, noteCloudSessionChanged } from "./cloudHost";
 
 // ---- response shapes (only the fields the UI reads) ----
@@ -269,6 +270,29 @@ export function fetchCloudUsage(signal?: AbortSignal): Promise<CloudUsage> {
 export async function fetchCloudRouterSubnet(signal?: AbortSignal): Promise<string | null> {
   const { subnet } = await cloudGet<{ subnet: string | null }>("/cloud/router-subnet", signal);
   return subnet;
+}
+
+/** The connected devices the router reports, asked of the account rather than
+ *  the LAN. The same roster, from the one path that still answers when this
+ *  machine is not on that network — or cannot see the router at all. */
+export async function fetchCloudRouterClients(signal?: AbortSignal): Promise<WifiClientJson[]> {
+  const { clients } = await cloudGet<{ clients: WifiClientJson[] | null }>(
+    "/cloud/router-clients",
+    signal,
+  );
+  return clients ?? [];
+}
+
+/** The router's WiFi config over the same path — SSIDs, mesh nodes, and the
+ *  saved per-device entries a roster is read alongside. */
+export async function fetchCloudRouterConfig(
+  signal?: AbortSignal,
+): Promise<WifiNetworkConfigJson | null> {
+  const { wifiConfig } = await cloudGet<{ wifiConfig: WifiNetworkConfigJson | null }>(
+    "/cloud/router-config",
+    signal,
+  );
+  return wifiConfig;
 }
 
 /** Persist a pasted session via the host binding. The host validates it against

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -3,3 +3,16 @@
 // getComputedStyle would report defaults and every fidelity assertion would be
 // meaningless.
 import "./index.css";
+import { afterEach, beforeEach } from "vitest";
+import { cleanup } from "vitest-browser-react";
+import { noteCloudSessionChanged } from "./lib/cloudHost";
+
+// One account answer is shared by every surface in the app, and by every test in
+// a file. Left alone, the first test decides what the account says for all of
+// them. Unmounting first is what makes dropping it take: a component still
+// watching refetches immediately, through whichever transport that test left set.
+afterEach(() => {
+  cleanup();
+  noteCloudSessionChanged();
+});
+beforeEach(() => noteCloudSessionChanged());

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -24,7 +24,12 @@ interface Window {
       method?: string;
       body?: unknown;
     }) => Promise<{ status: number; body: unknown }>;
-    selfIdentity: () => Promise<{ ipAddresses: string[]; macAddresses: string[] }>;
+    selfIdentity: () => Promise<{
+      ipAddresses: string[];
+      macAddresses: string[];
+      clientId?: number;
+    }>;
+    rememberSelfDevice?: (clientId: number) => Promise<void>;
     recorderInProcess: () => Promise<boolean>;
     // Where the host dials the router, with the default it falls back to. Absent
     // on hosts that reach it some other way, which is what keeps the setting from


### PR DESCRIPTION
The router answers only on its own LAN, and on current firmware it refuses every
write made there. That leaves two ordinary situations with no working path: a kit
in bypass, which is invisible on the local network by definition, and a viewer who
is not on that network at all.

This reads the same router through the user's Starlink account instead, over the
gateway the official app uses.

## What it does

- **Client roster from the cloud account.** When the LAN cannot serve the device
  list, the Network panel explains the silence and offers to read it through the
  account. The request covers one outage: the router answering retires it, so a
  later silence is offered again rather than switched over without asking.
  Refreshed every 15 s while a router-backed panel is open.
- **Pause and rename through the account gateway.** Both writes are prepared by
  the trusted host from reads made over that same gateway, so nothing depends on
  the LAN. Renderer-supplied protobuf is never accepted.
- **Router config from the cloud account, unasked.** SSIDs, mesh nodes and the
  subnet keep loading with no interaction, so the Router settings never go dark.
  The read repeats until one lands.
- **Self-pause refused from any network.** Pausing the device Dishylink runs on
  cannot be undone from that device. The host records the router's clientId for
  this machine whenever a LAN roster identifies it, and refuses a pause aimed at
  that id or at this machine's own addresses, which holds for a write made from
  off the router's network.
- **Provenance stated everywhere it matters.** Each reading says where it came
  from, live per-device rates are withheld from a cloud-sourced roster rather
  than shown stale, an empty throughput chart names whichever feed is silent, and
  a roster that stops refreshing says so instead of keeping its cadence.

## Notes

- A pause stays pending for two reads of whichever roster confirms it, so an
  account-sourced write is not called unapplied while its confirmation is due.
- A kit in permanent bypass needs the roster asked for once per app launch, since
  the request is scoped to an outage and the LAN never returns to retire it.
- The browser-dev proxy still guards a self-pause by address alone, which is