### PR TITLE
Feat/satellite handoff slots

### DIFF
--- a/src/hooks/useSatellites.ts
+++ b/src/hooks/useSatellites.ts
@@ -13,6 +13,7 @@ import {
   resolveObstructionFrame,
   skyDirectionToGrid,
 } from "../components/obstruction/obstructionFrame";
+import { chooseServingCandidate, type ServingHold } from "../lib/servingSlot";
 import {
   loadStarlinkTles,
   StarlinkTracker,
@@ -100,25 +101,6 @@ function isUnobstructed(
   return fractionUsable === undefined || fractionUsable < 0 || 1 - fractionUsable <= 0.05;
 }
 
-function pickServingCandidate(
-  inView: SatelliteSky[],
-  obstructionMap: DishObstructionMapJson | null,
-  dishModel: DishModel,
-  boresightAzimuthDeg: number,
-): SatelliteSky | null {
-  let bestUnobstructed: SatelliteSky | null = null;
-  for (const sky of inView) {
-    if (sky.elevationDeg < SERVING_ELEVATION_FLOOR_DEG) break; // sorted by elevation
-    if (isUnobstructed(sky, obstructionMap, dishModel, boresightAzimuthDeg)) {
-      bestUnobstructed = sky;
-      break;
-    }
-  }
-  return (
-    bestUnobstructed ?? (inView[0]?.elevationDeg >= SERVING_ELEVATION_FLOOR_DEG ? inView[0] : null)
-  );
-}
-
 export function useSatellites(
   observerLocation: ObserverLocation | null,
   obstructionMap: DishObstructionMapJson | null,
@@ -151,6 +133,7 @@ export function useSatellites(
   useEffect(() => {
     if (!hasLocation) return;
     let disposed = false;
+    let hold: ServingHold | null = null;
     const timerIds: number[] = [];
     const retryIds: number[] = [];
 
@@ -171,19 +154,24 @@ export function useSatellites(
         const updateStats = () => {
           const inView = tracker.finePass();
           const lookup = lookupRef.current;
-          const servingCandidate = pickServingCandidate(
-            inView,
-            lookup.obstructionMap,
-            lookup.dishModel,
-            lookup.boresightAzimuthDeg,
+          // The 1 Hz sampler reads the boundary up to a second late: a fixed
+          // offset, not per-slot jitter.
+          const serving = chooseServingCandidate(inView, Date.now(), hold, (sky) =>
+            isUnobstructed(
+              sky,
+              lookup.obstructionMap,
+              lookup.dishModel,
+              lookup.boresightAzimuthDeg,
+            ),
           );
+          hold = serving.hold;
           setStats((previousStats) => ({
             ...previousStats,
             inViewCount: inView.length,
             serviceableCount: inView.filter(
               (sky) => sky.elevationDeg >= SERVING_ELEVATION_FLOOR_DEG,
             ).length,
-            servingCandidate,
+            servingCandidate: serving.candidate,
             constellationSize: tracker.constellationSize,
           }));
         };

--- a/src/lib/servingSlot.test.ts
+++ b/src/lib/servingSlot.test.ts
@@ -1,0 +1,100 @@
+// The claim is a sequence, not a single call: one satellite for a whole slot.
+
+import { describe, expect, it } from "vitest";
+import { chooseServingCandidate, slotIndexAt, type ServingHold } from "./servingSlot";
+import type { SatelliteSky } from "./satellites";
+
+const sat = (name: string, elevationDeg: number): SatelliteSky => ({
+  name,
+  azimuthDeg: 0,
+  elevationDeg,
+  rangeKm: 550,
+});
+
+/** Sorted by elevation, as the tracker's fine pass returns them. */
+const inViewOf = (...sats: SatelliteSky[]) =>
+  [...sats].sort((a, b) => b.elevationDeg - a.elevationDeg);
+
+const clear = () => true;
+
+function ride(
+  startMs: number,
+  seconds: number,
+  skyAt: (second: number) => SatelliteSky[],
+  isUnobstructed: (sky: SatelliteSky, second: number) => boolean = clear,
+) {
+  let hold: ServingHold | null = null;
+  const names: (string | null)[] = [];
+  for (let second = 0; second < seconds; second += 1) {
+    const choice = chooseServingCandidate(skyAt(second), startMs + second * 1_000, hold, (sky) =>
+      isUnobstructed(sky, second),
+    );
+    hold = choice.hold;
+    names.push(choice.candidate?.name ?? null);
+  }
+  return names;
+}
+
+describe("slot boundaries", () => {
+  it("falls on the shared :00/:15/:30/:45 clock", () => {
+    const at = (s: number, ms = 0) => Date.UTC(2026, 0, 1, 12, 0, s, ms);
+    expect(slotIndexAt(at(14, 999))).toBe(slotIndexAt(at(0)));
+    expect(slotIndexAt(at(15))).toBe(slotIndexAt(at(0)) + 1);
+    expect(slotIndexAt(at(45))).toBe(slotIndexAt(at(30)) + 1);
+  });
+});
+
+describe("chooseServingCandidate", () => {
+  const boundary = Date.UTC(2026, 0, 1, 12, 0, 0);
+
+  it("holds one satellite per slot while a rival climbs past it", () => {
+    // B overtakes A five seconds in; re-picking every sample would follow it.
+    const skyAt = (second: number) => inViewOf(sat("A", 70), sat("B", 60 + second * 3));
+    const names = ride(boundary, 30, skyAt);
+
+    expect(names.slice(0, 15)).toEqual(Array(15).fill("A"));
+    expect(names.slice(15)).toEqual(Array(15).fill("B"));
+    expect(new Set(names).size).toBe(2);
+  });
+
+  it("drops a held satellite that goes behind an obstruction", () => {
+    const skyAt = () => inViewOf(sat("A", 70), sat("B", 60));
+    const names = ride(boundary, 20, skyAt, (sky, second) => !(sky.name === "A" && second >= 3));
+
+    expect(names.slice(0, 3)).toEqual(["A", "A", "A"]);
+    expect(names.slice(3)).toEqual(Array(17).fill("B"));
+  });
+
+  it("keeps the slot in progress when a replacement is forced mid-slot", () => {
+    // B takes over 3s in, so it serves the remaining 12s and no longer.
+    const skyAt = () => inViewOf(sat("A", 70), sat("B", 60), sat("C", 50));
+    const names = ride(boundary, 20, skyAt, (sky, second) => {
+      if (sky.name === "A") return second < 3;
+      if (sky.name === "B") return second < 15 || second >= 18;
+      return true;
+    });
+
+    expect(names.slice(3, 15)).toEqual(Array(12).fill("B"));
+    expect(names[15]).toBe("C");
+  });
+
+  it("ignores a hold left over from an earlier slot", () => {
+    const inView = inViewOf(sat("A", 70), sat("B", 60));
+    const stale: ServingHold = { slotIndex: slotIndexAt(boundary) - 1, name: "B" };
+    expect(chooseServingCandidate(inView, boundary, stale, clear).candidate?.name).toBe("A");
+  });
+
+  it("falls back to the highest satellite when every one is obstructed", () => {
+    const inView = inViewOf(sat("A", 70), sat("B", 60));
+    const choice = chooseServingCandidate(inView, boundary, null, () => false);
+    expect(choice.candidate?.name).toBe("A");
+  });
+
+  it("serves nothing when the sky is empty or below the service floor", () => {
+    expect(chooseServingCandidate([], boundary, null, clear)).toEqual({
+      candidate: null,
+      hold: null,
+    });
+    expect(chooseServingCandidate([sat("A", 10)], boundary, null, clear).candidate).toBeNull();
+  });
+});

--- a/src/lib/servingSlot.ts
+++ b/src/lib/servingSlot.ts
@@ -1,0 +1,56 @@
+// Starlink reassigns terminals on 15-second boundaries against a clock every
+// terminal shares, so the serving guess is made when the slot turns over and
+// held until the next, rather than re-picked on every sample.
+
+import { SERVING_ELEVATION_FLOOR_DEG, type SatelliteSky } from "./satellites";
+
+export const HANDOFF_SLOT_MS = 15_000;
+
+/** Counted from the epoch, so observers on the same clock agree on boundaries. */
+export function slotIndexAt(nowMs: number): number {
+  return Math.floor(nowMs / HANDOFF_SLOT_MS);
+}
+
+export interface ServingHold {
+  slotIndex: number;
+  name: string;
+}
+
+export interface ServingChoice {
+  candidate: SatelliteSky | null;
+  hold: ServingHold | null;
+}
+
+function bestAvailable(
+  inView: SatelliteSky[],
+  isUnobstructed: (sky: SatelliteSky) => boolean,
+): SatelliteSky | null {
+  // Sorted by elevation, so the first clear one is the highest.
+  for (const sky of inView) {
+    if (sky.elevationDeg < SERVING_ELEVATION_FLOOR_DEG) break;
+    if (isUnobstructed(sky)) return sky;
+  }
+  const highest = inView[0];
+  return highest && highest.elevationDeg >= SERVING_ELEVATION_FLOOR_DEG ? highest : null;
+}
+
+export function chooseServingCandidate(
+  inView: SatelliteSky[],
+  nowMs: number,
+  hold: ServingHold | null,
+  isUnobstructed: (sky: SatelliteSky) => boolean,
+): ServingChoice {
+  const slotIndex = slotIndexAt(nowMs);
+
+  if (hold && hold.slotIndex === slotIndex) {
+    const held = inView.find((sky) => sky.name === hold.name);
+    if (held && held.elevationDeg >= SERVING_ELEVATION_FLOOR_DEG && isUnobstructed(held)) {
+      return { candidate: held, hold };
+    }
+  }
+
+  // A replacement inherits the slot in progress: losing a satellite does not
+  // restart the dish's clock.
+  const candidate = bestAvailable(inView, isUnobstructed);
+  return { candidate, hold: candidate ? { slotIndex, name: candidate.name } : null };
+}


### PR DESCRIPTION
The serving guess was re-picked on every 1 Hz sample, so it answered which satellite looks best right now rather than which one the dish is on. Starlink reassigns terminals on 15-second boundaries against a clock every terminal shares, so the choice now turns over with the slot and is held until the next, except when the held satellite goes behind an obstruction mid-slot.