### PR TITLE
 fix/Show Roam kits as Roam, not Residential

### DIFF
--- a/src/components/dashboard/DishTerminalCard.tsx
+++ b/src/components/dashboard/DishTerminalCard.tsx
@@ -6,20 +6,7 @@ import { formatAttitudeState, formatRelativeTime, formatUptime } from "../../lib
 import { FactGrid, FactRow } from "../ui/fact-row";
 import { DishIcon } from "../../assets/icons/DishIcon";
 import { ExpandIcon } from "../../assets/icons/ExpandIcon";
-
-/** Plan tier. The API's CONSUMER is what the Starlink app labels "Residential". */
-function formatServiceClass(classOfService?: string): string {
-  switch (classOfService) {
-    case "CONSUMER":
-      return "residential";
-    case "BUSINESS":
-      return "business";
-    case "BUSINESS_PLUS":
-      return "business plus";
-    default:
-      return (classOfService ?? "—").replaceAll("_", " ").toLowerCase();
-  }
-}
+import { formatServiceClass } from "./serviceClass";
 
 /** Why downlink is capped, if it is. NO_LIMIT / NO_RESTRICTION read as "none". */
 function formatBandwidthLimit(reason?: string): string {
@@ -107,7 +94,10 @@ export function DishTerminalCard({
     { label: "Country", value: status.deviceInfo?.countryCode ?? "—" },
     { label: "Uptime", value: formatUptime(Number(status.deviceState?.uptimeS ?? 0)) },
     { label: "Boot count", value: String(status.deviceInfo?.bootcount ?? "—") },
-    { label: "Service class", value: formatServiceClass(status.classOfService) },
+    {
+      label: "Service class",
+      value: formatServiceClass(status.classOfService, status.mobilityClass),
+    },
     {
       label: "Satellites in View (GPS)",
       value: status.gpsStats?.gpsValid ? `${status.gpsStats.gpsSats ?? 0} satellites` : "no fix",

--- a/src/components/dashboard/serviceClass.test.ts
+++ b/src/components/dashboard/serviceClass.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatServiceClass } from "./serviceClass";
+
+describe("formatServiceClass", () => {
+  it("separates roam from residential by mobility class", () => {
+    expect(formatServiceClass("CONSUMER", "NOMADIC")).toBe("roam");
+    expect(formatServiceClass("CONSUMER", "MOBILE")).toBe("roam");
+    expect(formatServiceClass("CONSUMER", "STATIONARY")).toBe("residential");
+    expect(formatServiceClass("CONSUMER", undefined)).toBe("residential");
+  });
+
+  it("names the business tiers", () => {
+    expect(formatServiceClass("BUSINESS")).toBe("business");
+    expect(formatServiceClass("BUSINESS_PLUS")).toBe("business plus");
+  });
+
+  it("keeps a business tier's name whatever the kit is licensed to do", () => {
+    expect(formatServiceClass("BUSINESS", "MOBILE")).toBe("business");
+  });
+
+  it("falls back to the raw tier, and to a dash when there is none", () => {
+    expect(formatServiceClass("SOME_NEW_TIER")).toBe("some new tier");
+    expect(formatServiceClass(undefined)).toBe("—");
+  });
+});

--- a/src/components/dashboard/serviceClass.ts
+++ b/src/components/dashboard/serviceClass.ts
@@ -1,0 +1,16 @@
+/** Plan tier, in the vocabulary the Starlink app uses. CONSUMER covers both
+ *  "Residential" on a fixed install and "Roam" on a kit licensed to move, so the
+ *  mobility class is what tells those two apart. Absent mobility means
+ *  STATIONARY: proto3 drops the zero value, so a fixed kit never sends it. */
+export function formatServiceClass(classOfService?: string, mobilityClass?: string): string {
+  switch (classOfService) {
+    case "CONSUMER":
+      return mobilityClass === "NOMADIC" || mobilityClass === "MOBILE" ? "roam" : "residential";
+    case "BUSINESS":
+      return "business";
+    case "BUSINESS_PLUS":
+      return "business plus";
+    default:
+      return (classOfService ?? "—").replaceAll("_", " ").toLowerCase();
+  }
+}


### PR DESCRIPTION
CONSUMER covers both Residential and Roam. A kit reporting NOMADIC or MOBILE alongside it is on Roam, and the terminal card now says so:

- The terminal card's **Service class** read `classOfService` on its own, where
  `CONSUMER` mapped straight to "residential". Roam is also a CONSUMER-tier plan,
  so a Roam kit was labelled Residential.
- `mobilityClass` (`STATIONARY` / `NOMADIC` / `MOBILE`) already rides the existing
  `dish_get_status` reply and is what separates the two. `CONSUMER` plus
  `NOMADIC` or `MOBILE` now reads "roam".
- Absent mobility still reads "residential" — proto3 drops the zero value, so a
  fixed kit never sends `STATIONARY`.
- Business tiers are unaffected, whatever the kit is licensed to do.