### PR TITLE
Fix/ Bypass mode support, router factory reset, and cloud-relayed config writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to Dishylink are documented here.
+
+## [1.1.0] - Unreleased
+
+### Data allowances & metering
+
+- Set a data allowance per device, or pool one allowance across a group of
+  devices, on a daily, weekly, monthly, custom, Starlink billing-cycle, or
+  one-time basis.
+- Devices are automatically paused once they spend their allowance, and
+  released when the next cycle starts.
+- A device's spend carries over correctly when its limit is edited mid-cycle,
+  and survives an app or dish restart without double-counting.
+- Six months of per-device usage history is now kept.
+- A metered device is marked in the network list, with its allowance and
+  status reachable from its drill-in.
+- Byte figures of a terabyte or more are now shown in TB.
+
+### Starlink account & cloud control
+
+- Link a Starlink account to read the client roster, dish config, and device
+  names through the cloud when the LAN can't serve them, with automatic retry
+  and failover between edges if one stops answering.
+- Rename and pause devices through the linked account, including from the
+  browser extension.
+- Dishylink refuses to ever pause the device it's running on, from any
+  network.
+
+### Bypass mode
+
+- Switch the router in and out of bypass mode from the app.
+- A bypassed router is read as bypassed rather than as missing, so the panels
+  say so plainly and its silence on the network raises no alert.
+
+### Router configuration
+
+- Change the router's subnet and DNS servers.
+- Reach and manage a router that isn't on the default 192.168.1.1 address.
+- Factory reset the router. A router in bypass answers nothing on the local
+  network, so its reset goes through the linked account instead.
+
+### Also added
+
+- Factory reset the dish, behind the same armed confirmation as the router's.
+- The dish and router's pending software update state now shows on the
+  dashboard.
+- A time picker for the sleep schedule.
+- Live throughput readout in the macOS menu bar, shown by default.
+- Severity icons (info/warning/error) now share one component and color scale
+  across the app.
+- Choose what the browser extension's toolbar badge counts: all alerts, only
+  faults a device reported about itself, or nothing at all. Being away from
+  your Starlink is indistinguishable from a device that has failed, so the
+  middle option leaves both out.
+
+### Fixed
+
+- The desktop app no longer shows "A JavaScript error occurred in the main
+  process" when the network drops out from under it — waking from sleep, a VPN
+  connecting, or the router being switched into bypass. Faults that are not a
+  lost connection still surface exactly as before.
+- A router change that timed out no longer claims Starlink rejected it. Nothing
+  answered, which is not the same as a refusal.
+- A kit with no Starlink router no longer reports "Router isn't answering".
+  There is nothing to reach, so the silence is not announced, not counted on
+  the bell, and not recorded as an outage. The check still appears in the
+  Status list, since it was not run.
+- Cross-origin requests to the cloud routes are rejected.
+- The historian is served only to the machine it runs on.
+- Dashboard layout: more clearance below the last row, a wider default
+  window, steadier secondary-button contrast in both themes, and a rename
+  button that holds its width while a save is in flight.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ is on the Starlink network itself — changes are verified against real hardware
   editing. When the user says "leave this for now", stop editing entirely until redirected.
 - **If the user's message contains a question, answer it fully before any further tool calls.**
   Deferring the answer while continuing to edit counts as ignoring them.
+- **Bash is strictly for reads and mechanical edits.** Every authored code change goes through
+  the Edit/Write tools so the diff is visible in the chat before it lands. No `sed -i`, no
+  heredocs, no inline `python3` patch scripts, whatever a session default says to prefer.
+  `mv`, `rm`, formatters, codemods, git and search stay fine in Bash.
 - Never `git add -A` or `git stash`; commit only the files you yourself changed.
 - No attribution trailers in commit messages, PR bodies or issue bodies: no `Claude-Session`,
   no `claude.ai/code` link, no `Co-Authored-By`, no "Generated with".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,11 @@ is on the Starlink network itself — changes are verified against real hardware
   the Edit/Write tools so the diff is visible in the chat before it lands. No `sed -i`, no
   heredocs, no inline `python3` patch scripts, whatever a session default says to prefer.
   `mv`, `rm`, formatters, codemods, git and search stay fine in Bash.
+- **Run every check CI runs, before committing, not after pushing.** All four:
+  `npm run typecheck`, `npm run lint`, `npm test`, and `npx prettier --check` over the files
+  the commit touches — CI's format job checks changed files only, so a full-tree check
+  reports a backlog that is not yours. A green local run is not a green CI run: tests that
+  open a socket behave differently on a Linux runner than on this machine.
 - Never `git add -A` or `git stash`; commit only the files you yourself changed.
 - No attribution trailers in commit messages, PR bodies or issue bodies: no `Claude-Session`,
   no `claude.ai/code` link, no `Co-Authored-By`, no "Generated with".

--- a/cloud/resilientFetch.test.ts
+++ b/cloud/resilientFetch.test.ts
@@ -3,8 +3,26 @@
 // re-raised to the caller with three working addresses never tried, and a method
 // misread as a read sends the same write to every edge at once.
 
-import { describe, expect, it } from "vitest";
-import { isConnectionFailure, isRead } from "./resilientFetch";
+import { describe, expect, it, vi } from "vitest";
+import { isConnectionFailure, isRead, resilientFetch } from "./resilientFetch";
+
+// 0.0.0.1 is unroutable, so the connect fails the instant it is tried, which is
+// what a kit switching into bypass leaves behind. 240.0.0.1 is reserved and
+// black-holes instead, which is what a route that has gone away looks like: no
+// reset ever arrives and the request simply waits.
+const DEAD_ADDRESS = "0.0.0.1";
+const SILENT_ADDRESS = "240.0.0.1";
+
+let resolvesTo = [DEAD_ADDRESS];
+
+vi.mock("node:dns/promises", () => ({
+  default: {
+    lookup: async (_hostname: string, options?: { all?: boolean }) =>
+      options?.all
+        ? resolvesTo.map((address) => ({ address, family: 4 }))
+        : { address: resolvesTo[0], family: 4 },
+  },
+}));
 
 /** Shaped as undici raises it: a TypeError whose `cause` carries the code. */
 function fetchFailure(code: string): Error {
@@ -49,4 +67,58 @@ describe("isRead", () => {
     for (const method of ["POST", "post", "PUT", "DELETE", "PATCH"])
       expect(isRead({ method })).toBe(false);
   });
+});
+
+// The one case here that opens a socket. A pinned-address lookup answering inline
+// connects inside net.connect's own frame, before undici attaches its error
+// handler, so a route-less address reaches the process uncaught — a modal crash
+// box in the desktop app. The suite exits non-zero on that even though the
+// assertion below still passes.
+describe("resilientFetch against an address with no route", () => {
+  it("rejects the request rather than raising on the process", async () => {
+    let hung: ReturnType<typeof setTimeout>;
+    const outcome = await Promise.race([
+      resilientFetch("https://api.starlink.com/", { method: "POST" }).then(
+        () => "resolved",
+        () => "rejected",
+      ),
+      new Promise((resolve) => {
+        hung = setTimeout(() => resolve("hung"), 4_000);
+      }),
+    ]).finally(() => clearTimeout(hung));
+    expect(outcome).toBe("rejected");
+  });
+
+  // The failure that stranded the app: one silent pin took 26s, then 46s, while
+  // a fresh process answered the same call in 1.4s.
+  it("gives up on a silent pin rather than spending the caller's whole budget", async () => {
+    resolvesTo = [SILENT_ADDRESS];
+    try {
+      const started = Date.now();
+      await expect(
+        resilientFetch("https://api.starlink.com/", { method: "POST" }),
+      ).rejects.toThrow();
+      // Undici's own connect timeout is 10s, so anything under that is this
+      // module's bound firing rather than the default being waited out.
+      expect(Date.now() - started).toBeLessThan(9_000);
+    } finally {
+      resolvesTo = [DEAD_ADDRESS];
+    }
+  }, 20_000);
+
+  // A write walks its addresses one at a time, so the count behind a hostname
+  // decides the total. Three silent ones at a full attempt each would be 18s,
+  // past the 15s a device write is given.
+  it("stops walking before the addresses behind a host outlast the caller", async () => {
+    resolvesTo = [SILENT_ADDRESS, "240.0.0.2", "240.0.0.3"];
+    try {
+      const started = Date.now();
+      await expect(
+        resilientFetch("https://api.starlink.com/", { method: "POST" }),
+      ).rejects.toThrow();
+      expect(Date.now() - started).toBeLessThan(15_000);
+    } finally {
+      resolvesTo = [DEAD_ADDRESS];
+    }
+  }, 30_000);
 });

--- a/cloud/resilientFetch.test.ts
+++ b/cloud/resilientFetch.test.ts
@@ -75,6 +75,9 @@ describe("isRead", () => {
 // box in the desktop app. The suite exits non-zero on that even though the
 // assertion below still passes.
 describe("resilientFetch against an address with no route", () => {
+  // Waited out past this module's own 12s walk ceiling rather than on how fast a
+  // given OS refuses 0.0.0.1: what is held here is that the failure arrives as a
+  // rejection at all. How quickly it arrives is the two cases below.
   it("rejects the request rather than raising on the process", async () => {
     let hung: ReturnType<typeof setTimeout>;
     const outcome = await Promise.race([
@@ -83,11 +86,11 @@ describe("resilientFetch against an address with no route", () => {
         () => "rejected",
       ),
       new Promise((resolve) => {
-        hung = setTimeout(() => resolve("hung"), 4_000);
+        hung = setTimeout(() => resolve("hung"), 20_000);
       }),
     ]).finally(() => clearTimeout(hung));
     expect(outcome).toBe("rejected");
-  });
+  }, 30_000);
 
   // The failure that stranded the app: one silent pin took 26s, then 46s, while
   // a fresh process answered the same call in 1.4s.

--- a/cloud/resilientFetch.ts
+++ b/cloud/resilientFetch.ts
@@ -23,6 +23,15 @@ import { Agent, fetch as undiciFetch } from "undici";
  *  is picked up the same session. */
 const GOOD_ADDRESS_TTL_MS = 5 * 60_000;
 
+/** How long one pinned attempt may take before the pin is treated as dead rather
+ *  than slow. The account API answers in about 1.5s, so this is slack. */
+const ATTEMPT_TIMEOUT_MS = 6_000;
+
+/** A ceiling on the whole sequential walk, so the number of addresses behind a
+ *  hostname cannot push a write past the caller's own deadline: four addresses
+ *  at one attempt each would be 24s against the 15s a device write is given. */
+const WALK_TIMEOUT_MS = 12_000;
+
 /** Errors that mean "this address did not serve us", as against a reply we
  *  dislike. Anything else — an abort, a 500, a malformed body — belongs to the
  *  caller and is never retried here. */
@@ -44,6 +53,13 @@ export function isConnectionFailure(error: unknown): boolean {
   return code !== undefined && CONNECTION_FAILURES.has(code);
 }
 
+/** A deadline expiring, whoever set it. Raised as a DOMException whose legacy
+ *  numeric `code` is 23, which the string-keyed set above cannot match. */
+export function isTimeout(error: unknown): boolean {
+  const held = error as { name?: string; cause?: { name?: string } };
+  return held?.name === "TimeoutError" || held?.cause?.name === "TimeoutError";
+}
+
 const agents = new Map<string, Agent>();
 const lastGoodAddress = new Map<string, { address: string; atMs: number }>();
 
@@ -57,19 +73,49 @@ function agentFor(hostname: string, address: string): Agent {
   const agent = new Agent({
     connect: {
       servername: hostname,
+      // Deferred a tick because dns.lookup is always asynchronous and the
+      // connect machinery is built on that. Answering inline runs internalConnect
+      // inside net.connect's own frame, so an address that fails the moment it is
+      // tried — no route at all, which is what a kit switching into bypass leaves
+      // behind — emits before the caller has attached its error handler, and
+      // lands as an uncaught exception in the main process instead of a rejected
+      // request.
       lookup: ((_host: string, options: { all?: boolean }, callback: unknown) => {
         const done = callback as (
           error: Error | null,
           address: string | { address: string; family: number }[],
           family?: number,
         ) => void;
-        if (options?.all) done(null, [{ address, family }]);
-        else done(null, address, family);
+        setImmediate(() => {
+          if (options?.all) done(null, [{ address, family }]);
+          else done(null, address, family);
+        });
       }) as never,
     },
   });
   agents.set(key, agent);
   return agent;
+}
+
+/** A pooled connection whose route has gone is never reset, so requests written
+ *  into it wait and later ones queue behind: 26s then 46s in the app against
+ *  1.4s from a process with no pool to inherit. */
+function forgetHost(hostname: string): void {
+  for (const key of agents.keys()) {
+    if (key.startsWith(`${hostname}|`)) forgetPin(hostname, key.slice(hostname.length + 1));
+  }
+  lastGoodAddress.delete(hostname);
+}
+
+function forgetPin(hostname: string, address: string): void {
+  const key = `${hostname}|${address}`;
+  const agent = agents.get(key);
+  if (!agent) return;
+  agents.delete(key);
+  if (lastGoodAddress.get(hostname)?.address === address) lastGoodAddress.delete(hostname);
+  void agent.destroy().catch(() => {
+    // Already torn down; the point is that nothing reuses it.
+  });
 }
 
 function rememberedAddress(hostname: string): string | null {
@@ -82,12 +128,21 @@ function rememberedAddress(hostname: string): string | null {
   return held.address;
 }
 
-async function addressesFor(hostname: string): Promise<string[]> {
-  const [v4, v6] = await Promise.all([
-    dns.resolve4(hostname).catch(() => [] as string[]),
-    dns.resolve6(hostname).catch(() => [] as string[]),
-  ]);
-  return [...v4, ...v6];
+/** Not `dns.resolve*`: that reads its nameservers once at startup, so a process
+ *  outliving a network change keeps asking resolvers that no longer answer, 15s
+ *  of pure lookup in the app against 46ms here. Resolution takes no signal, so
+ *  the caller's is raced against it. */
+async function addressesFor(hostname: string, signal?: AbortSignal | null): Promise<string[]> {
+  const resolving = dns
+    .lookup(hostname, { all: true })
+    .then((found) => found.map((one) => one.address))
+    .catch(() => [] as string[]);
+  if (!signal) return resolving;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    if (signal.aborted) reject(signal.reason);
+    else signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
+  return Promise.race([resolving, aborted]);
 }
 
 /** Whether trying every address at once is acceptable for this request. A read
@@ -111,6 +166,29 @@ export function isRead(init?: RequestInit): boolean {
  */
 export const resilientFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const { hostname } = new URL(input instanceof Request ? input.url : String(input));
+  try {
+    return await sendTo(hostname, input, init);
+  } catch (error) {
+    // Only a transport fault condemns the pool. A refusal delivered over a
+    // healthy connection says nothing about the socket, and tearing it down
+    // would put a TLS handshake in front of every retry.
+    if (isConnectionFailure(error) || isTimeout(error)) forgetHost(hostname);
+    throw error;
+  }
+}) as unknown as typeof fetch;
+
+async function sendTo(
+  hostname: string,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Awaited<ReturnType<typeof undiciFetch>>> {
+  // Bounds each pin as well as the caller's deadline, so one silent socket
+  // cannot spend the whole budget.
+  const ownDeadline = (withinMs = ATTEMPT_TIMEOUT_MS) => {
+    const mine = AbortSignal.timeout(Math.min(ATTEMPT_TIMEOUT_MS, withinMs));
+    return init?.signal ? AbortSignal.any([init.signal, mine]) : mine;
+  };
+
   const attempt = (address?: string, signal?: AbortSignal) => {
     const options: Record<string, unknown> = { ...(init ?? {}) };
     if (signal) options.signal = signal;
@@ -123,27 +201,37 @@ export const resilientFetch = (async (input: RequestInfo | URL, init?: RequestIn
   const remembered = rememberedAddress(hostname);
   if (remembered) {
     try {
-      return await attempt(remembered);
+      return await attempt(remembered, ownDeadline());
     } catch (error) {
-      if (!isConnectionFailure(error)) throw error;
-      lastGoodAddress.delete(hostname);
+      // The caller's own deadline is theirs to report; only our attempt bound
+      // means "this pin is not worth waiting on".
+      if (init?.signal?.aborted) throw error;
+      if (!isConnectionFailure(error) && !isTimeout(error)) throw error;
+      forgetPin(hostname, remembered);
     }
   }
 
-  const addresses = (await addressesFor(hostname)).filter((one) => one !== remembered);
+  const addresses = (await addressesFor(hostname, init?.signal)).filter(
+    (one) => one !== remembered,
+  );
   // Nothing resolved — no addresses to choose between, so this is an ordinary
   // request and its failure is the honest one.
   if (addresses.length === 0) return await attempt();
 
   if (!isRead(init)) {
     let failure: unknown;
+    const walkEndsAt = Date.now() + WALK_TIMEOUT_MS;
     for (const address of addresses) {
+      const left = walkEndsAt - Date.now();
+      if (left <= 0) break;
       try {
-        const response = await attempt(address);
+        const response = await attempt(address, ownDeadline(left));
         lastGoodAddress.set(hostname, { address, atMs: Date.now() });
         return response;
       } catch (error) {
-        if (!isConnectionFailure(error)) throw error;
+        if (init?.signal?.aborted) throw error;
+        forgetPin(hostname, address);
+        if (!isConnectionFailure(error) && !isTimeout(error)) throw error;
         failure = error;
       }
     }
@@ -152,12 +240,14 @@ export const resilientFetch = (async (input: RequestInfo | URL, init?: RequestIn
 
   const abandon = addresses.map(() => new AbortController());
   const tries = addresses.map((address, index) =>
-    attempt(
-      address,
-      init?.signal
-        ? AbortSignal.any([init.signal, abandon[index]!.signal])
-        : abandon[index]!.signal,
-    ).then((response) => ({ address, response, index })),
+    attempt(address, AbortSignal.any([ownDeadline(), abandon[index]!.signal])).then(
+      (response) => ({ address, response, index }),
+      (error: unknown) => {
+        // A loser abandoned once another edge won is not a bad pin.
+        if (!abandon[index]!.signal.aborted) forgetPin(hostname, address);
+        throw error;
+      },
+    ),
   );
   try {
     const won = await Promise.any(tries);
@@ -171,4 +261,4 @@ export const resilientFetch = (async (input: RequestInfo | URL, init?: RequestIn
     const [first] = (error as AggregateError).errors ?? [];
     throw first ?? error;
   }
-}) as unknown as typeof fetch;
+}

--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -652,7 +652,11 @@ describe("updateRouterConfig", () => {
             ok: true,
             headers: {
               get: (name: string) =>
-                name === "grpc-status" ? "5" : name === "grpc-message" ? "DEVICE_NOT_CONNECTED" : null,
+                name === "grpc-status"
+                  ? "5"
+                  : name === "grpc-message"
+                    ? "DEVICE_NOT_CONNECTED"
+                    : null,
             },
             arrayBuffer: async () => new Uint8Array().buffer,
           } as unknown as Response;
@@ -757,9 +761,10 @@ describe("updateRouterConfig", () => {
       prepareRouterConfigUpdate: async () => new Uint8Array(),
     });
 
-    await expect(
-      handler.updateRouterConfig({ kind: "factoryReset" }),
-    ).resolves.toMatchObject({ status: 200, body: { applied: true } });
+    await expect(handler.updateRouterConfig({ kind: "factoryReset" })).resolves.toMatchObject({
+      status: 200,
+      body: { applied: true },
+    });
   });
 
   it("given: a target cached during a flip, should: re-derive it rather than write to it", async () => {

--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -551,10 +551,277 @@ describe("updateRouterConfig", () => {
       prepareRouterConfigUpdate: async (_update, _targetId, send) => send(new Uint8Array()),
     });
 
+    // Nothing was dispatched, so the router not answering describes no call made.
     await expect(handler.updateRouterConfig(SUBNET)).resolves.toMatchObject({
       status: 504,
-      body: { error: "device_call_timeout" },
+      body: { error: "prepare_call_timeout" },
     });
+  });
+
+  it("given: a slow preamble, should: leave the write a full window of its own", async () => {
+    // Each phase fits the budget and the two together do not. DNS is the subject
+    // because it does not sever its own reply, so a timeout is still reported.
+    const PHASE_MS = 90;
+    // Abortable, or the deadline under test has nothing to cut short.
+    const wait = (signal?: AbortSignal | null) =>
+      new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, PHASE_MS);
+        signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(signal.reason);
+          },
+          { once: true },
+        );
+      });
+    const accepted = () =>
+      ({
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => new Uint8Array([0, 0, 0, 0, 0]).buffer,
+      }) as unknown as Response;
+    const inner = gateway(async (init) => {
+      await wait(init?.signal);
+      return accepted();
+    });
+
+    const handler = createCloudHandler({
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === AUTH_URL) await wait(init?.signal);
+        return inner(input, init);
+      }) as typeof fetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceCallTimeoutMs: PHASE_MS + 60,
+      prepareRouterConfigUpdate: async () => new Uint8Array(),
+    });
+
+    await expect(
+      handler.updateRouterConfig({ kind: "customDns", nameservers: ["1.1.1.1"] }),
+    ).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("given: a session miss and then a stalled retry, should: not report the router as silent", async () => {
+    // The refused first attempt is retried whole, so how far that one got says
+    // nothing about the second, which never reaches the router at all.
+    let authCalls = 0;
+    let deviceCalls = 0;
+    const denied = () =>
+      ({
+        status: 200,
+        ok: true,
+        headers: { get: (name: string) => (name === "grpc-status" ? "16" : null) },
+        arrayBuffer: async () => new Uint8Array().buffer,
+      }) as unknown as Response;
+    const inner = gateway(async () => {
+      deviceCalls += 1;
+      return denied();
+    });
+
+    const handler = createCloudHandler({
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === AUTH_URL && ++authCalls > 1) return stall(init);
+        return inner(input, init);
+      }) as typeof fetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceCallTimeoutMs: 20,
+      prepareRouterConfigUpdate: async () => new Uint8Array(),
+    });
+
+    await expect(handler.updateRouterConfig(SUBNET)).resolves.toMatchObject({
+      status: 504,
+      body: { error: "prepare_call_timeout" },
+    });
+    expect(deviceCalls).toBe(1);
+  });
+
+  it("given: the gateway briefly having no session to the router, should: try again", async () => {
+    // Measured on hardware: the write that ends bypass is refused with
+    // DEVICE_NOT_CONNECTED and accepted six seconds later, because a bypassed
+    // router holds only an intermittent session with the gateway.
+    let calls = 0;
+    const handler = createCloudHandler({
+      fetch: gateway(async () => {
+        calls += 1;
+        if (calls === 1)
+          return {
+            status: 200,
+            ok: true,
+            headers: {
+              get: (name: string) =>
+                name === "grpc-status" ? "5" : name === "grpc-message" ? "DEVICE_NOT_CONNECTED" : null,
+            },
+            arrayBuffer: async () => new Uint8Array().buffer,
+          } as unknown as Response;
+        return {
+          status: 200,
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([0, 0, 0, 0, 0]).buffer,
+        } as unknown as Response;
+      }),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceRetryDelayMs: 0,
+      prepareRouterConfigUpdate: async () => new Uint8Array(),
+    });
+
+    await expect(
+      handler.updateRouterConfig({ kind: "bypass", enabled: false }),
+    ).resolves.toMatchObject({ status: 200 });
+    expect(calls).toBe(2);
+  });
+
+  it("given: a router the gateway never has a session to, should: stop rather than retry forever", async () => {
+    let calls = 0;
+    const handler = createCloudHandler({
+      fetch: gateway(async () => {
+        calls += 1;
+        return {
+          status: 200,
+          ok: true,
+          headers: { get: (name: string) => (name === "grpc-status" ? "5" : null) },
+          arrayBuffer: async () => new Uint8Array().buffer,
+        } as unknown as Response;
+      }),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceRetryDelayMs: 0,
+      prepareRouterConfigUpdate: async () => new Uint8Array(),
+    });
+
+    // The far end refused, so this is not one of the writes that severs its own
+    // reply: it never took effect and must not be reported as applied. Tried
+    // exactly twice, the second time having thrown away everything learned,
+    // because resending the same bytes could only earn the same refusal.
+    await expect(
+      handler.updateRouterConfig({ kind: "bypass", enabled: false }),
+    ).resolves.toMatchObject({ status: 502 });
+    expect(calls).toBe(2);
+  });
+
+  it("given: an account read that lists only a mesh node, should: not cache it as the target", async () => {
+    // A bypass flip drops the controller out of telemetry for a moment. A lone
+    // router left in that gap is the mesh node, which is never the controller
+    // and answers DEVICE_NOT_CONNECTED to everything.
+    const MESH = "Router-01000000000000000049375B";
+    let listController = false;
+    const handler = createCloudHandler({
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/device-data/cache/v1/telemetry"))
+          return res(200, {
+            data: {
+              columnNamesByDeviceType: {
+                r: ["DeviceType", "DeviceId", "WifiHopsFromController"],
+              },
+              values: listController
+                ? [
+                    ["r", TARGET, 0],
+                    ["r", MESH, 1],
+                  ]
+                : [["r", MESH, 1]],
+            },
+          });
+        return gateway(async () => res(200))(input, init);
+      }) as typeof fetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      readRouterConfig: async (targetId) => ({ countryCode: targetId }),
+    });
+
+    // A background account read landing in the gap. It may cache a controller
+    // for later writes, but a lone mesh node is not one.
+    await handler.handle("/cloud/account");
+    listController = true;
+    // The controller is back, and the read must go to it rather than to whatever
+    // the gap left behind.
+    await expect(handler.handle("/cloud/router-config")).resolves.toEqual({
+      status: 200,
+      body: { wifiConfig: { countryCode: TARGET } },
+    });
+  });
+
+  it("given: a factory reset whose reply dies with the router, should: report it as applied", async () => {
+    // A reset restarts the device it was sent to, so the reply is lost the same
+    // way a bypass flip loses its own. Reporting that as a failure would send the
+    // user to reset a router that is already wiping.
+    const handler = createCloudHandler({
+      fetch: gateway(stall),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceCallTimeoutMs: 5,
+      prepareRouterConfigUpdate: async () => new Uint8Array(),
+    });
+
+    await expect(
+      handler.updateRouterConfig({ kind: "factoryReset" }),
+    ).resolves.toMatchObject({ status: 200, body: { applied: true } });
+  });
+
+  it("given: a target cached during a flip, should: re-derive it rather than write to it", async () => {
+    // The snapshot taken mid-flip can omit the controller and leave only the mesh
+    // node, which is never connected. Cached, that answer refuses every write
+    // behind it for as long as it lives, which no amount of retrying survives.
+    const MESH = "Router-01000000000000000049375B";
+    let listController = false;
+    const targets: string[] = [];
+    const handler = createCloudHandler({
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).includes("/device-data/cache/v1/telemetry"))
+          return res(200, {
+            data: {
+              columnNamesByDeviceType: { r: ["DeviceType", "DeviceId", "WifiHopsFromController"] },
+              values: listController
+                ? [
+                    ["r", TARGET, 0],
+                    ["r", MESH, 1],
+                  ]
+                : [["r", MESH, 1]],
+            },
+          });
+        return gateway(async () => res(200))(input, init);
+      }) as typeof fetch,
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      readRouterConfig: async (targetId) => ({ countryCode: targetId }),
+      prepareRouterConfigUpdate: async (_update, targetId) => {
+        targets.push(targetId);
+        return new Uint8Array();
+      },
+    });
+
+    // A read during the gap caches the only router the account listed.
+    await handler.handle("/cloud/router-config");
+    listController = true;
+    await handler.updateRouterConfig({ kind: "bypass", enabled: false });
+
+    expect(targets).toEqual([TARGET]);
+  });
+
+  it("given: a refused subnet write, should: not repeat a networks block read before it", async () => {
+    let calls = 0;
+    const handler = createCloudHandler({
+      fetch: gateway(async () => {
+        calls += 1;
+        return {
+          status: 200,
+          ok: true,
+          headers: { get: (name: string) => (name === "grpc-status" ? "5" : null) },
+          arrayBuffer: async () => new Uint8Array().buffer,
+        } as unknown as Response;
+      }),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      deviceRetryDelayMs: 0,
+      prepareRouterConfigUpdate: async () => new Uint8Array(),
+    });
+
+    await expect(handler.updateRouterConfig(SUBNET)).resolves.toMatchObject({ status: 502 });
+    expect(calls).toBe(1);
   });
 
   it("given: a DNS write that stalls, should: stay retryable rather than claim success", async () => {

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -26,9 +26,7 @@ const IDS_TTL_MS = 5 * 60_000; // account/service-line numbers change ~never; ca
  *  a snapshot that is no longer current; the others name one field and nothing
  *  else, so sending the same value twice is the same as sending it once. */
 function retriesWhenMissing(update: RouterConfigUpdate): boolean {
-  return (
-    update.kind === "bypass" || update.kind === "customDns" || update.kind === "factoryReset"
-  );
+  return update.kind === "bypass" || update.kind === "customDns" || update.kind === "factoryReset";
 }
 
 /** The account has not named a router this write could target. Nothing is wrong

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -21,6 +21,15 @@ const API = "https://starlink.com/api";
 const DEVICE_HANDLE = `${API}/SpaceX.API.Device.Device/Handle`;
 const REFRESH_TTL_MS = 60_000; // the Access.V1 token is short-lived; refresh at most this often
 const IDS_TTL_MS = 5 * 60_000; // account/service-line numbers change ~never; cache across routes
+/** Whether a refused write may simply be sent again. A subnet change carries a
+ *  `networks` block read before the first try, so repeating it would write back
+ *  a snapshot that is no longer current; the others name one field and nothing
+ *  else, so sending the same value twice is the same as sending it once. */
+function retriesWhenMissing(update: RouterConfigUpdate): boolean {
+  return (
+    update.kind === "bypass" || update.kind === "customDns" || update.kind === "factoryReset"
+  );
+}
 
 /** The account has not named a router this write could target. Nothing is wrong
  *  with the session or the connection: the telemetry feed is momentarily empty,
@@ -38,6 +47,16 @@ export class SessionExpiredError extends Error {
   constructor() {
     super("Starlink session expired or not connected");
     this.name = "SessionExpiredError";
+  }
+}
+
+/** A failure raised by the write itself rather than by anything leading up to it.
+ *  Carried on the error because a session miss retries the whole attempt, and a
+ *  flag set by an earlier one would still be standing. */
+class DispatchFailure extends Error {
+  constructor(readonly reason: unknown) {
+    super("router config write failed");
+    this.name = "DispatchFailure";
   }
 }
 
@@ -61,6 +80,11 @@ export interface CloudHandlerOptions {
   retryDelayMs?: number;
   /** Maximum time for each remote router mutation attempt. */
   deviceCallTimeoutMs?: number;
+  /** How long to wait for a device session to come back before trying again.
+   *  Injected so tests retry without waiting. */
+  deviceRetryDelayMs?: number;
+  /** Drop the transport's own cached state, for hosts that keep any. */
+  forgetHosts?: () => void;
   /** Trusted host callback: reads what the write must preserve — through the same
    *  gateway, against the target this handler resolved from the account — and
    *  encodes exactly one client update. Renderer-provided protobuf is never
@@ -118,7 +142,8 @@ const NO_CONTROLLER: CloudResult = {
   status: 503,
   body: {
     error: "router_not_reported",
-    message: "Starlink hasn't reported your router yet — try again in a minute.",
+    message:
+      "Starlink hasn't reported your router yet, so there's nothing to send this to. Try again once it checks in.",
   },
 };
 
@@ -199,12 +224,16 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
   const clearCookie = options.clearCookie ?? (() => {});
   const retryDelayMs = options.retryDelayMs ?? 150;
   const deviceCallTimeoutMs = options.deviceCallTimeoutMs ?? 15_000;
+  // Spaces the one retry past the 6s blink measured on hardware: with a refusal's
+  // own ~1.2s counted, the second and last attempt goes out at roughly 6.2s.
+  const deviceRetryDelayMs = options.deviceRetryDelayMs ?? 5_000;
   const prepareDeviceUpdate = options.prepareDeviceUpdate;
   const prepareDishConfigUpdate = options.prepareDishConfigUpdate;
   const prepareRouterConfigUpdate = options.prepareRouterConfigUpdate;
   const readRouterSubnet = options.readRouterSubnet;
   const readRouterClients = options.readRouterClients;
   const readRouterConfig = options.readRouterConfig;
+  const forgetHosts = options.forgetHosts;
 
   let cachedCookie: string | null = null;
   let cachedAt = 0;
@@ -222,6 +251,15 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     cachedIdsAt = 0;
     cachedControllerId = null;
     cachedControllerIdAt = 0;
+  }
+
+  /** Everything a restart would drop. A device the gateway says it cannot reach
+   *  is the one case where our own cached answers are the likelier fault: a
+   *  target learned during a flip can name a mesh node that is never connected,
+   *  and no amount of asking again fixes an id. */
+  function forgetEverythingLearned(): void {
+    forgetSession();
+    forgetHosts?.();
   }
 
   /** Swap in a freshly-minted Access.V1 (the webagg/telemetryagg calls 401
@@ -375,8 +413,17 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
    * whole reason a bypassed kit, which answers nothing on the LAN, can still be
    * configured.
    */
-  async function resolveControllerId(cookie: string, abortSignal?: AbortSignal): Promise<string> {
-    if (cachedControllerId && Date.now() - cachedControllerIdAt < IDS_TTL_MS) {
+  async function resolveControllerId(
+    cookie: string,
+    abortSignal?: AbortSignal,
+    /** Reads may reuse a recent answer. A write may not: the id is learned from a
+     *  telemetry snapshot, and the snapshot taken during a flip can omit the
+     *  controller and name only a mesh node, which is never connected. Cached,
+     *  that answer outlives the flip and refuses every write behind it. The
+     *  correction costs one call on a deliberate, rare action. */
+    cached = true,
+  ): Promise<string> {
+    if (cached && cachedControllerId && Date.now() - cachedControllerIdAt < IDS_TTL_MS) {
       return cachedControllerId;
     }
     const { acc } = await resolveIds(cookie, abortSignal);
@@ -386,17 +433,29 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       { accountNumber: acc },
       abortSignal,
     );
+    if (!rememberController(telemetry, true)) throw new ControllerUnknownError();
+    return cachedControllerId as string;
+  }
+
+  /** Caches the controller named by any telemetry reply, so a write prepared over
+   *  a network it is about to take down needs one round trip fewer.
+   *
+   *  `lastResort` is only for a caller about to write: a lone router in a reply
+   *  is the controller when someone asked for it right then, but a bypass flip
+   *  can drop the controller out of telemetry for a moment, and a background read
+   *  landing there would cache the mesh node — which is never the controller and
+   *  answers DEVICE_NOT_CONNECTED — for the whole life of the cache. */
+  function rememberController(telemetry: unknown, lastResort = false): boolean {
     const routers = Object.entries(deviceTelemetryFrom(telemetry)).filter(
       ([, device]) => device.kind === "router",
     );
-    if (routers.length === 0) throw new ControllerUnknownError();
     const controller =
       routers.find(([, device]) => device.hops === 0) ??
-      (routers.length === 1 ? routers[0] : undefined);
-    if (!controller) throw new ControllerUnknownError();
+      (lastResort && routers.length === 1 ? routers[0] : undefined);
+    if (!controller) return false;
     cachedControllerId = controller[0];
     cachedControllerIdAt = Date.now();
-    return cachedControllerId;
+    return true;
   }
 
   /** Run one bounded read against the account's controller: resolve the target,
@@ -434,6 +493,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
               () => null,
             ),
           ]);
+          if (telemetry) rememberController(telemetry);
           return { identity, serviceLine, deviceTelemetry: deviceTelemetryFrom(telemetry) };
         });
         return { status: 200, body };
@@ -678,32 +738,55 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
     return applyDishConfigUpdate(changes);
   }
 
+  /**
+   * A device the gateway says it cannot reach, tried once more from nothing.
+   *
+   * Resending the same bytes cannot help: the target id is already encoded in
+   * them, and a target learned during a flip can name a mesh node that is never
+   * connected. Only dropping what we learned and building the request again can
+   * change the answer, which is why reloading the app worked and retrying by
+   * hand did not.
+   */
   async function applyRouterConfigUpdate(update: RouterConfigUpdate): Promise<CloudResult> {
+    const first = await sendRouterConfigUpdate(update);
+    const body = first.body as { deviceUnreachable?: boolean } | undefined;
+    if (!body?.deviceUnreachable || !retriesWhenMissing(update)) return first;
+    forgetEverythingLearned();
+    await new Promise((resolve) => setTimeout(resolve, deviceRetryDelayMs));
+    return sendRouterConfigUpdate(update);
+  }
+
+  async function sendRouterConfigUpdate(update: RouterConfigUpdate): Promise<CloudResult> {
     if (!readCookie()) return NOT_CONNECTED;
-    let configWriteDispatched = false;
     try {
       if (!prepareRouterConfigUpdate)
         return { status: 503, body: { error: "router_config_update_unavailable" } };
-      const abortSignal = AbortSignal.timeout(deviceCallTimeoutMs);
+      // The calls that prepare a write must not spend the window the write needs.
+      const preambleSignal = AbortSignal.timeout(deviceCallTimeoutMs);
       await withFreshCookie(async (cookie) => {
-        const targetId = await resolveControllerId(cookie, abortSignal);
-        const callGateway = (requestBytes: Uint8Array) =>
+        const targetId = await resolveControllerId(cookie, preambleSignal, false);
+        const gatewayOn = (abortSignal: AbortSignal) => (requestBytes: Uint8Array) =>
           grpcWebUnaryCall(DEVICE_HANDLE, requestBytes, abortSignal, {
             fetch: doFetch,
             headers: { cookie },
           });
-        const requestBytes = await prepareRouterConfigUpdate(update, targetId, callGateway);
+        const requestBytes = await prepareRouterConfigUpdate(
+          update,
+          targetId,
+          gatewayOn(preambleSignal),
+        );
         try {
-          configWriteDispatched = true;
-          await callGateway(requestBytes);
-        } catch (error) {
-          if (error instanceof GrpcWebError && error.grpcStatus === 16)
+          await gatewayOn(AbortSignal.timeout(deviceCallTimeoutMs))(requestBytes);
+        } catch (failure) {
+          if (failure instanceof GrpcWebError && failure.grpcStatus === 16)
             throw new SessionExpiredError();
-          throw error;
+          throw new DispatchFailure(failure);
         }
-      }, abortSignal);
+      }, preambleSignal);
       return { status: 200, body: { ok: true } };
-    } catch (error) {
+    } catch (thrown) {
+      const dispatched = thrown instanceof DispatchFailure;
+      const error = dispatched ? thrown.reason : thrown;
       if (error instanceof SessionExpiredError) return NOT_CONNECTED;
       if (error instanceof ControllerUnknownError) return NO_CONTROLLER;
       // A subnet change and a bypass switch both reconfigure the LAN carrying
@@ -712,22 +795,39 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       // dead socket where it is not — a service worker's fetch rejects the moment
       // the network goes. Neither is the far end refusing, and only the far end
       // can refuse.
-      const seversItsOwnReply = update.kind === "subnet" || update.kind === "bypass";
-      if (seversItsOwnReply && configWriteDispatched && !(error instanceof GrpcWebError)) {
+      const seversItsOwnReply =
+        update.kind === "subnet" || update.kind === "bypass" || update.kind === "factoryReset";
+      if (seversItsOwnReply && dispatched && !(error instanceof GrpcWebError)) {
         return { status: 200, body: { ok: true, applied: true } };
       }
       if (error instanceof DOMException && error.name === "TimeoutError") {
+        // A write that was never dispatched cannot be the router not answering.
         return {
           status: 504,
-          body: {
-            error: "device_call_timeout",
-            message: "Starlink did not answer the router change in time. Try again.",
-          },
+          body: dispatched
+            ? {
+                error: "device_call_timeout",
+                message: "Starlink did not answer the router change in time. Try again.",
+              }
+            : {
+                error: "prepare_call_timeout",
+                message:
+                  "Starlink didn't answer in time while preparing the change, so nothing was sent. Try again.",
+              },
         };
       }
       return {
         status: 502,
-        body: { error: "device_call_failed", message: (error as Error).message },
+        body: {
+          error: "device_call_failed",
+          message: (error as Error).message,
+          // The gateway had no session to the router. Nothing was applied and
+          // nothing is wrong with the request, so asking again later is the only
+          // thing that can succeed.
+          ...(error instanceof GrpcWebError && error.grpcStatus === 5
+            ? { deviceUnreachable: true }
+            : {}),
+        },
       };
     }
   }
@@ -740,6 +840,7 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       return subnetRefusal(update.subnet, update.password) === null;
     }
     if (update?.kind === "bypass") return typeof update.enabled === "boolean";
+    if (update?.kind === "factoryReset") return true;
     if (update?.kind !== "customDns") return false;
     if (!Array.isArray(update.nameservers)) return false;
     if (!update.nameservers.every((server) => typeof server === "string")) return false;

--- a/collector/historian.mts
+++ b/collector/historian.mts
@@ -30,6 +30,8 @@ import { join, resolve } from "node:path";
 import { createFileRegistry, fromBinary, toJson, type DescMessage } from "@bufbuild/protobuf";
 import { FileDescriptorSetSchema } from "@bufbuild/protobuf/wkt";
 import { grpcWebUnaryCall } from "../core/grpcWeb.ts";
+import { routerPresence, type RouterPresence } from "../core/routerPresence.ts";
+import type { DishStatusJson } from "../core/dishClient.ts";
 import { createRouterOrigins } from "../core/routerEndpoint.ts";
 import { readDevRouterAddress } from "./devRouterAddress.mts";
 import {
@@ -296,15 +298,18 @@ async function getWifiHistory(): Promise<{ eventLog?: { events?: unknown[] } }> 
 async function getStatusAlerts(): Promise<{
   alerts: Record<string, boolean>;
   ethSpeedMbps?: number;
+  routerPresence: RouterPresence;
 }> {
   const json = (await deviceCall(DISH_URL, GET_STATUS_FIELD)) as {
-    dishGetStatus?: { alerts?: Record<string, boolean>; ethSpeedMbps?: number };
+    dishGetStatus?: DishStatusJson;
   };
+  const status = json.dishGetStatus ?? null;
   return {
-    alerts: json.dishGetStatus?.alerts ?? {},
+    alerts: status?.alerts ?? {},
     // Carried alongside the flags because one of them contradicts it: the engine
     // needs the negotiated speed to tell a real dead link from a latched flag.
-    ethSpeedMbps: json.dishGetStatus?.ethSpeedMbps,
+    ethSpeedMbps: status?.ethSpeedMbps,
+    routerPresence: routerPresence(status),
   };
 }
 
@@ -1108,6 +1113,7 @@ async function pollAlerts(): Promise<void> {
     observation.dish = {
       alerts: dishStatus.alerts,
       ethSpeedMbps: dishStatus.ethSpeedMbps,
+      routerPresence: dishStatus.routerPresence,
       atMs: Date.now(),
     };
   } catch {
@@ -1125,7 +1131,8 @@ async function pollAlerts(): Promise<void> {
     latestRouterPingSuccessPercent = readRouterPingSuccessPercent(routerStatus.popPingDropRate5m);
     observation.router = { alerts: routerStatus.alerts ?? {}, atMs: Date.now() };
   } catch {
-    // router unreachable (or bypass mode) — leave its open episodes open
+    // router unreachable — leave its open episodes open. Whether the silence is
+    // a fault or a bypassed kit is the engine's call, off the dish reading above.
     latestRouterLatencyMs = null;
     latestRouterPingSuccessPercent = null;
     observation.router = { alerts: null, atMs: Date.now() };

--- a/core/alertEngine.test.ts
+++ b/core/alertEngine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { AlertEngine, type AlertObservation, type AlertTransition } from "./alertEngine";
+import type { RouterPresence } from "./routerPresence";
 
 const NOW = 1_700_000_000_000;
 
@@ -10,6 +11,14 @@ function bothAnswered(
   atMs = NOW,
 ): AlertObservation {
   return { dish: { alerts: dishAlerts, atMs }, router: { alerts: routerAlerts, atMs } };
+}
+
+/** A cycle where the router said nothing and the dish explained why. */
+function routerSilent(routerPresence: RouterPresence | undefined, atMs = NOW): AlertObservation {
+  return {
+    dish: { alerts: {}, routerPresence, atMs },
+    router: { alerts: null, atMs },
+  };
 }
 
 function keysOf(transitions: AlertTransition[]): string[] {
@@ -139,5 +148,75 @@ describe("AlertEngine", () => {
     engine.update(bothAnswered({ isHeating: true }));
     engine.update({ dish: { alerts: null, atMs: NOW + 5_000 } });
     expect(engine.statusList().find((check) => check.key === "isHeating")?.active).toBe(true);
+  });
+});
+
+describe("AlertEngine and a router that is silent on purpose", () => {
+  it("raises the unreachability when a router that should answer does not", () => {
+    const engine = new AlertEngine();
+    expect(keysOf(engine.update(routerSilent("present")))).toEqual([
+      "fired:system:routerUnreachable",
+    ]);
+  });
+
+  it("stays quiet when the dish reports the router bypassed", () => {
+    // The user switched it off from this very app. Announcing it as a fault is
+    // the app complaining about what it was told to do.
+    const engine = new AlertEngine();
+    expect(engine.update(routerSilent("bypassed"))).toEqual([]);
+  });
+
+  it("stays quiet when the kit has no router at all", () => {
+    const engine = new AlertEngine();
+    expect(engine.update(routerSilent("absent"))).toEqual([]);
+  });
+
+  it("closes an episode already open when bypass is switched on", () => {
+    // The key stays in scope, so the pass that stops desiring it also ends it.
+    const engine = new AlertEngine();
+    engine.update(routerSilent("present"));
+    expect(keysOf(engine.update(routerSilent("bypassed", NOW + 5_000)))).toEqual([
+      "cleared:system:routerUnreachable",
+    ]);
+  });
+
+  it("raises it again when the router is un-bypassed and still does not answer", () => {
+    const engine = new AlertEngine();
+    engine.update(routerSilent("bypassed"));
+    expect(keysOf(engine.update(routerSilent("present", NOW + 5_000)))).toEqual([
+      "fired:system:routerUnreachable",
+    ]);
+  });
+
+  it("raises it when the dish has said nothing about routers at all", () => {
+    // No evidence is not evidence of bypass.
+    const engine = new AlertEngine();
+    expect(keysOf(engine.update(routerSilent(undefined)))).toEqual([
+      "fired:system:routerUnreachable",
+    ]);
+  });
+
+  it("holds the last known presence across a silent dish poll", () => {
+    // A dish that stops replying has no new opinion. Dropping to "unknown" would
+    // resurrect the alert on the first dish timeout of a bypassed kit.
+    const engine = new AlertEngine();
+    engine.update(routerSilent("bypassed"));
+    const dishAlsoSilent: AlertObservation = {
+      dish: { alerts: null, atMs: NOW + 5_000 },
+      router: { alerts: null, atMs: NOW + 5_000 },
+    };
+    expect(keysOf(engine.update(dishAlsoSilent))).toEqual(["fired:system:dishUnreachable"]);
+  });
+
+  it("still holds the router's own alerts while its silence is excused", () => {
+    // Suppressing the unreachability must not also clear what the router last
+    // reported: that would record a recovery nobody observed.
+    const engine = new AlertEngine();
+    engine.update({
+      dish: { alerts: {}, routerPresence: "present", atMs: NOW },
+      router: { alerts: { poeRouterOvercurrent: true }, atMs: NOW },
+    });
+    expect(engine.update(routerSilent("bypassed", NOW + 5_000))).toEqual([]);
+    expect(engine.activeAlerts().map((a) => a.key)).toContain("poeRouterOvercurrent");
   });
 });

--- a/core/alertEngine.ts
+++ b/core/alertEngine.ts
@@ -32,6 +32,7 @@ import {
   type AlertSource,
   type AlertState,
 } from "./alertDefinitions";
+import { routerSilenceExpected, type RouterPresence } from "./routerPresence";
 
 /** One device's reply, stamped when it arrived. */
 export interface DeviceReading {
@@ -46,6 +47,10 @@ export interface DishReading extends DeviceReading {
   /** The dish's negotiated Ethernet speed, when the reply carried one. Read to
    *  catch a flag the firmware latches — see correctLatchedEthernetFlag. */
   ethSpeedMbps?: number;
+  /** What the dish says about the routers downstream of it. A router cannot
+   *  report its own absence, so this is the only thing that tells a bypassed or
+   *  missing router from one that has stopped answering. */
+  routerPresence?: RouterPresence;
 }
 
 /** Conditions a host observes about itself rather than off a device. It governs
@@ -123,6 +128,9 @@ export class AlertEngine {
   /** The last reading's checks per device, kept so an unanswered poll leaves the
    *  previous values standing rather than reading as an all-clear. */
   private dishChecks: AlertState[] = resolveAlerts(DISH_ALERTS, undefined, "dish");
+  /** The dish's last word on whether a router should be answering at all. Held
+   *  across a silent dish poll: a dish that stops replying has no new opinion. */
+  private routerPresence: RouterPresence | null = null;
   private routerChecks: AlertState[] = resolveAlerts(ROUTER_ALERTS, undefined, "router");
 
   /**
@@ -142,12 +150,13 @@ export class AlertEngine {
     const transitions: AlertTransition[] = [];
 
     if (observation.dish) {
-      const { alerts, atMs, ethSpeedMbps } = observation.dish;
+      const { alerts, atMs, ethSpeedMbps, routerPresence } = observation.dish;
       if (alerts !== null) {
         this.dishChecks = correctLatchedEthernetFlag(
           resolveAlerts(DISH_ALERTS, alerts, "dish"),
           ethSpeedMbps,
         );
+        if (routerPresence !== undefined) this.routerPresence = routerPresence;
       }
       transitions.push(
         ...this.reconcile(
@@ -169,11 +178,15 @@ export class AlertEngine {
       if (alerts !== null) {
         this.routerChecks = resolveAlerts(ROUTER_ALERTS, alerts, "router");
       }
+      const expected = routerSilenceExpected(this.routerPresence);
       transitions.push(
         ...this.reconcile(
           ROUTER_SCOPE,
           alerts === null
-            ? [...this.heldFor("router"), firingSystemAlert(SYSTEM_ALERTS.routerUnreachable)]
+            ? [
+                ...this.heldFor("router"),
+                ...(expected ? [] : [firingSystemAlert(SYSTEM_ALERTS.routerUnreachable)]),
+              ]
             : this.routerChecks.filter((check) => check.active),
           atMs,
         ),

--- a/core/dishClient.ts
+++ b/core/dishClient.ts
@@ -56,6 +56,7 @@ export const DISH_LAN_HANDLE_URL = `http://${DISH_LAN_ADDRESS}:9201/SpaceX.API.D
 // Oneof field numbers inside SpaceX.API.Device.Request (from the dish schema).
 const REQUEST_FIELD = {
   reboot: 1001,
+  factoryReset: 1011,
   getStatus: 1004,
   getHistory: 1007,
   getDeviceInfo: 1008,
@@ -584,6 +585,13 @@ export class DishClient {
   /** Reboot this device (dish or router). Drops connectivity for a few minutes. */
   async reboot(abortSignal?: AbortSignal): Promise<void> {
     await this.call(REQUEST_FIELD.reboot, abortSignal);
+  }
+
+  /** Wipe the device back to its shipped state. On a router that includes the
+   *  WiFi name and passphrase, and bypass mode with them: it is the only exit
+   *  the official app leaves once bypass is on. FactoryResetRequest is empty. */
+  async factoryReset(abortSignal?: AbortSignal): Promise<void> {
+    await this.call(REQUEST_FIELD.factoryReset, abortSignal);
   }
 
   /** Stow (fold flat) or unstow the dish. Motorized (mast) models only. */

--- a/core/routerConfigUpdate.test.ts
+++ b/core/routerConfigUpdate.test.ts
@@ -87,7 +87,7 @@ describe("buildRouterConfigRequest", () => {
     });
     // The passphrase lives under `networks`, which this must never carry: it only
     // ever reads back masked, so resending it would write the mask.
-    expect(Object.keys(request.wifiSetConfig.wifiConfig)).toEqual([
+    expect(Object.keys(request.wifiSetConfig!.wifiConfig)).toEqual([
       "nameservers",
       "applyNameservers",
     ]);
@@ -95,7 +95,7 @@ describe("buildRouterConfigRequest", () => {
 
   it("still sets the apply flag when clearing, so the router acts on the empty list", () => {
     const request = buildRouterConfigRequest(TARGET, { kind: "customDns", nameservers: [] });
-    expect(request.wifiSetConfig.wifiConfig).toEqual({ nameservers: [], applyNameservers: true });
+    expect(request.wifiSetConfig!.wifiConfig).toEqual({ nameservers: [], applyNameservers: true });
   });
 
   it("names only the bypass fields, so no other setting rides along", () => {
@@ -104,7 +104,7 @@ describe("buildRouterConfigRequest", () => {
       targetId: TARGET,
       wifiSetConfig: { wifiConfig: { bypassMode: true, applyBypassMode: true } },
     });
-    expect(Object.keys(request.wifiSetConfig.wifiConfig)).toEqual([
+    expect(Object.keys(request.wifiSetConfig!.wifiConfig)).toEqual([
       "bypassMode",
       "applyBypassMode",
     ]);
@@ -112,9 +112,17 @@ describe("buildRouterConfigRequest", () => {
 
   it("sends the apply flag when switching bypass off, not just when turning it on", () => {
     const request = buildRouterConfigRequest(TARGET, { kind: "bypass", enabled: false });
-    expect(request.wifiSetConfig.wifiConfig).toEqual({
+    expect(request.wifiSetConfig!.wifiConfig).toEqual({
       bypassMode: false,
       applyBypassMode: true,
+    });
+  });
+
+  it("sends a factory reset as its own oneof arm, carrying no config with it", () => {
+    // The router's only exit from bypass, and it must not smuggle a wifi write.
+    expect(buildRouterConfigRequest(TARGET, { kind: "factoryReset" })).toEqual({
+      targetId: TARGET,
+      factoryReset: {},
     });
   });
 
@@ -217,8 +225,8 @@ describe("buildRouterConfigRequest for a subnet", () => {
       { kind: "subnet", subnet: "192.168.2.1/24", password: "hunter2hunter2" },
       ROUTER_NETWORKS,
     );
-    expect(Object.keys(request.wifiSetConfig.wifiConfig)).toEqual(["networks", "applyNetworks"]);
-    expect(request.wifiSetConfig.wifiConfig.applyNetworks).toBe(true);
+    expect(Object.keys(request.wifiSetConfig!.wifiConfig)).toEqual(["networks", "applyNetworks"]);
+    expect(request.wifiSetConfig!.wifiConfig.applyNetworks).toBe(true);
   });
 
   it("refuses when the router reported no networks, rather than wiping them", () => {

--- a/core/routerConfigUpdate.ts
+++ b/core/routerConfigUpdate.ts
@@ -47,9 +47,12 @@ export function isSubnetPreset(value: string): value is SubnetPreset {
   return (SUBNET_PRESETS as readonly string[]).includes(value);
 }
 
+/** One `Request` oneof arm, as proto3 JSON renders it: the chosen field present
+ *  and the rest absent. */
 export interface RouterConfigRequestJson {
   targetId: string;
-  wifiSetConfig: { wifiConfig: Record<string, unknown> };
+  wifiSetConfig?: { wifiConfig: Record<string, unknown> };
+  factoryReset?: Record<string, never>;
 }
 
 /** The writes this builds. Each names one field, so two in flight cannot clobber
@@ -67,6 +70,12 @@ export type RouterConfigUpdate =
        *  router reports the stored one as `•••••` and takes that string
        *  literally if it is written back, locking every device off the WiFi. */
       password: string;
+    }
+  | {
+      /** Not a config field but the same shape of request: one targeted mutation
+       *  over the gateway, whose reply its own effect destroys. Carried here so
+       *  it inherits that handling rather than growing a parallel path. */
+      kind: "factoryReset";
     }
   | {
       kind: "bypass";
@@ -236,6 +245,8 @@ export function buildRouterConfigRequest(
       wifiSetConfig: { wifiConfig: { bypassMode: update.enabled, applyBypassMode: true } },
     };
   }
+  // FactoryResetRequest carries no fields.
+  if (update.kind === "factoryReset") return { targetId, factoryReset: {} };
   const nameservers = normalizeNameservers(update.nameservers);
   if (!nameservers) throw new Error("invalid DNS server address");
   return {

--- a/core/routerPresence.test.ts
+++ b/core/routerPresence.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { DishStatusJson } from "./dishClient";
+import { freshDownstreamRouterIds, routerPresence, routerSilenceExpected } from "./routerPresence";
+
+/** The id the test kit reports, kept verbatim so the shapes below are the ones
+ *  the dish actually sends. */
+const ROUTER_ID = "Router-010000000000000001B31340";
+const NOW = 1_787_345_200_000;
+
+/** The dish stamps lastSeen in nanoseconds. */
+function nsAgo(ms: number): string {
+  return String((NOW - ms) * 1e6);
+}
+
+function status(
+  downstream: Record<string, { role?: string; lastSeen?: string }> | undefined,
+  connected?: string[],
+): DishStatusJson {
+  return { downstreamRouters: downstream, connectedRouters: connected } as DishStatusJson;
+}
+
+describe("routerPresence", () => {
+  it("reads a working kit as present", () => {
+    // Captured from a Gen 3 kit with bypass off, 2026-08-21.
+    const dish = status({ [ROUTER_ID]: { role: "CONTROLLER", lastSeen: nsAgo(300) } });
+    expect(routerPresence(dish, NOW)).toBe("present");
+  });
+
+  it("reads a bypassed kit as bypassed, not as absent", () => {
+    // Captured from the same kit with bypass on: the entry stays and lastSeen
+    // keeps refreshing, so an empty map is never the test for bypass.
+    const dish = status({ [ROUTER_ID]: { role: "BYPASSED", lastSeen: nsAgo(838) } });
+    expect(routerPresence(dish, NOW)).toBe("bypassed");
+    expect(freshDownstreamRouterIds(dish, NOW)).toEqual([ROUTER_ID]);
+  });
+
+  it("reads a kit with no router at all as absent", () => {
+    expect(routerPresence(status({}), NOW)).toBe("absent");
+    expect(routerPresence(status(undefined), NOW)).toBe("absent");
+    expect(routerPresence(null, NOW)).toBe("absent");
+  });
+
+  it("ignores a bypassed entry the dish has stopped refreshing", () => {
+    // Past the freshness window the entry is no evidence of anything, so it must
+    // not keep asserting bypass long after the map went stale.
+    const dish = status({ [ROUTER_ID]: { role: "BYPASSED", lastSeen: nsAgo(120_000) } });
+    expect(routerPresence(dish, NOW)).toBe("absent");
+  });
+
+  it("counts an entry the dish sent without a timestamp", () => {
+    const dish = status({ [ROUTER_ID]: { role: "BYPASSED" } });
+    expect(routerPresence(dish, NOW)).toBe("bypassed");
+  });
+
+  it("falls back to present when only the role-less list is sent", () => {
+    // connectedRouters carries no roles, so bypass cannot be read from it.
+    expect(routerPresence(status(undefined, [ROUTER_ID]), NOW)).toBe("present");
+  });
+
+  it("treats a mesh node alongside a bypassed controller as bypassed", () => {
+    const dish = status({
+      [ROUTER_ID]: { role: "BYPASSED", lastSeen: nsAgo(300) },
+      "Router-mesh": { role: "MESH", lastSeen: nsAgo(300) },
+    });
+    expect(routerPresence(dish, NOW)).toBe("bypassed");
+  });
+
+  it("accepts whatever case the firmware sends the role in", () => {
+    const dish = status({ [ROUTER_ID]: { role: "bypassed", lastSeen: nsAgo(300) } });
+    expect(routerPresence(dish, NOW)).toBe("bypassed");
+  });
+});
+
+describe("routerSilenceExpected", () => {
+  it("excuses a router that was switched off or was never there", () => {
+    expect(routerSilenceExpected("bypassed")).toBe(true);
+    expect(routerSilenceExpected("absent")).toBe(true);
+  });
+
+  it("does not excuse a router that should be answering", () => {
+    expect(routerSilenceExpected("present")).toBe(false);
+  });
+
+  it("has no opinion when the dish gave none", () => {
+    // An unreachable dish is no evidence, so the unreachability still gets
+    // raised — the dish's own alert is what tells the real story there.
+    expect(routerSilenceExpected(null)).toBe(false);
+  });
+});

--- a/core/routerPresence.ts
+++ b/core/routerPresence.ts
@@ -1,0 +1,78 @@
+// What the dish says about the routers downstream of it.
+//
+// Probed on a Gen 3 kit on 2026-08-21: a bypassed router stays listed with its
+// `role` changed from CONTROLLER to BYPASSED and its lastSeen still refreshing,
+// while a router that is merely off is dropped from the map entirely (verified
+// 2026-07-29). Bypass is therefore read from the role, never from absence.
+
+import type { DishStatusJson } from "./dishClient";
+
+/** Backstop against an entry that lingers; the dish drops a dead node itself. */
+const LAST_SEEN_MS = 60_000;
+
+const BYPASSED_ROLE = "BYPASSED";
+
+export type RouterPresence =
+  /** A router is up and is expected to answer on the LAN. */
+  | "present"
+  /** In bypass mode: it serves nothing, by design. */
+  | "bypassed"
+  /** No router on the kit at all, or it is powered off. */
+  | "absent";
+
+/** Nanosecond epoch string → milliseconds, or null when unparseable. */
+function lastSeenMs(value: string | undefined): number | null {
+  if (value == null) return null;
+  const ns = Number(value);
+  return Number.isFinite(ns) && ns > 0 ? ns / 1e6 : null;
+}
+
+/**
+ * The routers the dish is currently vouching for, by cloud DeviceId.
+ *
+ * connectedRouters carries the same ids with no timestamp, so it stands in only
+ * when the timestamped map is absent altogether — re-adding those ids alongside
+ * it would hand back the staleness the lastSeen check exists to filter.
+ */
+export function freshDownstreamRouterIds(
+  dish: DishStatusJson | null,
+  nowMs: number = Date.now(),
+): string[] {
+  const downstream = dish?.downstreamRouters;
+  if (!downstream) return (dish?.connectedRouters ?? []).filter((id): id is string => !!id);
+  const ids: string[] = [];
+  for (const [routerId, entry] of Object.entries(downstream)) {
+    const seenMs = lastSeenMs(entry?.lastSeen);
+    // Listing the router at all is the dish's statement that the link is up.
+    if (seenMs == null || nowMs - seenMs < LAST_SEEN_MS) ids.push(routerId);
+  }
+  return ids;
+}
+
+export function isBypassedRole(role: string | undefined): boolean {
+  return role?.toUpperCase() === BYPASSED_ROLE;
+}
+
+/**
+ * Why the router is or isn't expected to answer, according to the dish. Callers
+ * pass null for an unreachable dish, whose last snapshot is no longer evidence.
+ */
+export function routerPresence(
+  dish: DishStatusJson | null,
+  nowMs: number = Date.now(),
+): RouterPresence {
+  const fresh = new Set(freshDownstreamRouterIds(dish, nowMs));
+  if (fresh.size === 0) return "absent";
+  const downstream = dish?.downstreamRouters;
+  // connectedRouters carries no roles, so bypass cannot be read from it.
+  if (!downstream) return "present";
+  // A mesh node is never the bypassed one, so any entry claiming it settles it.
+  for (const [routerId, entry] of Object.entries(downstream))
+    if (fresh.has(routerId) && isBypassedRole(entry?.role)) return "bypassed";
+  return "present";
+}
+
+/** Whether the router's silence on the LAN is expected rather than a fault. */
+export function routerSilenceExpected(presence: RouterPresence | null): boolean {
+  return presence === "bypassed" || presence === "absent";
+}

--- a/core/schedule.test.ts
+++ b/core/schedule.test.ts
@@ -13,6 +13,7 @@ import {
   formatScheduleParam,
   parseScheduleParam,
   scheduleActive,
+  scheduleGoverns,
   scheduleSegment,
   type Schedule,
 } from "./schedule";
@@ -154,6 +155,33 @@ describe("a timetable's current state", () => {
     };
     expect(blockedAt(january, at(17, 10))).toBe(false);
     expect(Number.isFinite(scheduleSegment(january, at(17, 10)).endMs)).toBe(true);
+  });
+});
+
+// `blockedAt` returning false covers two different situations, and a card that
+// cannot tell them apart calls a rule sitting out the weekend "Active".
+describe("whether the timetable has any bearing at all", () => {
+  const weekdaysOnly: Schedule = {
+    mode: "allow",
+    windows: [{ weekdays: WEEKDAYS, startMinute: 16 * 60, endMinute: 20 * 60 }],
+  };
+
+  it("sits out a day it never mentions", () => {
+    expect(scheduleGoverns(weekdaysOnly, at(22, 12))).toBe(false);
+  });
+
+  it("governs a day it covers, inside its window and outside it", () => {
+    expect(scheduleGoverns(weekdaysOnly, at(21, 18))).toBe(true);
+    expect(scheduleGoverns(weekdaysOnly, at(21, 10))).toBe(true);
+  });
+
+  it("goes on governing past midnight while a window it opened is still running", () => {
+    const overnight: Schedule = {
+      mode: "allow",
+      windows: [{ weekdays: [5], startMinute: 21 * 60, endMinute: 2 * 60 }],
+    };
+    expect(scheduleGoverns(overnight, at(22, 1))).toBe(true);
+    expect(scheduleGoverns(overnight, at(22, 3))).toBe(false);
   });
 });
 

--- a/core/schedule.ts
+++ b/core/schedule.ts
@@ -102,6 +102,18 @@ function dayIsScheduled(schedule: Schedule, atMs: number): boolean {
 }
 
 /**
+ * Whether the timetable has any bearing at this instant.
+ *
+ * False on a day it never names, where the rule neither allows nor blocks and is
+ * simply sitting the day out. Distinct from `blockedAt` returning false, which
+ * also covers being inside a window that is letting traffic through.
+ */
+export function scheduleGoverns(schedule: Schedule, atMs: number): boolean {
+  if (schedule.windows.some((window) => windowContains(window, atMs))) return true;
+  return dayIsScheduled(schedule, atMs);
+}
+
+/**
  * Whether the schedule holds the device shut at this instant.
  *
  * A day the timetable does not cover is unrestricted rather than shut: a

--- a/dev/bypass.mts
+++ b/dev/bypass.mts
@@ -1,0 +1,74 @@
+// Turn bypass on or off without the app.
+//
+// The UI's bypass control is gated on a live account read, so a failed read
+// leaves the one thing that undoes bypass unusable. This talks to the same
+// cloud handler the app does, with the same session file, and needs no window.
+//
+//   npx tsx dev/bypass.mts off
+//   npx tsx dev/bypass.mts on
+
+import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { createCloudHandler } from "../cloud/starlinkCloudHandler.ts";
+import { resilientFetch } from "../cloud/resilientFetch.ts";
+import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
+import { buildRouterConfigRequest, readCurrentNetworks } from "../core/routerConfigUpdate.ts";
+
+const COOKIE_FILE = resolve(process.cwd(), ".starlink-cookie");
+
+function readCookie(): string | null {
+  try {
+    return readFileSync(COOKIE_FILE, "utf8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+const wanted = process.argv[2];
+if (wanted !== "on" && wanted !== "off") {
+  console.error("usage: npx tsx dev/bypass.mts <on|off>");
+  process.exit(2);
+}
+
+if (!readCookie()) {
+  console.error(`No session in ${COOKIE_FILE}. Sign in through the app first.`);
+  process.exit(1);
+}
+
+let routerPromise: Promise<DishClient> | null = null;
+const loadRouter = () =>
+  (routerPromise ??= DishClient.load("router", {
+    handleUrl: ROUTER_LAN_HANDLE_URL,
+    protosetBytes: new Uint8Array(readFileSync(resolve(process.cwd(), "public/dish.protoset"))),
+  }));
+
+const handler = createCloudHandler({
+  fetch: resilientFetch,
+  readCookie,
+  writeCookie: (cookie: string) => writeFileSync(COOKIE_FILE, cookie, "utf8"),
+  clearCookie: () => {
+    try {
+      rmSync(COOKIE_FILE);
+    } catch {
+      /* already gone */
+    }
+  },
+  prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
+    const client = await loadRouter();
+    const networks = await readCurrentNetworks(update, client, targetId, callGateway);
+    return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
+  },
+});
+
+const enabled = wanted === "on";
+console.log(`Sending bypass ${wanted}…`);
+const { status, body } = await handler.updateRouterConfig({ kind: "bypass", enabled });
+// A write that lands kills the network carrying its own reply, so the handler
+// reports 200 for a deadline it could not have heard the far end refuse.
+console.log(`HTTP ${status} ${JSON.stringify(body)}`);
+console.log(
+  status === 200
+    ? "Sent. Watch the dish's downstreamRouters role to see it take effect."
+    : "Not sent. Run it again; the session or the route may have been mid-change.",
+);
+process.exit(status === 200 ? 0 : 1);

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -6,7 +6,15 @@
 // exactly as the dev proxy relies on.
 
 import { app, safeStorage, BrowserWindow, session } from "electron";
-import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  appendFileSync,
+  mkdirSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler";
 import { resilientFetch } from "../cloud/resilientFetch";
@@ -67,6 +75,54 @@ function clearCookie(): void {
   }
 }
 
+/** Roughly a day of calls at this app's rate, and small enough to paste. */
+const TIMING_LOG_MAX_BYTES = 256 * 1024;
+
+/** One line per cloud call into logs/cloud-timing.log. A write that fails here
+ *  reports a deadline with no record of which call spent it, and the phase is
+ *  the whole diagnosis. */
+const timedFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = String(input instanceof Request ? input.url : input);
+  const name = url.includes("auth-rp")
+    ? "auth"
+    : url.includes("service-lines")
+      ? "service-lines"
+      : url.includes("telemetry")
+        ? "telemetry"
+        : url.includes("Handle")
+          ? "gateway"
+          : // Path only: a query string carries the session, and an account or
+            // service-line number in the path is the customer's, not a route name.
+            new URL(url).pathname.replace(/\/(AST|SL)-[\w-]+/gi, "/…");
+  const started = Date.now();
+  const note = (outcome: string) => {
+    try {
+      const directory = app.getPath("logs");
+      mkdirSync(directory, { recursive: true });
+      const file = join(directory, "cloud-timing.log");
+      // Truncated rather than rotated: this is a rolling window for diagnosing
+      // the call in front of you, not a record worth keeping.
+      if ((statSync(file, { throwIfNoEntry: false })?.size ?? 0) > TIMING_LOG_MAX_BYTES)
+        rmSync(file);
+      appendFileSync(
+        file,
+        `[${new Date().toISOString()}] ${name} ${Date.now() - started}ms ${outcome}\n`,
+      );
+    } catch {
+      // Nowhere to write it is not worth failing the request over.
+    }
+  };
+  try {
+    const response = await resilientFetch(input, init);
+    note(`HTTP ${response.status}`);
+    return response;
+  } catch (error) {
+    const held = error as { name?: string; code?: string; cause?: { code?: string } };
+    note(`FAILED ${held.cause?.code ?? held.code ?? held.name ?? "unknown"}`);
+    throw error;
+  }
+}) as typeof fetch;
+
 /** Create the cloud client once, after the app is ready (the data path needs it). */
 export function startCloud(rendererRoot: string, sessionFile?: string): void {
   cookieFile = sessionFile ?? join(app.getPath("userData"), "starlink-session.bin");
@@ -84,7 +140,7 @@ export function startCloud(rendererRoot: string, sessionFile?: string): void {
       protosetBytes: new Uint8Array(readFileSync(protosetPath)),
     }));
   handler = createCloudHandler({
-    fetch: resilientFetch,
+    fetch: timedFetch,
     readCookie,
     writeCookie,
     clearCookie,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@
 import {
   app,
   BrowserWindow,
+  dialog,
   Tray,
   Menu,
   nativeImage,
@@ -17,7 +18,7 @@ import {
 } from "electron";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
-import { existsSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { registerAppProtocolScheme, handleAppProtocol, APP_ENTRY_URL } from "./appProtocol";
 import {
   startCollector,
@@ -63,6 +64,79 @@ app.setName("Dishylink");
 
 // Must run before the app is ready, so it's at module load rather than in whenReady.
 registerAppProtocolScheme();
+
+// This process keeps a recorder and a cloud session reaching the network with no
+// window open, so a route that goes away under a request in flight — sleep, a
+// VPN, switching the router into bypass — arrives here as a modal "A JavaScript
+// error occurred" box the user can neither act on nor prevent. Only that class
+// is absorbed; anything else is re-thrown and stays as fatal as it was, because
+// a guard that hid real faults would trade a visible crash for a silent one.
+const NETWORK_FAILURES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+]);
+
+function networkFailure(value: unknown): boolean {
+  const code = (value as NodeJS.ErrnoException | null)?.code;
+  return typeof code === "string" && NETWORK_FAILURES.has(code);
+}
+
+/** The last thing written, so a machine that stays offline repeating the same
+ *  failure every tick does not grow the file without bound. */
+let lastFailureLogged = "";
+
+function logFailure(kind: string, value: unknown): void {
+  // The code lives on the object rather than in the message, and without it a
+  // network fault reads as an ordinary error.
+  const detail =
+    value instanceof Error
+      ? `${(value as NodeJS.ErrnoException).code ?? ""} ${value.stack ?? value.message}`.trim()
+      : String(value);
+  console.error(`[main] ${kind}: ${detail}`);
+  if (detail === lastFailureLogged) return;
+  lastFailureLogged = detail;
+  try {
+    const directory = app.getPath("logs");
+    mkdirSync(directory, { recursive: true });
+    appendFileSync(
+      join(directory, "main.log"),
+      `[${new Date().toISOString()}] ${kind}: ${detail}\n`,
+    );
+  } catch {
+    // Nowhere to write it is not itself worth bringing the app down for.
+  }
+}
+
+// Installing a handler replaces Electron's, which is what puts the box on
+// screen, so anything not absorbed has to raise it again: a real fault must stay
+// exactly as loud and as fatal as it is without this. Re-throwing from here does
+// not recurse — Node exits with the stack printed.
+function fatal(kind: string, value: unknown): never {
+  const detail = value instanceof Error ? (value.stack ?? value.message) : String(value);
+  try {
+    dialog.showErrorBox("A JavaScript error occurred in the main process", detail);
+  } catch {
+    // Before the app is ready there is no window server to ask; the throw stands.
+  }
+  throw value instanceof Error ? value : new Error(`${kind}: ${detail}`);
+}
+
+process.on("unhandledRejection", (reason) => {
+  logFailure("unhandled rejection", reason);
+  if (!networkFailure(reason)) fatal("unhandled rejection", reason);
+});
+process.on("uncaughtException", (error) => {
+  logFailure("uncaught exception", error);
+  if (!networkFailure(error)) fatal("uncaught exception", error);
+});
 
 // Set by vite-plugin-electron while serving; absent in a packaged build.
 const devServerUrl = process.env.VITE_DEV_SERVER_URL;

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -10,6 +10,8 @@ import type { MeterHost } from "../lib/meterHost";
 import { IndexedDbHistory } from "../lib/history";
 import { singleFlight } from "../lib/singleFlight";
 import { NOTIFICATIONS_ENABLED_KEY, type NotifyResult } from "../lib/notificationHost";
+import { BADGE_MODE_KEY, storedBadgeMode } from "../lib/badgeModeHost";
+import { badgeAlerts } from "@/lib/badgeMode";
 import { loadRouterAddress, watchRouterAddress } from "../lib/endpoints";
 
 // The toolbar icon opens the full dashboard page, never a toolbar-anchored
@@ -21,6 +23,7 @@ const SURFACE_KEY = "surface";
 const WINDOW_BOUNDS_KEY = "dashboardWindowBounds";
 const DASHBOARD_WINDOW_ID_KEY = "dashboardWindowId";
 const LAST_DRAIN_KEY = "lastDrain";
+const LAST_ACTIVE_KEY = "lastActiveAlerts";
 
 /** The account this worker holds, as the recorder and the API router use it. */
 const meterHost: MeterHost = {
@@ -208,28 +211,22 @@ const BADGE_COLOR: Record<AlertSeverity, string> = {
 // `browser_action` for Firefox at build time, but the JS namespace does not.
 const action = browser.action ?? browser.browserAction;
 
-/**
- * Reflect the live alert set onto the toolbar icon — the same count the app's
- * bell shows, so it reads identically inside and out.
- *
- * Driven from `active` — the episodes still open after this tick's reconcile,
- * worst first — not from the tick's transitions. A badge set from edges would
- * blank on the next service-worker restart, which happens between every alarm;
- * the standing count has to come from the standing state. An empty set clears
- * the badge, so a cleared alert removes it with no separate step.
- *
- * Starlink outages are left out, exactly as the bell leaves them out: a healthy
- * dish drops its link to the satellites many times an hour as they hand over,
- * and a badge that counted each one would sit permanently lit over something
- * that needs no attention. Outages surface as their own thing, not as a device
- * fault to be tallied here.
- */
-function badgeWorthy(alert: AlertState): boolean {
-  return !(alert.source === "system" && alert.key === "starlinkOutage");
+/** The last tick's alert set, so a setting changed between ticks can re-render
+ *  the badge without polling the devices again. */
+async function rememberActive(active: AlertState[]): Promise<void> {
+  await browser.storage.local.set({ [LAST_ACTIVE_KEY]: active });
 }
 
+async function repaintBadge(): Promise<void> {
+  const stored = await browser.storage.local.get(LAST_ACTIVE_KEY);
+  await updateBadge((stored[LAST_ACTIVE_KEY] as AlertState[] | undefined) ?? []);
+}
+
+/** Driven from the standing `active` set, never from the tick's transitions: a
+ *  badge set from edges would blank on the next service-worker restart, which
+ *  happens between every alarm. */
 async function updateBadge(active: AlertState[]): Promise<void> {
-  const shown = active.filter(badgeWorthy);
+  const shown = badgeAlerts(active, await storedBadgeMode());
   await action.setBadgeText({ text: shown.length === 0 ? "" : String(shown.length) });
   if (shown.length === 0) return;
   // activeAlerts() sorts worst-first, so the head sets the tint.
@@ -327,9 +324,15 @@ export default defineBackground(() => {
   const drain = async () => {
     const { status, alerts, active } = await drainOnce(meterHost);
     await browser.storage.local.set({ [LAST_DRAIN_KEY]: status });
+    await rememberActive(active);
     await updateBadge(active);
     await announceAlerts(alerts);
   };
+  // The tick is half a minute away at worst, which is long enough for a setting
+  // that changed nothing on screen to read as broken.
+  browser.storage.onChanged.addListener((changes, area) => {
+    if (area === "local" && BADGE_MODE_KEY in changes) void repaintBadge();
+  });
   // Waking on an alarm evaluates this module and dispatches onAlarm, so both
   // paths below ask for a tick at once. Data limits are read-modify-write: two
   // ticks in flight together would each read an unspent allowance, each pause the

--- a/extension/entrypoints/dashboard/main.tsx
+++ b/extension/entrypoints/dashboard/main.tsx
@@ -8,6 +8,8 @@ import { setApiHost } from "@/lib/apiHost";
 import { setCloudHost } from "@/lib/cloudHost";
 import { setSelfDeviceHost } from "@/lib/selfDeviceHost";
 import { bindNotifications, setNotificationHost } from "@/lib/notifications";
+import { setBadgeModeHost } from "@/lib/badgeMode";
+import { extensionBadgeModeHost } from "../../lib/badgeModeHost";
 import { setDishHost } from "@core/dishClient";
 import { setSatelliteHost } from "@/lib/satellites";
 import { extensionApiTransport } from "../../lib/apiTransport";
@@ -47,6 +49,8 @@ setSelfDeviceHost({ read: loadSelfDeviceClientId, write: storeSelfDeviceClientId
 // notifications" toggle reads and writes the worker's own preference through this
 // bridge.
 setNotificationHost(extensionNotificationHost);
+
+setBadgeModeHost(extensionBadgeModeHost);
 
 // Where the router is, when 192.168.1.1 is wrong for this kit. Unlike the desktop
 // app, which resolves an origin per request in its main process, the extension

--- a/extension/lib/badgeModeHost.ts
+++ b/extension/lib/badgeModeHost.ts
@@ -1,0 +1,25 @@
+// The extension's side of the badge setting. It lives in chrome.storage.local,
+// not the page's localStorage, which the service worker cannot see.
+
+import { browser } from "wxt/browser";
+import {
+  DEFAULT_BADGE_MODE,
+  isBadgeMode,
+  type BadgeMode,
+  type BadgeModeBinding,
+} from "@/lib/badgeMode";
+
+export const BADGE_MODE_KEY = "badgeMode";
+
+export async function storedBadgeMode(): Promise<BadgeMode> {
+  const stored = await browser.storage.local.get(BADGE_MODE_KEY);
+  const value = stored[BADGE_MODE_KEY];
+  return isBadgeMode(value) ? value : DEFAULT_BADGE_MODE;
+}
+
+export const extensionBadgeModeHost: BadgeModeBinding = {
+  read: storedBadgeMode,
+  async write(mode: BadgeMode): Promise<void> {
+    await browser.storage.local.set({ [BADGE_MODE_KEY]: mode });
+  },
+};

--- a/extension/lib/collector.ts
+++ b/extension/lib/collector.ts
@@ -8,6 +8,7 @@
 
 import { DishClient, throughputMbps, type WifiClientJson } from "@core/dishClient";
 import { GrpcWebError } from "@core/grpcWeb";
+import { routerPresence } from "@core/routerPresence";
 import {
   decodeHistoryWindow,
   decodeOutageEvents,
@@ -168,6 +169,7 @@ async function readDishAlerts(dish: DishClient): Promise<DishReading> {
       // Carried because one of the flags contradicts it: the engine needs the
       // negotiated speed to tell a dead link from the firmware's latched one.
       ethSpeedMbps: status.ethSpeedMbps,
+      routerPresence: routerPresence(status),
       atMs: Date.now(),
     };
   } catch {

--- a/src/components/dashboard/DishTerminalCard.tsx
+++ b/src/components/dashboard/DishTerminalCard.tsx
@@ -1,6 +1,7 @@
 // Hardware, alignment, GPS, and network facts from the live status message.
 
 import type { DishStatusJson, DishReadyStatesJson } from "@core/dishClient";
+import { routerPresence } from "@core/routerPresence";
 import { dishModelFor, specForModel } from "../../lib/dishMesh";
 import { formatAttitudeState, formatRelativeTime, formatUptime } from "../../lib/format";
 import { FactGrid, FactRow } from "../ui/fact-row";
@@ -128,10 +129,12 @@ export function DishTerminalCard({
     },
     {
       // The dish sends router identities, not a count — keep both: the count
-      // reads at a glance, the ids say which routers.
-      label: "Mesh routers",
+      // reads at a glance, the ids say which routers. The controller counts here
+      // too, so this is every router the dish is talking to, mesh or not.
+      label: "Downstream routers",
       value: status.connectedRouters?.length
-        ? `${status.connectedRouters.length} · ${status.connectedRouters.join(", ")}`
+        ? `${status.connectedRouters.length} · ${status.connectedRouters.join(", ")}` +
+          (routerPresence(status) === "bypassed" ? " · bypassed" : "")
         : "0",
     },
     { label: "Bandwidth limit", value: formatBandwidthLimit(status.dlBandwidthRestrictedReason) },

--- a/src/components/network/rules/MeterStatus.tsx
+++ b/src/components/network/rules/MeterStatus.tsx
@@ -20,7 +20,7 @@ import {
   splitDuration,
   timeLeft,
 } from "./allowanceTerms";
-import { leadingMeasure, meterTone, NEARING_LIMIT } from "./ruleMeasure";
+import { leadingMeasure, meterTone, NEARING_LIMIT, scheduleDormant } from "./ruleMeasure";
 import { Bar, RuleStats, Section, Stat } from "./ruleReadout";
 import { ScheduleWindows } from "./scheduleFields";
 
@@ -246,12 +246,24 @@ export function MeterStatus({
         {leading === "schedule" ? (
           <div className='grid grid-cols-2 gap-3 border-t border-border/60 pt-4'>
             <Stat
-              label={rule.windowBlocked ? "Opens in" : "Closes in"}
+              label={
+                scheduleDormant(rule, nowMs)
+                  ? "Resumes in"
+                  : rule.windowBlocked
+                    ? "Opens in"
+                    : "Closes in"
+              }
               value={rule.windowEndMs ? (timeLeft(rule.windowEndMs, nowMs) ?? "—") : "—"}
             />
             <Stat
               label='Right now'
-              value={rule.windowBlocked ? "Paused" : "Online"}
+              value={
+                scheduleDormant(rule, nowMs)
+                  ? "Not scheduled"
+                  : rule.windowBlocked
+                    ? "Paused"
+                    : "Online"
+              }
               align='right'
             />
           </div>

--- a/src/components/network/rules/RuleCard.test.tsx
+++ b/src/components/network/rules/RuleCard.test.tsx
@@ -26,6 +26,7 @@ function rule(over: Partial<Rule> = {}): Rule {
     members: [],
     memberCount: 3,
     paused: false,
+    pausedCount: 0,
     reached: false,
     windowBlocked: false,
     periodEndMs: NOW + 5 * 86_400_000,
@@ -41,6 +42,15 @@ const hours = {
   windows: [
     { weekdays: [1, 2, 3, 4, 5], startMinute: 16 * 60, endMinute: 20 * 60 },
     { weekdays: [0, 6], startMinute: 9 * 60, endMinute: 21 * 60 },
+  ],
+};
+
+/** A timetable naming a weekday that is never today, so the rule is sitting the
+ *  day out whenever this suite runs. */
+const notToday = {
+  mode: "allow" as const,
+  windows: [
+    { weekdays: [(new Date().getDay() + 3) % 7], startMinute: 16 * 60, endMinute: 20 * 60 },
   ],
 };
 
@@ -103,6 +113,7 @@ describe("RuleCard", () => {
       allocationBytes: 0,
       schedule: hours,
       paused: true,
+      pausedCount: 3,
       windowBlocked: true,
       windowEndMs: NOW + 3_600_000,
     });
@@ -112,8 +123,43 @@ describe("RuleCard", () => {
     expect(text()).toContain("Opens in");
   });
 
+  // One device out of bytes stops that device, not the rule. Reading the group
+  // as paused turned a card sitting at 22 of 30 GB fully red while two of its
+  // three devices were still online.
+  test("given: one device of three paused, should: stay active and say how many", async () => {
+    show({
+      usageBytes: 22 * GB,
+      capacityBytes: 30 * GB,
+      allocationBytes: 10 * GB,
+      paused: true,
+      pausedCount: 1,
+      reached: true,
+    });
+
+    await expect.poll(text).toContain("Active · 1 of 3 paused");
+    expect(text()).not.toContain("Paused, limit reached");
+    expect(document.querySelector("[class*='status-critical']")).toBeNull();
+  });
+
+  // A weekday rule read on a Saturday allows nothing and blocks nothing, and
+  // reporting that as "Active, closes in 1 day" reads as the hours shutting.
+  test("given: a timetable that does not cover today, should: say it is not scheduled", async () => {
+    show({ allocationBytes: 0, schedule: notToday, windowEndMs: NOW + 32 * 3_600_000 });
+
+    await expect.poll(text).toContain("Not scheduled today");
+    expect(text()).toContain("Resumes in");
+    expect(text()).not.toContain("Active");
+    expect(text()).not.toContain("Closes in");
+  });
+
   test("given: a rule over its allowance, should: name the limit as the reason", async () => {
-    show({ usageBytes: 20 * GB, capacityBytes: 20 * GB, paused: true, reached: true });
+    show({
+      usageBytes: 20 * GB,
+      capacityBytes: 20 * GB,
+      paused: true,
+      pausedCount: 3,
+      reached: true,
+    });
     await expect.poll(text).toContain("Paused, limit reached");
   });
 
@@ -134,6 +180,7 @@ describe("RuleCard", () => {
       schedule: hours,
       usageBytes: 60 * GB,
       paused: true,
+      pausedCount: 3,
       reached: true,
       windowEndMs: NOW + 3_600_000,
     });

--- a/src/components/network/rules/RuleCard.tsx
+++ b/src/components/network/rules/RuleCard.tsx
@@ -14,6 +14,7 @@ import {
   meterTone,
   NEARING_LIMIT,
   pauseCause,
+  scheduleDormant,
   type RuleMeasure,
 } from "./ruleMeasure";
 import { Bar } from "./ruleReadout";
@@ -58,6 +59,10 @@ export function RuleCard({
   // both the group's and the bar measures the two against each other.
   const shared = rule.mode === "pooled" && rule.memberCount > 1;
   const capped = rule.allocationBytes > 0;
+  const dormant = scheduleDormant(rule, nowMs);
+  // A rule is only paused when it is holding every device it names. One member
+  // out of bytes leaves the rest online, and the rule running.
+  const allPaused = rule.pausedCount > 0 && rule.pausedCount === rule.memberCount;
   const capLabel = `${formatBytes(rule.allocationBytes)}${perDevice ? " each" : shared ? " shared" : ""}`;
 
   return (
@@ -108,7 +113,7 @@ export function RuleCard({
                   </span>
                   <span className='text-muted-foreground'>of {capLabel}</span>
                 </div>
-                <Bar spent={spent} tone={meterTone(spent, rule.paused)} />
+                <Bar spent={spent} tone={meterTone(spent, allPaused)} />
               </div>
             )}
           </div>
@@ -124,7 +129,7 @@ export function RuleCard({
             </div>
             <Bar
               spent={spent}
-              tone={rule.paused ? "bg-[var(--status-critical)]" : "bg-[var(--accent)]"}
+              tone={allPaused ? "bg-[var(--status-critical)]" : "bg-[var(--accent)]"}
             />
           </div>
         ) : (
@@ -137,7 +142,7 @@ export function RuleCard({
                 {capped ? `Limit: ${capLabel}` : "No cap"}
               </span>
             </div>
-            {capped && <Bar spent={spent} tone={meterTone(spent, rule.paused)} />}
+            {capped && <Bar spent={spent} tone={meterTone(spent, allPaused)} />}
           </div>
         )}
 
@@ -145,18 +150,28 @@ export function RuleCard({
           <span
             className={cn(
               "flex items-center gap-1.5",
-              rule.paused ? "text-[var(--status-critical)]" : "text-muted-foreground",
+              allPaused ? "text-[var(--status-critical)]" : "text-muted-foreground",
             )}
           >
             <span
               className={cn(
                 "size-1.5 rounded-full",
-                rule.paused ? "bg-[var(--status-critical)]" : "bg-[var(--status-good)]",
+                allPaused
+                  ? "bg-[var(--status-critical)]"
+                  : dormant
+                    ? "bg-muted-foreground"
+                    : "bg-[var(--status-good)]",
               )}
             />
-            {rule.paused ? PAUSED_BECAUSE[pauseCause(rule)] : "Active"}
+            {allPaused
+              ? PAUSED_BECAUSE[pauseCause(rule)]
+              : rule.pausedCount > 0
+                ? `Active · ${rule.pausedCount} of ${rule.memberCount} paused`
+                : dormant
+                  ? "Not scheduled today"
+                  : "Active"}
           </span>
-          <RuleNote rule={rule} measure={measure} nowMs={nowMs} spent={spent} />
+          <RuleNote rule={rule} measure={measure} nowMs={nowMs} spent={spent} dormant={dormant} />
         </div>
       </div>
     </div>
@@ -169,18 +184,20 @@ function RuleNote({
   measure,
   nowMs,
   spent,
+  dormant,
 }: {
   rule: Rule;
   measure: RuleMeasure;
   nowMs: number;
   spent: number;
+  dormant: boolean;
 }) {
   if (measure === "schedule") {
     const turns = rule.windowEndMs ? timeLeft(rule.windowEndMs, nowMs) : null;
     if (!turns) return null;
     return (
       <span className='text-muted-foreground'>
-        {rule.windowBlocked ? "Opens" : "Closes"} in {turns}
+        {dormant ? "Resumes" : rule.windowBlocked ? "Opens" : "Closes"} in {turns}
       </span>
     );
   }

--- a/src/components/network/rules/RuleDialog.test.tsx
+++ b/src/components/network/rules/RuleDialog.test.tsx
@@ -97,6 +97,7 @@ function deviceRule(over: Partial<Rule> = {}): Rule {
     members: [],
     memberCount: 1,
     paused: false,
+    pausedCount: 0,
     reached: false,
     windowBlocked: false,
     periodEndMs: NOW + 5 * 86_400_000,

--- a/src/components/network/rules/RuleStatus.test.tsx
+++ b/src/components/network/rules/RuleStatus.test.tsx
@@ -41,6 +41,7 @@ function rule(over: Partial<Rule> = {}): Rule {
       member("3", "Laptop", 3 * GB),
     ],
     paused: false,
+    pausedCount: 0,
     reached: false,
     windowBlocked: false,
     periodEndMs: NOW + 5 * 86_400_000,
@@ -102,6 +103,7 @@ describe("RuleStatus", () => {
   test("given: some devices held, should: name the ones actually paused", async () => {
     show({
       paused: true,
+      pausedCount: 1,
       reached: true,
       members: [
         member("1", "iPad", 50 * GB, true),

--- a/src/components/network/rules/RuleStatus.tsx
+++ b/src/components/network/rules/RuleStatus.tsx
@@ -14,7 +14,7 @@ import { Callout } from "../../ui/callout";
 import { DialogFooter, DialogHeader, DialogTitle, DialogDescription } from "../../ui/dialog";
 import type { MemberCandidate } from "./allowanceTerms";
 import { cycleLabel, endsAtLabel, formatDuration, timeLeft } from "./allowanceTerms";
-import { leadingMeasure, meterTone } from "./ruleMeasure";
+import { leadingMeasure, meterTone, scheduleDormant } from "./ruleMeasure";
 import { Bar, RuleStats, Section, Stat } from "./ruleReadout";
 import { ScheduleWindows } from "./scheduleFields";
 
@@ -87,6 +87,9 @@ export function RuleStatus({
   const leftMs = timing ? Math.max(0, rule.countdownStartMs + rule.countdownMs! - nowMs) : 0;
   const capped = rule.allocationBytes > 0;
   const pooled = rule.mode === "pooled" && rule.memberCount > 1;
+  // One device out of bytes is not the whole rule stopping, so the headline bar
+  // stays on its own figure rather than reddening for a member.
+  const allPaused = rule.pausedCount > 0 && rule.pausedCount === rule.memberCount;
   // Every device carries the whole allowance, so each is read on its own.
   const perDevice = rule.mode === "perMember" && rule.memberCount > 1 && capped;
   // Pooled reads as one meter; a lone device is the same shape with one member.
@@ -137,7 +140,7 @@ export function RuleStatus({
             </div>
             <Bar
               spent={1 - leftMs / (rule.countdownMs || 1)}
-              tone={rule.paused ? "bg-[var(--status-critical)]" : "bg-[var(--accent)]"}
+              tone={allPaused ? "bg-[var(--status-critical)]" : "bg-[var(--accent)]"}
             />
           </div>
         ) : leading === "schedule" ? (
@@ -155,7 +158,7 @@ export function RuleStatus({
                 {pooled ? " shared" : ""}
               </span>
             </div>
-            <Bar spent={spent} tone={meterTone(spent, rule.paused)} />
+            <Bar spent={spent} tone={meterTone(spent, allPaused)} />
           </div>
         ) : null}
 
@@ -185,10 +188,25 @@ export function RuleStatus({
         ) : leading === "schedule" ? (
           <RuleStats>
             <Stat
-              label={rule.windowBlocked ? "Opens in" : "Closes in"}
+              label={
+                scheduleDormant(rule, nowMs)
+                  ? "Resumes in"
+                  : rule.windowBlocked
+                    ? "Opens in"
+                    : "Closes in"
+              }
               value={rule.windowEndMs ? (timeLeft(rule.windowEndMs, nowMs) ?? "—") : "—"}
             />
-            <Stat label='Right now' value={rule.windowBlocked ? "Paused" : "Online"} />
+            <Stat
+              label='Right now'
+              value={
+                scheduleDormant(rule, nowMs)
+                  ? "Not scheduled"
+                  : rule.windowBlocked
+                    ? "Paused"
+                    : "Online"
+              }
+            />
             <Stat
               label='Devices'
               value={`${rule.memberKeys.length} device${rule.memberKeys.length === 1 ? "" : "s"}`}

--- a/src/components/network/rules/ruleMeasure.ts
+++ b/src/components/network/rules/ruleMeasure.ts
@@ -1,4 +1,4 @@
-import { scheduleActive, type Schedule } from "@core/schedule";
+import { scheduleActive, scheduleGoverns, type Schedule } from "@core/schedule";
 
 export type RuleMeasure = "schedule" | "timer" | "allowance";
 
@@ -20,6 +20,12 @@ interface Measured {
 export function leadingMeasure(rule: Measured): RuleMeasure {
   if (rule.countdownMs !== undefined) return "timer";
   return scheduleActive(rule.schedule) ? "schedule" : "allowance";
+}
+
+/** A timetable sitting out the day rather than running: it neither allows nor
+ *  blocks, so "Active" and "Closes" both misread it. */
+export function scheduleDormant(rule: Measured, nowMs: number): boolean {
+  return scheduleActive(rule.schedule) && !scheduleGoverns(rule.schedule, nowMs);
 }
 
 /** Which measure is doing the holding — not always the one the rule leads with,

--- a/src/components/settings/AppSettingsTab.tsx
+++ b/src/components/settings/AppSettingsTab.tsx
@@ -24,6 +24,7 @@ import {
   type ToolbarStyle,
 } from "../../lib/toolbarStyle";
 import { selfDeviceHost } from "../../lib/selfDeviceHost";
+import { badgeModeHost, DEFAULT_BADGE_MODE, type BadgeMode } from "../../lib/badgeMode";
 import { displayName, isClientDevice } from "../network/networkFormat";
 import type { WifiClientJson } from "@core/dishClient";
 
@@ -169,6 +170,57 @@ function SelfDeviceRow({ clients }: { clients: WifiClientJson[] }) {
   );
 }
 
+/** What the extension's toolbar badge counts. Absent on every other host, which
+ *  is what keeps the row out of the desktop app and a plain browser tab. */
+function BadgeModeRow() {
+  const host = badgeModeHost();
+  const [mode, setMode] = useState<BadgeMode>(DEFAULT_BADGE_MODE);
+
+  useEffect(() => {
+    if (!host) return;
+    let active = true;
+    void host.read().then((stored) => {
+      if (active) setMode(stored);
+    });
+    return () => {
+      active = false;
+    };
+  }, [host]);
+
+  if (!host) return null;
+
+  const choose = (value: string) => {
+    const next = value as BadgeMode;
+    setMode(next);
+    void host.write(next);
+  };
+
+  return (
+    <SettingRow
+      title='Toolbar badge'
+      info='The count on the extension icon. Being away from your Starlink makes both devices unreachable, and the badge cannot tell that from a device that has actually failed — so "Device faults only" leaves both out. Alerts still reach the panel and your notifications either way.'
+      caption='What the count on the extension icon includes'
+    >
+      <Select value={mode} onValueChange={choose}>
+        <SelectTrigger className={triggerClass} style={{ width: 158 }}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className={selectContentClass}>
+          <SelectItem value='all' className={selectItemClass}>
+            All alerts
+          </SelectItem>
+          <SelectItem value='faults' className={selectItemClass}>
+            Device faults only
+          </SelectItem>
+          <SelectItem value='off' className={selectItemClass}>
+            No badge
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </SettingRow>
+  );
+}
+
 export function AppSettingsTab({ clients }: { clients: WifiClientJson[] }) {
   const toolbarStyle = useSyncExternalStore(subscribeToToolbarStyle, readToolbarStyle);
   const menuBar = useMenuBarThroughput();
@@ -198,6 +250,8 @@ export function AppSettingsTab({ clients }: { clients: WifiClientJson[] }) {
       </SettingRow>
 
       <SelfDeviceRow clients={clients} />
+
+      <BadgeModeRow />
 
       {menuBar && (
         <SettingRow

--- a/src/components/settings/BypassSection.test.tsx
+++ b/src/components/settings/BypassSection.test.tsx
@@ -58,7 +58,9 @@ function mount(overrides: Partial<Props> = {}) {
   const props: Props = {
     reported: false,
     routerAnswering: true,
+    dishPresence: "absent",
     disabled: false,
+    accountAnswering: true,
     onSave,
     onReload,
     ...overrides,
@@ -67,23 +69,36 @@ function mount(overrides: Partial<Props> = {}) {
   // The account's answer is a prop here, so a holder owns it and the cases move
   // it — that is how the lag is reproduced at the moment each one needs it.
   let publish: (reported: boolean | null) => void = () => {};
+  // The dish's answer moves independently of the account's, and the point of
+  // several cases is that it arrives first.
+  let publishObserved: (patch: Partial<Props>) => void = () => {};
   function Holder() {
     const [reported, setReported] = useState(props.reported);
+    const [observed, setObserved] = useState<Partial<Props>>({});
     publish = setReported;
-    return <BypassSection {...props} reported={reported} />;
+    publishObserved = (patch) => setObserved((held) => ({ ...held, ...patch }));
+    return <BypassSection {...props} reported={reported} {...observed} />;
   }
   render(<Holder />);
 
-  return { onSave, onReload, reportNow: (reported: boolean | null) => publish(reported) };
+  return {
+    onSave,
+    onReload,
+    reportNow: (reported: boolean | null) => publish(reported),
+    observeNow: (patch: Partial<Props>) => publishObserved(patch),
+  };
 }
 
 /** Presses the handle, crosses the whole track, and lets go. */
 function slide() {
   const grip = handle();
   const start = grip.getBoundingClientRect();
+  const rail = track().getBoundingClientRect();
   const travel = track().clientWidth - start.width - TRACK_INSET_PX * 2;
   const from = start.left + start.width / 2;
-  const to = from + travel * 1.2;
+  // A track offering "off" runs the other way, with the handle parked at its end.
+  const rightward = start.left - rail.left <= rail.width / 2;
+  const to = rightward ? from + travel * 1.2 : from - travel * 1.2;
 
   grip.setPointerCapture = () => {};
   grip.releasePointerCapture = () => {};
@@ -148,7 +163,7 @@ describe("BypassSection", () => {
   });
 
   test("holds the assumed state until the account agrees, then stops saying so", async () => {
-    const { reportNow } = mount({ reported: false });
+    const { reportNow, observeNow } = mount({ reported: false });
     await waitForText("Slide to turn on bypass");
 
     slide();
@@ -160,6 +175,9 @@ describe("BypassSection", () => {
     // asked for rather than what is known.
     expect(document.querySelector("[aria-label='Turning bypass on']")).not.toBeNull();
 
+    // Bypass silences the router on the LAN, so the account agreeing while it
+    // still answers is a state the hardware cannot be in.
+    observeNow({ routerAnswering: false });
     reportNow(true);
     await settle();
 
@@ -168,16 +186,146 @@ describe("BypassSection", () => {
     expect(text()).not.toContain("Sent.");
   });
 
+  test("settles on the dish rather than waiting out the account", async () => {
+    // A bypassed router stops uploading telemetry, so the account can sit on the
+    // old value until the wait times out. The dish names the role in seconds.
+    const { observeNow } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+
+    // The account is left saying the old thing, exactly as it does on hardware.
+    observeNow({ dishPresence: "bypassed", routerAnswering: false });
+    await settle();
+
+    expect(document.querySelector("[aria-label='Turning bypass on']")).toBeNull();
+    expect(text()).toContain("The Starlink router is disabled");
+  });
+
+  test("takes the dish's word even in the pass that loses the account", async () => {
+    const { observeNow } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+
+    // Both arrive together: the confirmation settles it, so the unreachable
+    // account is no longer worth a word.
+    observeNow({ dishPresence: "bypassed", routerAnswering: false, accountAnswering: false });
+    await settle();
+
+    expect(text()).toContain("The Starlink router is disabled");
+    expect(text()).not.toContain("can't reach your Starlink account");
+    expect(text()).not.toContain("Sent.");
+  });
+
+  test("refuses the opposite write while the first is still unresolved", async () => {
+    const { onSave } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+    await settle();
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    // The row now offers "off", but the "on" it just sent has not landed. Sending
+    // the opposite into that window races two writes at one router.
+    expect(handle().getAttribute("aria-disabled")).toBe("true");
+    slide();
+    await settle();
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  test("believes the router answering over an account still reporting bypass", async () => {
+    // On hardware the WiFi was back and the machine was on it while the account
+    // still said bypassed. The row sat on `On` for four minutes because the
+    // slowest signal outranked the one that had just proved itself.
+    const { observeNow } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+
+    // The account catches up, so the assumption is spent and the row reads it.
+    observeNow({ routerAnswering: false, dishPresence: "bypassed" });
+    await settle();
+    expect(text()).toContain("The Starlink router is disabled");
+
+    // The router comes back on the LAN. The account has not caught up yet.
+    observeNow({ routerAnswering: true, dishPresence: "bypassed" });
+    await settle();
+    expect(text()).toContain("The Starlink router is running your network");
+  });
+
+  test("ends the wait on the dish dropping the bypassed role, not on the account", async () => {
+    // Hardware: the WiFi was back and the dish said so, while the account still
+    // reported bypass and held the row on `On` for four minutes.
+    const { observeNow } = mount({
+      reported: true,
+      routerAnswering: false,
+      dishPresence: "bypassed",
+    });
+    await waitForText("Slide to turn off bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn off").click();
+    await waitForText("Sent!");
+
+    observeNow({ dishPresence: "present" });
+    await settle();
+
+    expect(document.querySelector("[aria-label='Turning bypass off']")).toBeNull();
+    expect(text()).toContain("The Starlink router is running your network");
+  });
+
   test("reads bypass as off when the router answers, whatever the account carries", async () => {
     mount({ reported: null, routerAnswering: true });
     await waitForText("The Starlink router is running your network");
     expect(text()).toContain("Slide to turn on bypass");
   });
 
-  test("refuses to guess a direction when nothing can say where bypass stands", async () => {
-    mount({ reported: null, routerAnswering: false });
+  test("offers the way back when nothing can say where bypass stands", async () => {
+    const { onSave } = mount({ reported: null, routerAnswering: false });
     await waitForText("Couldn't tell whether the router is bypassed");
-    expect(handle().getAttribute("aria-disabled")).toBe("true");
+    expect(handle().getAttribute("aria-disabled")).not.toBe("true");
+    expect(text()).toContain("Slide to turn off bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn off").click();
+    await settle();
+    expect(onSave).toHaveBeenCalledWith(false);
+  });
+
+  test("stops waiting on an account that turning bypass on has put out of reach", async () => {
+    // The confirmation rides the network the write tears down.
+    const { observeNow } = mount({ reported: false });
+    await waitForText("Slide to turn on bypass");
+
+    slide();
+    await waitForText("Are you sure?");
+    button("Turn on").click();
+    await waitForText("Sent.");
+    expect(document.querySelector("[aria-label='Turning bypass on']")).not.toBeNull();
+
+    observeNow({ accountAnswering: false, routerAnswering: false });
+    await waitForText("can't reach your Starlink account");
+
+    // The spinner stops without unlearning the write, so the way back is offered.
+    expect(document.querySelector("[aria-label='Turning bypass on']")).toBeNull();
+    expect(handle().getAttribute("aria-disabled")).not.toBe("true");
+    expect(text()).toContain("Slide to turn off bypass");
+    expect(text()).toContain("The Starlink router is disabled");
   });
 
   test("names the way back when the account cannot be reached", async () => {

--- a/src/components/settings/BypassSection.tsx
+++ b/src/components/settings/BypassSection.tsx
@@ -1,19 +1,17 @@
 // Whether the Starlink router runs the network at all.
 //
-// The state comes from the account first, never from `wifiConfig`: a bypassed
-// router serves no gRPC on the LAN, so the router is silent for the whole time
-// the answer would be `true`. That silence is itself an answer in the other
-// direction, which is the fallback here — a router answering locally is not
-// bypassed, whatever the account's telemetry does or does not carry.
+// Read from the LAN first and the account last. A router answering locally is one
+// bypass has not silenced, which settles it outright; the account carries the same
+// fact but was measured lagging a flip by minutes, so trusting it first leaves the
+// row insisting on bypass while the WiFi is already back.
 //
-// The account is also what makes the way back reachable. The write rides the
+// The account is still what makes the way back reachable: the write rides the
 // cloud gateway, which needs some internet rather than Starlink's in particular,
 // so a kit with a third-party router wired in can be un-bypassed from the very
-// machine that bypassed it. With nothing else serving internet that takes another
-// device on mobile data, which is why an unreachable account says so plainly
-// instead of only greying the control out.
+// machine that bypassed it.
 
 import { useEffect, useState } from "react";
+import type { RouterPresence } from "@core/routerPresence";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/ui/callout";
@@ -32,10 +30,9 @@ import { SettingRow } from "./settingsChrome";
 const BYPASS_TIP =
   "Advanced feature that disables the Starlink router completely, so the dish serves a third-party router instead. The Starlink WiFi goes off and the client list, custom DNS and subnet stop working. Most users should leave this off.";
 
-/** How long the account is given to report a write before the row stops waiting
- *  on it. Measured against hardware, the flip showed up around two minutes. */
-const SETTLE_TIMEOUT_MS = 4 * 60_000;
-const SETTLE_POLL_MS = 15_000;
+/** The dish names the role within seconds of a flip, so a wait that outlasts this
+ *  is one the dish is not going to end. */
+const SETTLE_TIMEOUT_MS = 45_000;
 
 export function BypassSection({
   /** What the account reports, or null when its telemetry carries no controller
@@ -43,15 +40,22 @@ export function BypassSection({
   reported,
   /** The router is answering on the LAN, which only an un-bypassed router does. */
   routerAnswering,
+  /** The dish's read on the routers below it, which names the role in seconds
+   *  where the account lags a flip by minutes. */
+  dishPresence,
   /** No account connected, so the write has nowhere to go. */
   disabled,
+  /** Whether the account is answering at all. */
+  accountAnswering,
   onSave,
-  /** Re-asks the account, which is the only thing that can confirm a write. */
+  /** Re-asks the account, the last resort once the dish has not answered. */
   onReload,
 }: {
   reported: boolean | null;
   routerAnswering: boolean;
+  dishPresence: RouterPresence;
   disabled: boolean;
+  accountAnswering: boolean;
   onSave: (enabled: boolean) => Promise<void>;
   onReload: () => void;
 }) {
@@ -62,16 +66,22 @@ export function BypassSection({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
-  // What the last write asked for. The row shows this in preference to what the
-  // account says, because the account keeps reporting the old value for the
-  // minutes the router takes to go down or come back — a row that waited for it
-  // would spend that time insisting the change had not happened.
-  const [awaiting, setAwaiting] = useState<boolean | null>(null);
+  // What the last write asked for, outranking an account that keeps reporting the
+  // old value for the minutes the router takes to go down or come back.
+  const [assumed, setAssumed] = useState<boolean | null>(null);
+  // Whether that assumption is still expecting confirmation.
+  const [settling, setSettling] = useState(false);
 
-  const bypassed = awaiting ?? reported ?? (routerAnswering ? false : null);
-  // Null is not a state to write from: without knowing where it stands, the
-  // control cannot say which way it would go.
-  const target = bypassed === null ? null : !bypassed;
+  // Local proof first: the account lags a flip by minutes, and a router answering
+  // on the LAN is one no bypass has silenced. One order serves both the display
+  // and the wait below, so no signal can end the wait while a stronger one still
+  // contradicts it.
+  // `absent` is no evidence either way: a router that is off is not a bypassed one.
+  const dishSays = dishPresence === "bypassed" ? true : dishPresence === "present" ? false : null;
+  const known = (routerAnswering ? false : null) ?? dishSays ?? reported;
+  const bypassed = assumed ?? known;
+  // Off is the safe direction when the state is unknown, and a no-op if already off.
+  const target = bypassed === null ? false : !bypassed;
   // What the control depicts. While a dialog is open it depicts what that dialog
   // offered, so nothing shifts underneath the question being asked.
   const shown = offered ?? target;
@@ -81,26 +91,36 @@ export function BypassSection({
   // The note is cleared rather than replaced with a confirmation: once the state
   // has settled, the badge and the caption both say it, and a third sentence
   // saying it again is the only thing left to read.
-  if (awaiting !== null && reported === awaiting) {
-    setAwaiting(null);
+  if (assumed !== null && known === assumed) {
+    setAssumed(null);
+    setSettling(false);
     setNote(null);
+  }
+  // Chained, because a state update in render does not change what this pass
+  // already read: settling on the dish and losing the account in the same pass
+  // would otherwise clear the note and then write this one over it.
+  //
+  // Nothing can confirm through an account this device can no longer reach, and
+  // `assumed` outlives the wait so the row keeps offering the way back.
+  else if (settling && assumed === true && !accountAnswering) {
+    setSettling(false);
+    setNote(
+      "Sent. This device can't reach your Starlink account now, so nothing here can confirm it.",
+    );
   }
 
   useEffect(() => {
-    if (awaiting === null) return;
-    const poll = setInterval(onReload, SETTLE_POLL_MS);
-    // Assumed until the account contradicts it, but not forever: past this the
-    // guess has outlived any lag it was covering, and the row goes back to
-    // reporting what is actually known.
+    if (!settling) return;
     const giveUp = setTimeout(() => {
-      setAwaiting(null);
-      setNote("Your account still reports the old state. Reopen this panel to check again.");
+      setAssumed(null);
+      setSettling(false);
+      setNote("Couldn't confirm the change from here. Reopen this panel to check again.");
+      // Asked once on the way out rather than polled throughout: the account is
+      // the only thing left to ask, and it is the slowest of the three.
+      onReload();
     }, SETTLE_TIMEOUT_MS);
-    return () => {
-      clearInterval(poll);
-      clearTimeout(giveUp);
-    };
-  }, [awaiting, onReload]);
+    return () => clearTimeout(giveUp);
+  }, [settling, onReload]);
 
   const caption = disabled
     ? // A router answering locally settles it: bypass is off, and this row is
@@ -127,15 +147,14 @@ export function BypassSection({
       await onSave(value);
       // Deliberately "sent", not "applied": a write that takes effect can kill
       // its own reply, and a reply that arrives cleanly is only ever ACCEPTED,
-      // which the router also returns for changes it goes on to discard. The
-      // account reporting the new value is the only thing that settles it, and
-      // `awaiting` is what waits for that.
+      // which the router also returns for changes it goes on to discard.
       setNote(
         value
           ? "Sent. The Starlink WiFi is going down; waiting for the account to confirm."
-          : "Sent. The router is coming back up; waiting for the account to confirm.",
+          : "Sent! The router is coming back up; waiting for confirmation…",
       );
-      setAwaiting(value);
+      setAssumed(value);
+      setSettling(true);
     } catch (saveError) {
       setError((saveError as Error).message);
     } finally {
@@ -161,8 +180,8 @@ export function BypassSection({
           </>
         }
       >
-        {awaiting !== null ? (
-          <SpinLoader size={15} label={awaiting ? "Turning bypass on" : "Turning bypass off"} />
+        {settling ? (
+          <SpinLoader size={15} label={assumed ? "Turning bypass on" : "Turning bypass off"} />
         ) : (
           bypassed !== null && (
             <Badge tone={bypassed ? "critical" : "neutral"}>{bypassed ? "On" : "Off"}</Badge>
@@ -176,20 +195,22 @@ export function BypassSection({
           busyLabel={saving ? "Sending…" : "Confirm to continue"}
           direction={shown ? "right" : "left"}
           tone={shown ? "danger" : "default"}
-          disabled={disabled || target === null}
+          // A flip is unresolved until the dish or the account says otherwise, and
+          // the opposite write sent into that window races the one already out.
+          disabled={disabled || settling}
           busy={offered !== null || saving}
           onConfirm={() => setOffered(target)}
         />
-        {target !== null && (
-          // A tinted box is the app's colour for "something is broken"; this is a
-          // standing description of what the control does. The icon carries the
-          // weight instead, which is what it is separately severable for.
-          <Callout tone='info' icon='warning' iconSeverity={target ? "danger" : "normal"}>
-            {target
-              ? "Bypass mode will completely disable the Starlink router and its WiFi. Only a third-party router wired to the dish stay online. You can turn it back off from here as long as this device is has access to the internet."
-              : "Bypass is on, so the Starlink router is disabled and a third-party router runs your network. Turning bypass off brings the Starlink router and its WiFi back."}
-          </Callout>
-        )}
+        {/* A tinted box is the app's colour for "something is broken"; this is a
+            standing description of what the control does. The icon carries the
+            weight instead, which is what it is separately severable for. */}
+        <Callout tone='info' icon='warning' iconSeverity={bypassed === false ? "danger" : "normal"}>
+          {bypassed === false
+            ? "Bypass mode will completely disable the Starlink router and its WiFi. Only a third-party router wired to the dish stays online. You can turn it back off from here as long as this device has access to the internet."
+            : bypassed
+              ? "Bypass is on, so the Starlink router is disabled and a third-party router runs your network. Turning bypass off brings the Starlink router and its WiFi back."
+              : "Can't tell whether bypass is on. Turning it off is the safe direction either way: it brings the Starlink router and its WiFi back, and changes nothing if bypass was already off."}
+        </Callout>
       </div>
 
       <Dialog open={offered !== null} onOpenChange={(open) => !open && setOffered(null)}>

--- a/src/components/settings/RouterSettingsTab.test.tsx
+++ b/src/components/settings/RouterSettingsTab.test.tsx
@@ -1,0 +1,123 @@
+// The factory reset is the one irreversible thing in this panel, and it has two
+// ways to reach the router. What is held here is the gate: that it cannot be
+// armed with nothing to send through, and that a router off the LAN is reset
+// through the account rather than by dialling an address nothing answers on.
+
+import { expect, describe, test, afterEach, beforeEach, vi } from "vitest";
+import { render, cleanup } from "vitest-browser-react";
+import type { RouterUnreachable } from "../../lib/routerDiagnosis";
+import { RouterSettingsTab } from "./RouterSettingsTab";
+
+const applyRouterConfigUpdate = vi.fn().mockResolvedValue(undefined);
+const loadDish = vi.fn();
+let accountStatus: "loading" | "ready" | "not-connected" | "error" = "not-connected";
+
+vi.mock("../../hooks/useCloudAccount", () => ({
+  useCloudAccount: () => ({ data: null, status: accountStatus, reload: vi.fn() }),
+  useCloudRouterSubnet: () => ({ data: null, status: accountStatus, reload: vi.fn() }),
+}));
+
+vi.mock("../../lib/routerConfigUpdate", () => ({
+  applyRouterConfigUpdate: (...args: unknown[]) => applyRouterConfigUpdate(...args),
+  AccountRequiredError: class AccountRequiredError extends Error {},
+  DeviceUnreachableError: class DeviceUnreachableError extends Error {},
+}));
+
+vi.mock("@core/dishClient", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DishClient: { load: (...args: unknown[]) => loadDish(...args) },
+}));
+
+afterEach(cleanup);
+beforeEach(() => {
+  applyRouterConfigUpdate.mockClear();
+  loadDish.mockClear();
+  accountStatus = "not-connected";
+});
+
+const SILENT: RouterUnreachable = { cause: "noRouter", message: "No router on this kit." };
+const TRACK_INSET_PX = 3;
+
+function text(): string {
+  return document.body.textContent ?? "";
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = [...document.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no button labelled ${label}`);
+  return found as HTMLButtonElement;
+}
+
+/** Carries the named handle the whole way across its track and lets go. */
+function slide(label: string) {
+  const grip = document.querySelector(`[data-slide-handle][aria-label="${label}"]`) as HTMLElement;
+  const rail = grip.closest("[data-slide-track]") as HTMLElement;
+  const start = grip.getBoundingClientRect();
+  const travel = rail.clientWidth - start.width - TRACK_INSET_PX * 2;
+  const from = start.left + start.width / 2;
+
+  grip.setPointerCapture = () => {};
+  grip.releasePointerCapture = () => {};
+  grip.dispatchEvent(new PointerEvent("pointerdown", { clientX: from, bubbles: true }));
+  grip.dispatchEvent(new PointerEvent("pointermove", { clientX: from + travel * 1.2, bubbles: true }));
+  grip.dispatchEvent(new PointerEvent("pointerup", { clientX: from + travel * 1.2, bubbles: true }));
+}
+
+async function settle(ms = 30): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** A router that answers nothing on the LAN, which is every bypassed kit. */
+function mountWithSilentRouter() {
+  render(
+    <RouterSettingsTab
+      wifiConfig={null}
+      dishStatus={null}
+      routerReachable={false}
+      viaAccount={false}
+      unreachable={SILENT}
+      onConfigChanged={vi.fn()}
+    />,
+  );
+}
+
+describe("RouterSettingsTab factory reset", () => {
+  test("cannot be armed when neither the LAN nor an account can carry it", async () => {
+    accountStatus = "not-connected";
+    mountWithSilentRouter();
+    await settle();
+
+    expect(text()).toContain("Needs the router on this network, or your Starlink account");
+    expect(button("Factory reset").disabled).toBe(true);
+
+    button("Factory reset").click();
+    await settle();
+    // Still nothing to confirm: arming is what the gate refuses.
+    expect(document.querySelector("[data-slide-handle]")).toBeNull();
+    expect(applyRouterConfigUpdate).not.toHaveBeenCalled();
+  });
+
+  test("resets a router off the LAN through the account rather than dialling it", async () => {
+    accountStatus = "ready";
+    mountWithSilentRouter();
+    await settle();
+
+    expect(button("Factory reset").disabled).toBe(false);
+    button("Factory reset").click();
+    await settle();
+
+    slide("Slide to factory reset the router");
+    await settle();
+
+    // The slide only opens the confirm; nothing is sent until it is accepted.
+    expect(applyRouterConfigUpdate).not.toHaveBeenCalled();
+    button("Factory reset router").click();
+    await settle();
+
+    expect(applyRouterConfigUpdate).toHaveBeenCalledWith({ kind: "factoryReset" });
+    // The address it would dial answers nothing; that is why this path exists.
+    expect(loadDish).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/RouterSettingsTab.test.tsx
+++ b/src/components/settings/RouterSettingsTab.test.tsx
@@ -61,8 +61,12 @@ function slide(label: string) {
   grip.setPointerCapture = () => {};
   grip.releasePointerCapture = () => {};
   grip.dispatchEvent(new PointerEvent("pointerdown", { clientX: from, bubbles: true }));
-  grip.dispatchEvent(new PointerEvent("pointermove", { clientX: from + travel * 1.2, bubbles: true }));
-  grip.dispatchEvent(new PointerEvent("pointerup", { clientX: from + travel * 1.2, bubbles: true }));
+  grip.dispatchEvent(
+    new PointerEvent("pointermove", { clientX: from + travel * 1.2, bubbles: true }),
+  );
+  grip.dispatchEvent(
+    new PointerEvent("pointerup", { clientX: from + travel * 1.2, bubbles: true }),
+  );
 }
 
 async function settle(ms = 30): Promise<void> {

--- a/src/components/settings/RouterSettingsTab.tsx
+++ b/src/components/settings/RouterSettingsTab.tsx
@@ -169,6 +169,29 @@ export function RouterSettingsTab({
           return "Reboot sent — the router is restarting.";
         }}
       />
+      <DangerAction
+        title='Factory reset router'
+        caption={
+          answering || accountConnected
+            ? "Wipes the WiFi name, password and every router setting. Not reversible."
+            : "Needs the router on this network, or your Starlink account"
+        }
+        buttonLabel='Factory reset'
+        slideLabel='Slide to factory reset the router'
+        confirmLabel='Factory reset router'
+        warning='Factory reset will clear your WiFi network name, password, and other settings. This will interrupt your service until you set it up again.'
+        disabled={!answering && !accountConnected}
+        onRun={async () => {
+          // A bypassed router is off the LAN, which is exactly when a reset is
+          // wanted: the account reaches it there and nothing local does.
+          if (!answering) {
+            await applyRouterConfigUpdate({ kind: "factoryReset" });
+            return "Factory reset sent through your Starlink account — the router is wiping and restarting.";
+          }
+          await (await DishClient.load("router")).factoryReset();
+          return "Factory reset sent — the router is wiping and restarting.";
+        }}
+      />
       <CollapsibleSection title='Advanced'>
         {addresses && (
           <>

--- a/src/components/settings/RouterSettingsTab.tsx
+++ b/src/components/settings/RouterSettingsTab.tsx
@@ -1,7 +1,7 @@
 // Router information and maintenance — the Router half of the settings panel.
 // Read-mostly by design: the one write here is a reboot.
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Callout } from "@/components/ui/callout";
 import { Loading } from "@/components/ui/loading";
 import { DishClient, type WifiNetworkConfigJson } from "@core/dishClient";
@@ -18,6 +18,8 @@ import { routerAddressHost } from "../../lib/routerAddressHost";
 import { applyRouterConfigUpdate } from "../../lib/routerConfigUpdate";
 import { useCloudAccount, useCloudRouterSubnet } from "../../hooks/useCloudAccount";
 import { useRouterAddressState } from "../../hooks/useRouterAddress";
+import { routerPresence } from "@core/routerPresence";
+import type { DishStatusJson } from "@core/dishClient";
 
 /** SSIDs with the bands each is broadcast on. One network can appear on several
  *  radios, so they are folded by name rather than listed once per radio. */
@@ -49,12 +51,14 @@ function controllerBypassed(account: CloudAccount | null): boolean | null {
 
 export function RouterSettingsTab({
   wifiConfig,
+  dishStatus,
   routerReachable,
   viaAccount,
   unreachable,
   onConfigChanged,
 }: {
   wifiConfig: WifiNetworkConfigJson | null;
+  dishStatus: DishStatusJson | null;
   routerReachable: boolean | null;
   /** Whether `wifiConfig` was read through the account because the LAN could not
    *  serve it. What it says is the same either way; what still cannot be done
@@ -73,6 +77,10 @@ export function RouterSettingsTab({
   // front rather than failing at the moment Save is pressed.
   const account = useCloudAccount(true);
   const accountConnected = account.status === "ready";
+  // A store still on its first read says nothing either way, and the retry loop
+  // keeps flicking it back through "loading", so the first answer is remembered.
+  const [accountAnswered, setAccountAnswered] = useState(false);
+  if (!accountAnswered && account.status !== "loading") setAccountAnswered(true);
   // Read from the account rather than the router: a bypassed router answers
   // nothing on the LAN, so `wifiConfig` is silent exactly when the answer is yes.
   const bypassed = controllerBypassed(account.data);
@@ -97,14 +105,6 @@ export function RouterSettingsTab({
       {/* Branch on the diagnosis rather than on `routerReachable` again: it is
           derived from that same flag, so this cannot render an empty callout. */}
       {unreachable && <Callout tone='error'>{unreachable.message}</Callout>}
-      {/* Populated sections under that error would otherwise read as if the
-          router were answering after all. */}
-      {viaAccount && (
-        <Callout tone='info' className='mt-2.5'>
-          What follows is read through your Starlink account. Anything that dials the router
-          directly — a reboot — stays unavailable until it answers here.
-        </Callout>
-      )}
 
       {configKnown && (
         <>
@@ -214,7 +214,10 @@ export function RouterSettingsTab({
         <BypassSection
           reported={bypassed}
           routerAnswering={answering}
-          disabled={!accountConnected}
+          dishPresence={routerPresence(dishStatus)}
+          // A failed read is not an absent session, and bypass is what fails reads.
+          disabled={!accountAnswered || account.status === "not-connected"}
+          accountAnswering={accountConnected}
           onReload={account.reload}
           onSave={async (enabled) => {
             await applyRouterConfigUpdate({ kind: "bypass", enabled });

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -139,6 +139,7 @@ export function SettingsModal({
             {tab === "router" && (
               <RouterSettingsTab
                 wifiConfig={wifiConfig}
+                dishStatus={status}
                 routerReachable={routerReachable}
                 viaAccount={routerViaAccount}
                 unreachable={routerUnreachable}

--- a/src/components/settings/StarlinkSettingsTab.tsx
+++ b/src/components/settings/StarlinkSettingsTab.tsx
@@ -274,6 +274,18 @@ export function StarlinkSettingsTab({
               return "Reboot command sent — the dish is restarting.";
             }}
           />
+          <DangerAction
+            title='Factory reset Starlink'
+            caption='Wipes every dish setting back to how it shipped. Not reversible.'
+            buttonLabel='Factory reset'
+            slideLabel='Slide to factory reset the dish'
+            confirmLabel='Factory reset dish'
+            warning='Only factory reset as a last resort or when Starlink recommends it. Frequent factory resets can cause permanent hardware failure.'
+            onRun={async () => {
+              await (await loadDish()).factoryReset();
+              return "Factory reset sent — the dish is wiping and restarting.";
+            }}
+          />
           {isMotorized && (
             <DangerAction
               title={status?.stowRequested ? "Unstow dish" : "Stow dish"}

--- a/src/components/settings/settingsChrome.tsx
+++ b/src/components/settings/settingsChrome.tsx
@@ -15,6 +15,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { SlideToConfirm } from "@/components/ui/slide-to-confirm";
+import { Callout } from "@/components/ui/callout";
+import { useScrollIntoViewWhen } from "../../hooks/useScrollIntoViewWhen";
 import { InfoDot } from "../shared/InfoDot";
 import type { Severity } from "../ui/severity-icon";
 
@@ -116,6 +118,7 @@ export function DangerAction({
   buttonLabel,
   confirmLabel,
   slideLabel,
+  warning,
   disabled = false,
   onRun,
 }: {
@@ -124,6 +127,7 @@ export function DangerAction({
   buttonLabel: string;
   confirmLabel: string;
   slideLabel?: string;
+  warning?: string;
   /** Shown but not runnable, for an action whose device is not answering. */
   disabled?: boolean;
   onRun: () => Promise<string>;
@@ -132,6 +136,7 @@ export function DangerAction({
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<string | null>(null);
+  const armedRef = useScrollIntoViewWhen<HTMLDivElement>(armed);
 
   const run = async () => {
     setBusy(true);
@@ -154,7 +159,7 @@ export function DangerAction({
         note={
           <>
             {armed && slideLabel && (
-              <div className='pt-1 pb-0.5'>
+              <div ref={armedRef} className='flex flex-col gap-2 pt-1 pb-0.5'>
                 <SlideToConfirm
                   label={slideLabel}
                   busyLabel={busy ? "Sending…" : "Confirm to continue"}
@@ -162,6 +167,11 @@ export function DangerAction({
                   busy={confirming || busy}
                   onConfirm={() => setConfirming(true)}
                 />
+                {warning && (
+                  <Callout tone='error' icon='warning'>
+                    {warning}
+                  </Callout>
+                )}
               </div>
             )}
             {result && (

--- a/src/components/ui/details-modal.tsx
+++ b/src/components/ui/details-modal.tsx
@@ -47,27 +47,19 @@ export function DetailsModal({ title, onClose, children, size, onBack }: Details
   return (
     <DialogPrimitive.Root open onOpenChange={(open) => !open && onClose()}>
       <DialogPrimitive.Portal>
+        {/* The scrim, kept outside the scrolling Overlay: backdrop-filter is
+            re-resolved every frame its subtree scrolls, and Chromium presents the
+            frames where that has not finished. */}
+        <div
+          aria-hidden
+          className='pointer-events-none fixed inset-0 z-40 bg-[rgba(0,0,0,0.55)] backdrop-blur-[5px]'
+        />
         {/* Content nests inside Overlay (not Radix's usual sibling layout) so the
             backdrop stays the scroll container. */}
         <DialogPrimitive.Overlay
           data-slot='details-modal-overlay'
           className='thin-scroll fixed inset-0 z-50 flex items-start justify-center overflow-y-auto pt-[6vh] pr-5 pb-10 pl-5'
         >
-          {/* The scrim. It carries the blur, and it has to stay on a layer of its own
-              that neither scrolls nor parents the panel — a backdrop-filter is
-              re-resolved against what lies behind it on every frame its element
-              scrolls, and Chromium presents the frames where that has not finished, so
-              the surface blinks out and back for as long as the scroll runs. Fixed to
-              the viewport it never scrolls, and as a sibling it keeps backdrop-filter
-              off the ancestor chain of the lists that scroll inside the panel. Blur
-              belongs here and nowhere above the content.
-
-              pointer-events-none so dismiss-on-outside-pointerdown reaches the overlay
-              beneath; -z-10 to sit behind the panel in the overlay's stacking context. */}
-          <div
-            aria-hidden
-            className='pointer-events-none fixed inset-0 -z-10 bg-[rgba(0,0,0,0.55)] backdrop-blur-[5px]'
-          />
           <DialogPrimitive.Content
             data-slot='details-modal'
             className={cn(panel({ size }))}

--- a/src/components/ui/slide-to-confirm.tsx
+++ b/src/components/ui/slide-to-confirm.tsx
@@ -188,7 +188,7 @@ export function SlideToConfirm({
           "absolute inset-y-[3px] flex items-center justify-center rounded-full",
           "touch-none outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
           locked ? "cursor-not-allowed" : dragging ? "cursor-grabbing" : "cursor-grab",
-          danger ? "bg-[var(--status-critical)] text-white" : "bg-ink text-surface",
+          danger ? "bg-(--status-critical) text-white" : "bg-ink text-(--surface)",
           glide,
         )}
         style={{

--- a/src/hooks/useCloudAccount.test.tsx
+++ b/src/hooks/useCloudAccount.test.tsx
@@ -1,0 +1,114 @@
+// A failed account read must not strand the controls behind it. Turning bypass
+// on is what breaks this request, and the switch that undoes bypass is disabled
+// while it reads error, so a read that never retries locks the user out.
+
+import { expect, test, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-react";
+import { CloudNotConnectedError } from "../lib/starlinkCloud";
+
+const fetchCloudAccount = vi.fn();
+
+vi.mock("../lib/starlinkCloud", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/starlinkCloud")>();
+  return {
+    ...actual,
+    fetchCloudAccount: () => fetchCloudAccount(),
+    fetchCloudUsage: () => Promise.resolve({}),
+    fetchCloudRouterSubnet: () => Promise.resolve(""),
+  };
+});
+
+vi.mock("../lib/cloudHost", () => ({
+  subscribeCloudSession: () => () => {},
+  cloudRequest: () => Promise.resolve({ status: 200, body: {} }),
+}));
+
+/** Re-imported per test so the module-level store starts empty each time. */
+async function mountAccount(): Promise<{
+  status: () => string;
+  data: () => unknown;
+  reload: () => void;
+}> {
+  const { useCloudAccount } = await import("./useCloudAccount");
+  let latest = "loading";
+  let held: unknown = null;
+  let again: () => void = () => {};
+  function Probe() {
+    const account = useCloudAccount(true);
+    latest = account.status;
+    held = account.data;
+    again = account.reload;
+    return <span data-testid='status'>{latest}</span>;
+  }
+  render(<Probe />);
+  return { status: () => latest, data: () => held, reload: () => again() };
+}
+
+async function settle(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  fetchCloudAccount.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("given: a transport failure, should: recover on its own without a reload", async () => {
+  fetchCloudAccount
+    .mockRejectedValueOnce(new Error("connect ENETUNREACH"))
+    .mockResolvedValue({ deviceTelemetry: {} });
+
+  const { status } = await mountAccount();
+  await vi.waitFor(() => expect(status()).toBe("error"));
+
+  // Nothing here calls reload: the whole point is that the store retries itself,
+  // because the control that would trigger a reload is disabled while it fails.
+  await vi.waitFor(() => expect(status()).toBe("ready"), { timeout: 8_000 });
+  expect(fetchCloudAccount.mock.calls.length).toBeGreaterThan(1);
+});
+
+// The captions on the bypass row are keyed to this data. Dropping it on a failure
+// swings each of them once per retry, which the panel's height animation chases.
+test("given: a transport failure over an answer already held, should: keep it", async () => {
+  const account = { deviceTelemetry: { "Router-1": { kind: "router", hops: 0 } } };
+  fetchCloudAccount
+    .mockResolvedValueOnce(account)
+    .mockRejectedValue(new Error("connect ENETUNREACH"));
+
+  const { status, data, reload } = await mountAccount();
+  await vi.waitFor(() => expect(status()).toBe("ready"));
+
+  reload();
+  await vi.waitFor(() => expect(status()).toBe("error"));
+  expect(data()).toEqual(account);
+});
+
+// A refused session is an answer, so it does replace what was held.
+test("given: a session refused over an answer already held, should: drop it", async () => {
+  fetchCloudAccount
+    .mockResolvedValueOnce({ deviceTelemetry: {} })
+    .mockRejectedValue(new CloudNotConnectedError());
+
+  const { status, data, reload } = await mountAccount();
+  await vi.waitFor(() => expect(status()).toBe("ready"));
+
+  reload();
+  await vi.waitFor(() => expect(status()).toBe("not-connected"));
+  expect(data()).toBeNull();
+});
+
+test("given: no session, should: stay answered rather than dialling forever", async () => {
+  fetchCloudAccount.mockRejectedValue(new CloudNotConnectedError());
+
+  const { status } = await mountAccount();
+  await vi.waitFor(() => expect(status()).toBe("not-connected"));
+
+  const askedOnce = fetchCloudAccount.mock.calls.length;
+  await settle(3_000);
+  expect(fetchCloudAccount.mock.calls.length).toBe(askedOnce);
+  expect(status()).toBe("not-connected");
+});

--- a/src/hooks/useCloudAccount.ts
+++ b/src/hooks/useCloudAccount.ts
@@ -22,6 +22,9 @@ import {
 
 type Status = "loading" | "ready" | "not-connected" | "error";
 
+const RETRY_BASE_MS = 2_000;
+const RETRY_MAX_MS = 30_000;
+
 interface CloudStoreState<T> {
   data: T | null;
   status: Status;
@@ -50,9 +53,29 @@ function createCloudStore<T>(fetcher: () => Promise<T>): CloudStore<T> {
   // cancel it for the others.
   let token = 0;
 
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryDelayMs = RETRY_BASE_MS;
+
   function set(next: CloudStoreState<T>) {
     snapshot = next;
     for (const listener of [...listeners]) listener();
+  }
+
+  function cancelRetry() {
+    if (retryTimer !== null) clearTimeout(retryTimer);
+    retryTimer = null;
+    retryDelayMs = RETRY_BASE_MS;
+  }
+
+  /** Backed off so a network that is down for minutes is not dialled every
+   *  second, and capped so it still recovers on its own once it returns. */
+  function scheduleRetry() {
+    if (retryTimer !== null || listeners.size === 0) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      retryDelayMs = Math.min(retryDelayMs * 2, RETRY_MAX_MS);
+      if (listeners.size) load();
+    }, retryDelayMs);
   }
 
   function load() {
@@ -66,39 +89,56 @@ function createCloudStore<T>(fetcher: () => Promise<T>): CloudStore<T> {
         if (mine !== token) return;
         loaded = true;
         inFlight = false;
+        cancelRetry();
         set({ data, status: "ready" });
       })
       .catch((error: unknown) => {
         if (mine !== token) return;
-        loaded = true;
         inFlight = false;
-        set({
-          data: null,
-          status: error instanceof CloudNotConnectedError ? "not-connected" : "error",
-        });
+        const missing = error instanceof CloudNotConnectedError;
+        // A refused session is an answer and stays answered. A transport failure
+        // is not: the network changing under a request is exactly when this
+        // fails, and it is also when the controls behind it matter most — the
+        // bypass switch is unusable while this reads error, and turning bypass on
+        // is itself what breaks the request. Latching here strands the only
+        // control that undoes it.
+        loaded = missing;
+        // Same reason the status is not latched: a request that failed in
+        // transit learned nothing, so it cannot be what discards the last answer.
+        // Dropping it here swings every caption keyed on it once per retry, which
+        // the panel's height animation then chases.
+        set({ data: missing ? null : snapshot.data, status: missing ? "not-connected" : "error" });
+        if (!missing) scheduleRetry();
       });
   }
 
   return {
     subscribe(listener) {
       listeners.add(listener);
+      // A retry cannot be pending with nobody watching, so one arriving over a
+      // failed read is what starts it.
+      if (snapshot.status === "error" && !inFlight) scheduleRetry();
       return () => {
         listeners.delete(listener);
+        if (listeners.size === 0) cancelRetry();
       };
     },
     getSnapshot: () => snapshot,
     ensure() {
       if (loaded || inFlight) return;
+      cancelRetry();
       load();
     },
     reload() {
       loaded = false;
+      cancelRetry();
       load();
     },
     invalidate() {
       loaded = false;
       token++; // abandon anything in flight against the old session
       inFlight = false;
+      cancelRetry();
       if (listeners.size) load();
       else set({ data: null, status: "loading" });
     },

--- a/src/hooks/useDeviceAlerts.ts
+++ b/src/hooks/useDeviceAlerts.ts
@@ -33,6 +33,7 @@ import {
   type AlertState,
 } from "@core/alertDefinitions";
 import { announceAlert } from "../lib/notifications";
+import { routerPresence, routerSilenceExpected } from "@core/routerPresence";
 import { apiRequest, recorderRunsInHostProcess } from "../lib/apiHost";
 import { useMetersEnforceable, useTrippedMeters, type MeterRuleView } from "./useDataMeter";
 import { CONNECT_ACCOUNT_ADVICE, dataLimitAlertSpec } from "@core/dataMeterAlert";
@@ -159,6 +160,9 @@ export function useDeviceAlerts(
   // would mean the two disagree about the same fact for seconds at a time.
   // Flapping is a bug in whatever makes polls fail, not something to smooth over.
   const dishReachable = dishConnection !== "unreachable";
+  // Collapsed to a string before the memo below: the status object is new every
+  // poll, and reading it there would rebuild the alert list once a second.
+  const presence = dishReachable ? routerPresence(dishStatus) : null;
   const trippedMeters = useTrippedMeters();
   const metersEnforceable = useMetersEnforceable();
   const [routerAlerts, setRouterAlerts] = useState<Record<string, boolean> | null>(null);
@@ -249,9 +253,10 @@ export function useDeviceAlerts(
     // above uses. The connection status indicator and this panel therefore never
     // disagree: anything that turns the indicator red is an active alert in the
     // same render.
+    const routerSilenceIsExpected = routerSilenceExpected(presence);
     const system = [
       ...(dishReachable ? [] : [DISH_UNREACHABLE]),
-      ...(routerReachable === false ? [ROUTER_UNREACHABLE] : []),
+      ...(routerReachable === false && !routerSilenceIsExpected ? [ROUTER_UNREACHABLE] : []),
       // Never on a host that runs the recorder in its own process: there the
       // thing that would be down is the thing asking, so the alert can only ever
       // be a false alarm about a request that was slow.
@@ -259,7 +264,15 @@ export function useDeviceAlerts(
       ...trippedMeters.map((rule) => dataLimitAlert(rule, metersEnforceable)),
     ];
     return sortBySeverity([...firing, ...system]);
-  }, [statusList, dishReachable, routerReachable, historianUp, trippedMeters, metersEnforceable]);
+  }, [
+    statusList,
+    dishReachable,
+    routerReachable,
+    presence,
+    historianUp,
+    trippedMeters,
+    metersEnforceable,
+  ]);
 
   // Announce an alert opening or clearing. Seeded lazily so an alert already
   // firing when the app opens still gets announced once.

--- a/src/hooks/useRouterUnreachable.ts
+++ b/src/hooks/useRouterUnreachable.ts
@@ -7,7 +7,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { ROUTER_LAN_ADDRESS, type DishStatusJson } from "@core/dishClient";
-import { dishSeesRouter } from "../lib/lanPresence";
+import { routerPresence } from "@core/routerPresence";
 import { resolveSelfIdentity, type SelfIdentity } from "../lib/selfIdentity";
 import {
   diagnoseRouterUnreachable,
@@ -75,7 +75,7 @@ export function useRouterUnreachable(
   // one identity across the dish polls underneath it — the status object is new
   // every second, and a fresh message object each time would re-render the
   // callout showing it for no change in what it says.
-  const routerPresent = dishReachable ? dishSeesRouter(dishStatus, true) : null;
+  const presence = dishReachable ? routerPresence(dishStatus) : null;
   // Only addresses belonging to the machine that makes the router request say
   // anything about why that request failed. A phone viewing this dashboard over
   // the LAN is answered with its own address, which is not where the request
@@ -95,17 +95,10 @@ export function useRouterUnreachable(
     () =>
       unreachable
         ? diagnoseRouterUnreachable(
-            { routerPresent, onRouterSubnet, addressConfigured, silencePersisted },
+            { presence, onRouterSubnet, addressConfigured, silencePersisted },
             routerAddress,
           )
         : null,
-    [
-      unreachable,
-      silencePersisted,
-      routerPresent,
-      onRouterSubnet,
-      addressConfigured,
-      routerAddress,
-    ],
+    [unreachable, silencePersisted, presence, onRouterSubnet, addressConfigured, routerAddress],
   );
 }

--- a/src/hooks/useRules.ts
+++ b/src/hooks/useRules.ts
@@ -56,6 +56,9 @@ export interface Rule {
   members: RuleMember[];
   /** Any of its devices held by the router because of this rule. */
   paused: boolean;
+  /** How many of them, so a rule still running for the rest is not read as
+   *  stopped on the strength of one device out of bytes. */
+  pausedCount: number;
   reached: boolean;
   /** Shut by its timetable, as against out of allowance. */
   windowBlocked: boolean;
@@ -112,6 +115,8 @@ function ruleFromGroup(group: DeviceGroup, members: MeterRuleView[]): Rule {
     // another rule holds it, and a card claiming that pause for its own limit
     // reads as "paused" beside a figure nowhere near the limit.
     paused: members.some((member) => member.pauseState === "applied" && member.holding),
+    pausedCount: members.filter((member) => member.pauseState === "applied" && member.holding)
+      .length,
     reached: members.some((member) => member.reached),
     windowBlocked: members.some((member) => member.windowBlocked === true),
     windowEndMs: first?.windowEndMs,
@@ -146,6 +151,7 @@ function ruleFromDevice(rule: MeterRuleView): Rule {
       },
     ],
     paused: rule.pauseState === "applied" && rule.holding,
+    pausedCount: rule.pauseState === "applied" && rule.holding ? 1 : 0,
     reached: rule.reached,
     windowBlocked: rule.windowBlocked === true,
     windowEndMs: rule.windowEndMs,

--- a/src/hooks/useScrollIntoViewWhen.test.tsx
+++ b/src/hooks/useScrollIntoViewWhen.test.tsx
@@ -1,0 +1,66 @@
+// The revealing, not the scrolling: a confirmation that appears below the fold
+// is one the reader decides on without its warning ever being on screen.
+
+import { useState } from "react";
+import { expect, describe, test, afterEach, vi } from "vitest";
+import { render, cleanup } from "vitest-browser-react";
+import { useScrollIntoViewWhen } from "./useScrollIntoViewWhen";
+
+afterEach(cleanup);
+
+function Revealing({ start = false }: { start?: boolean }) {
+  const [shown, setShown] = useState(start);
+  const ref = useScrollIntoViewWhen<HTMLDivElement>(shown);
+  return (
+    <>
+      <button onClick={() => setShown((was) => !was)}>toggle</button>
+      {shown && <div ref={ref}>the warning</div>}
+    </>
+  );
+}
+
+function watchScrolling() {
+  const calls: ScrollIntoViewOptions[] = [];
+  const spy = vi
+    .spyOn(Element.prototype, "scrollIntoView")
+    .mockImplementation(function (this: Element, options?: boolean | ScrollIntoViewOptions) {
+      calls.push((options ?? {}) as ScrollIntoViewOptions);
+    });
+  return { calls, restore: () => spy.mockRestore() };
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+describe("useScrollIntoViewWhen", () => {
+  test("stays put until the thing it guards is actually revealed", async () => {
+    const { calls, restore } = watchScrolling();
+    try {
+      render(<Revealing />);
+      await settle();
+      expect(calls).toHaveLength(0);
+
+      document.querySelector("button")?.click();
+      await settle();
+      expect(calls).toHaveLength(1);
+      // Moving the minimum keeps a control already on screen where it was.
+      expect(calls[0]?.block).toBe("nearest");
+    } finally {
+      restore();
+    }
+  });
+
+  test("does not drag the page back on the way down", async () => {
+    const { calls, restore } = watchScrolling();
+    try {
+      render(<Revealing start />);
+      await settle();
+      expect(calls).toHaveLength(1);
+
+      document.querySelector("button")?.click();
+      await settle();
+      expect(calls).toHaveLength(1);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/hooks/useScrollIntoViewWhen.test.tsx
+++ b/src/hooks/useScrollIntoViewWhen.test.tsx
@@ -21,11 +21,12 @@ function Revealing({ start = false }: { start?: boolean }) {
 
 function watchScrolling() {
   const calls: ScrollIntoViewOptions[] = [];
-  const spy = vi
-    .spyOn(Element.prototype, "scrollIntoView")
-    .mockImplementation(function (this: Element, options?: boolean | ScrollIntoViewOptions) {
-      calls.push((options ?? {}) as ScrollIntoViewOptions);
-    });
+  const spy = vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(function (
+    this: Element,
+    options?: boolean | ScrollIntoViewOptions,
+  ) {
+    calls.push((options ?? {}) as ScrollIntoViewOptions);
+  });
   return { calls, restore: () => spy.mockRestore() };
 }
 

--- a/src/hooks/useScrollIntoViewWhen.ts
+++ b/src/hooks/useScrollIntoViewWhen.ts
@@ -1,0 +1,15 @@
+// A control that reveals its confirmation on demand can reveal it below the
+// fold, leaving the decision on screen and the reason for it off it.
+
+import { useEffect, useRef } from "react";
+
+/** Brings the returned element into view each time `active` turns true. */
+export function useScrollIntoViewWhen<T extends HTMLElement>(active: boolean) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    // "nearest" moves the minimum needed, so a control already on screen stays
+    // where the reader left it.
+    if (active) ref.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [active]);
+  return ref;
+}

--- a/src/lib/badgeMode.test.ts
+++ b/src/lib/badgeMode.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { AlertState } from "@core/alertDefinitions";
+import { badgeAlerts, isBadgeMode } from "./badgeMode";
+
+function alert(source: AlertState["source"], key: string): AlertState {
+  return { source, key, active: true, ok: "", firing: "", severity: "warning" } as AlertState;
+}
+
+const DISH_FAULT = alert("dish", "thermalShutdown");
+const ROUTER_FAULT = alert("router", "poeFuseBlown");
+const DISH_UNREACHABLE = alert("system", "dishUnreachable");
+const ROUTER_UNREACHABLE = alert("system", "routerUnreachable");
+const OUTAGE = alert("system", "starlinkOutage");
+
+describe("badgeAlerts", () => {
+  it("counts faults and unreachability alike in the default mode", () => {
+    const shown = badgeAlerts([DISH_FAULT, DISH_UNREACHABLE], "all");
+    expect(shown).toHaveLength(2);
+  });
+
+  it("leaves Starlink outages out of every mode", () => {
+    for (const mode of ["all", "faults"] as const) {
+      expect(badgeAlerts([OUTAGE], mode)).toEqual([]);
+    }
+  });
+
+  it("drops both unreachability keys in faults mode", () => {
+    // Someone away from their kit sees exactly this pair and can act on neither.
+    const shown = badgeAlerts([DISH_UNREACHABLE, ROUTER_UNREACHABLE], "faults");
+    expect(shown).toEqual([]);
+  });
+
+  it("keeps what a device reported about itself in faults mode", () => {
+    const shown = badgeAlerts([DISH_FAULT, ROUTER_FAULT, DISH_UNREACHABLE], "faults");
+    expect(shown.map((a) => a.key)).toEqual(["thermalShutdown", "poeFuseBlown"]);
+  });
+
+  it("counts nothing at all when the badge is off", () => {
+    expect(badgeAlerts([DISH_FAULT, ROUTER_FAULT], "off")).toEqual([]);
+  });
+
+  it("preserves the order it was given, so the worst still tints the badge", () => {
+    const shown = badgeAlerts([ROUTER_FAULT, DISH_FAULT], "all");
+    expect(shown[0]).toBe(ROUTER_FAULT);
+  });
+
+  it("counts the pair someone away from their kit is left with", () => {
+    const away = [DISH_UNREACHABLE, ROUTER_UNREACHABLE];
+    expect(badgeAlerts(away, "all")).toHaveLength(2);
+    expect(badgeAlerts(away, "faults")).toHaveLength(0);
+    expect(badgeAlerts(away, "off")).toHaveLength(0);
+  });
+
+  it("keeps a spent data allowance, which is actionable wherever you are", () => {
+    const limit = alert("system", "dataLimit:aa:bb:cc");
+    expect(badgeAlerts([limit], "faults")).toEqual([limit]);
+  });
+
+  it("counts nothing from an empty set in any mode", () => {
+    for (const mode of ["all", "faults", "off"] as const) {
+      expect(badgeAlerts([], mode)).toEqual([]);
+    }
+  });
+
+  it("never invents an alert the caller did not pass", () => {
+    const mixed = [DISH_FAULT, DISH_UNREACHABLE, ROUTER_UNREACHABLE, OUTAGE, ROUTER_FAULT];
+    for (const mode of ["all", "faults", "off"] as const) {
+      expect(badgeAlerts(mixed, mode).every((a) => mixed.includes(a))).toBe(true);
+    }
+  });
+
+  it("narrows monotonically as the modes tighten", () => {
+    const mixed = [DISH_FAULT, DISH_UNREACHABLE, ROUTER_UNREACHABLE, OUTAGE, ROUTER_FAULT];
+    const all = badgeAlerts(mixed, "all");
+    const faults = badgeAlerts(mixed, "faults");
+    expect(faults.every((a) => all.includes(a))).toBe(true);
+    expect(faults.length).toBeLessThan(all.length);
+    expect(badgeAlerts(mixed, "off")).toEqual([]);
+  });
+
+  it("does not mutate what it was given", () => {
+    const mixed = [DISH_FAULT, DISH_UNREACHABLE, OUTAGE];
+    badgeAlerts(mixed, "faults");
+    expect(mixed).toEqual([DISH_FAULT, DISH_UNREACHABLE, OUTAGE]);
+  });
+});
+
+describe("isBadgeMode", () => {
+  it("accepts the three modes and nothing else", () => {
+    expect(["all", "faults", "off"].every(isBadgeMode)).toBe(true);
+    for (const value of [undefined, null, "", "ALL", true, 1]) {
+      expect(isBadgeMode(value)).toBe(false);
+    }
+  });
+});

--- a/src/lib/badgeMode.ts
+++ b/src/lib/badgeMode.ts
@@ -1,0 +1,56 @@
+// What the extension's toolbar badge counts. Only the extension binds this: no
+// other host keeps a standing alert count in the browser chrome.
+
+import type { AlertState } from "@core/alertDefinitions";
+
+export type BadgeMode =
+  /** Every alert, unreachability included. */
+  | "all"
+  /** Only faults a device reported about itself. */
+  | "faults"
+  /** No badge, ever. */
+  | "off";
+
+export const DEFAULT_BADGE_MODE: BadgeMode = "all";
+
+export function isBadgeMode(value: unknown): value is BadgeMode {
+  return value === "all" || value === "faults" || value === "off";
+}
+
+/** A healthy dish drops its link many times an hour as satellites hand over, so
+ *  counting outages would sit permanently lit over something needing nothing. */
+function badgeWorthy(alert: AlertState): boolean {
+  return !(alert.source === "system" && alert.key === "starlinkOutage");
+}
+
+/** Being away from the network raises unreachability exactly as a dead device
+ *  does, and nothing can tell those apart, so "faults" drops both. */
+function reportedByDevice(alert: AlertState): boolean {
+  return !(
+    alert.source === "system" &&
+    (alert.key === "dishUnreachable" || alert.key === "routerUnreachable")
+  );
+}
+
+/** The alerts a badge in this mode stands for. */
+export function badgeAlerts(active: AlertState[], mode: BadgeMode): AlertState[] {
+  if (mode === "off") return [];
+  const shown = active.filter(badgeWorthy);
+  return mode === "faults" ? shown.filter(reportedByDevice) : shown;
+}
+
+export interface BadgeModeBinding {
+  read: () => Promise<BadgeMode>;
+  write: (mode: BadgeMode) => Promise<void>;
+}
+
+let binding: BadgeModeBinding | null = null;
+
+/** Called once by a host entry point, before the UI renders. */
+export function setBadgeModeHost(hostBinding: BadgeModeBinding): void {
+  binding = hostBinding;
+}
+
+export function badgeModeHost(): BadgeModeBinding | null {
+  return binding;
+}

--- a/src/lib/lanPresence.ts
+++ b/src/lib/lanPresence.ts
@@ -16,12 +16,7 @@
 // opinion", never "offline", and the caller falls back to cloud freshness.
 
 import type { DishStatusJson, WifiStatusJson } from "@core/dishClient";
-
-/** How recently the dish must have heard from a downstream router to count it
- *  present. The dish drops a dead node from the map on its own, so this is a
- *  backstop against an entry that lingers; it is a LAN-local reading, hence
- *  seconds rather than the minutes the cloud path needs. */
-const LAST_SEEN_MS = 60_000;
+import { freshDownstreamRouterIds } from "@core/routerPresence";
 
 export interface LanPresenceInput {
   /** The dish's own get_status reply, and whether that poll is currently succeeding. */
@@ -31,36 +26,6 @@ export interface LanPresenceInput {
   router: WifiStatusJson | null;
   routerReachable: boolean;
   nowMs?: number;
-}
-
-/** Nanosecond epoch string → milliseconds, or null when unparseable. */
-function lastSeenMs(value: string | undefined): number | null {
-  if (value == null) return null;
-  const ns = Number(value);
-  return Number.isFinite(ns) && ns > 0 ? ns / 1e6 : null;
-}
-
-/**
- * The routers the dish is currently vouching for, by cloud DeviceId.
- *
- * downstreamRouters is preferred wherever the dish sends it, because its
- * per-router lastSeen can catch an entry that outlives the link it describes.
- * connectedRouters carries the same ids with no timestamp, so it stands in only
- * when the timestamped map is absent altogether rather than supplementing it —
- * re-adding those ids unconditionally would hand back exactly the staleness the
- * lastSeen check exists to filter.
- */
-function freshDownstreamRouterIds(dish: DishStatusJson | null, nowMs: number): string[] {
-  const downstream = dish?.downstreamRouters;
-  if (!downstream) return (dish?.connectedRouters ?? []).filter((id): id is string => !!id);
-  const ids: string[] = [];
-  for (const [routerId, entry] of Object.entries(downstream)) {
-    const seenMs = lastSeenMs(entry?.lastSeen);
-    // A missing or unreadable timestamp still counts: the dish listing the
-    // router at all is its statement that the link is up.
-    if (seenMs == null || nowMs - seenMs < LAST_SEEN_MS) ids.push(routerId);
-  }
-  return ids;
 }
 
 /**

--- a/src/lib/routerConfigUpdate.test.ts
+++ b/src/lib/routerConfigUpdate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { applyRouterConfigUpdate, AccountRequiredError } from "./routerConfigUpdate";
+import type { CloudReply } from "./cloudHost";
+
+const UPDATE = { kind: "bypass", enabled: false } as const;
+
+function replying(reply: CloudReply) {
+  return () => Promise.resolve(reply);
+}
+
+describe("applyRouterConfigUpdate", () => {
+  it("resolves when the gateway accepted it", async () => {
+    await expect(
+      applyRouterConfigUpdate(UPDATE, replying({ status: 200, body: { ok: true } })),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not call a timeout a refusal", async () => {
+    // Undoing bypass runs over the network bypass just reconfigured, so this is
+    // the failure the user is most likely to meet, and "rejected" would send
+    // them looking for a refusal that never happened.
+    const message = "Starlink did not answer the router change in time. Try again.";
+    await expect(
+      applyRouterConfigUpdate(
+        UPDATE,
+        replying({ status: 504, body: { error: "device_call_timeout", message } }),
+      ),
+    ).rejects.toThrow(message);
+    await expect(
+      applyRouterConfigUpdate(
+        UPDATE,
+        replying({ status: 504, body: { error: "device_call_timeout", message } }),
+      ),
+    ).rejects.not.toThrow(/rejected/);
+  });
+
+  it("asks for an account when none is connected", async () => {
+    await expect(
+      applyRouterConfigUpdate(UPDATE, replying({ status: 428, body: { error: "not_connected" } })),
+    ).rejects.toBeInstanceOf(AccountRequiredError);
+  });
+
+  it("reports a failed call without claiming it was refused", async () => {
+    await expect(
+      applyRouterConfigUpdate(
+        UPDATE,
+        replying({ status: 502, body: { error: "device_call_failed", message: "socket hang up" } }),
+      ),
+    ).rejects.toThrow("Starlink couldn't apply the change: socket hang up");
+  });
+
+  it("falls back to the status when the body carries no message", async () => {
+    await expect(
+      applyRouterConfigUpdate(UPDATE, replying({ status: 503, body: {} })),
+    ).rejects.toThrow("HTTP 503");
+  });
+});

--- a/src/lib/routerConfigUpdate.ts
+++ b/src/lib/routerConfigUpdate.ts
@@ -4,6 +4,15 @@ import type { RouterConfigUpdate } from "@core/routerConfigUpdate";
 
 export { AccountRequiredError };
 
+/** Starlink holds no session to the router, so it could not pass the change on.
+ *  The request was fine and nothing was applied: only time changes the answer. */
+export class DeviceUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeviceUnreachableError";
+  }
+}
+
 /** Send a router config change through Starlink cloud. There is no LAN path for
  *  this: the router answers PERMISSION_DENIED to a local set_config, and the
  *  cloud gateway reaches a bypassed router the local network cannot see at all. */
@@ -15,5 +24,13 @@ export async function applyRouterConfigUpdate(
   if (reply.status === 200) return;
   const message = (reply.body as { message?: string })?.message ?? `HTTP ${reply.status}`;
   if (reply.status === 428) throw new AccountRequiredError(message);
-  throw new Error(`Starlink rejected the change: ${message}`);
+  // Only the far end can refuse, and on a timeout it never spoke. The body
+  // already words that case, so it stands on its own.
+  if (reply.status === 504) throw new Error(message);
+  if ((reply.body as { deviceUnreachable?: boolean })?.deviceUnreachable)
+    throw new DeviceUnreachableError(
+      "Starlink can't reach your router right now, so it couldn't pass the change on. " +
+        "This clears on its own, usually within 4 to 5 minutes. Try again then.",
+    );
+  throw new Error(`Starlink couldn't apply the change: ${message}`);
 }

--- a/src/lib/routerDiagnosis.test.ts
+++ b/src/lib/routerDiagnosis.test.ts
@@ -44,7 +44,7 @@ describe("diagnoseRouterUnreachable", () => {
   it("blames the address when a live router is unreachable from its own subnet", () => {
     const { cause, message } = diagnoseRouterUnreachable({
       ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
-      routerPresent: true,
+      presence: "present",
       onRouterSubnet: true,
     });
     expect(cause).toBe("addressTaken");
@@ -55,7 +55,7 @@ describe("diagnoseRouterUnreachable", () => {
     expect(
       diagnoseRouterUnreachable({
         ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
-        routerPresent: true,
+        presence: "present",
         onRouterSubnet: false,
       }).cause,
     ).toBe("differentNetwork");
@@ -66,20 +66,20 @@ describe("diagnoseRouterUnreachable", () => {
     // new range while the app still dials the old default.
     const { message } = diagnoseRouterUnreachable({
       ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
-      routerPresent: true,
+      presence: "present",
       onRouterSubnet: false,
     });
     expect(message).toContain("subnet was changed");
   });
 
   it("reports no router when the dish says there is none", () => {
-    // Bypass mode: the dish answers, and names nothing downstream of it. Our own
-    // position is irrelevant — there is nothing at any address to reach.
+    // An enterprise kit or a powered-down router: the dish answers and names
+    // nothing downstream, so our own position is irrelevant.
     for (const onRouterSubnet of [true, false, null]) {
       for (const addressConfigured of [true, false]) {
         expect(
           diagnoseRouterUnreachable({
-            routerPresent: false,
+            presence: "absent",
             onRouterSubnet,
             addressConfigured,
             silencePersisted: true,
@@ -89,11 +89,47 @@ describe("diagnoseRouterUnreachable", () => {
     }
   });
 
+  it("names bypass rather than blaming the network the kit moved us onto", () => {
+    // Bypass leaves the router listed downstream and moves the viewer onto a
+    // CGNAT lease, so presence alone reads as a router up on another network.
+    const { cause, message } = diagnoseRouterUnreachable({
+      ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
+      presence: "bypassed",
+      onRouterSubnet: false,
+    });
+    expect(cause).toBe("bypassed");
+    expect(message).not.toContain("Connect to your Starlink WiFi");
+  });
+
+  it("names bypass whatever our own address and settings say", () => {
+    for (const onRouterSubnet of [true, false, null]) {
+      for (const addressConfigured of [true, false]) {
+        expect(
+          diagnoseRouterUnreachable({
+            presence: "bypassed",
+            onRouterSubnet,
+            addressConfigured,
+            silencePersisted: true,
+          }).cause,
+        ).toBe("bypassed");
+      }
+    }
+  });
+
+  it("keeps bypass out of the wording for a kit with no router", () => {
+    const { message } = diagnoseRouterUnreachable({
+      ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
+      presence: "absent",
+      onRouterSubnet: null,
+    });
+    expect(message).not.toContain("bypass");
+  });
+
   it("stays unknown while the dish cannot say whether a router exists", () => {
     expect(
       diagnoseRouterUnreachable({
         ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
-        routerPresent: null,
+        presence: null,
         onRouterSubnet: true,
       }).cause,
     ).toBe("unknown");
@@ -103,20 +139,20 @@ describe("diagnoseRouterUnreachable", () => {
     expect(
       diagnoseRouterUnreachable({
         ...AT_DEFAULT_ADDRESS_AND_PERSISTENT,
-        routerPresent: true,
+        presence: "present",
         onRouterSubnet: null,
       }).cause,
     ).toBe("unknown");
   });
 
   it("gives every cause something to read", () => {
-    for (const routerPresent of [true, false, null]) {
+    for (const presence of ["present", "absent", "bypassed", null] as const) {
       for (const onRouterSubnet of [true, false, null]) {
         for (const addressConfigured of [true, false]) {
           for (const silencePersisted of [true, false]) {
             expect(
               diagnoseRouterUnreachable({
-                routerPresent,
+                presence,
                 onRouterSubnet,
                 addressConfigured,
                 silencePersisted,
@@ -130,7 +166,7 @@ describe("diagnoseRouterUnreachable", () => {
 
   it("names the address actually being dialled, not the default", () => {
     const message = diagnoseRouterUnreachable(
-      { ...AT_DEFAULT_ADDRESS_AND_PERSISTENT, routerPresent: null, onRouterSubnet: null },
+      { ...AT_DEFAULT_ADDRESS_AND_PERSISTENT, presence: null, onRouterSubnet: null },
       "192.168.2.1",
     ).message;
     expect(message).toContain("192.168.2.1");
@@ -142,7 +178,7 @@ describe("diagnoseRouterUnreachable with an address the user chose", () => {
   it("blames the setting, not a neighbour, wherever this device sits", () => {
     for (const onRouterSubnet of [true, false, null]) {
       const { cause, message } = diagnoseRouterUnreachable(
-        { routerPresent: true, onRouterSubnet, addressConfigured: true, silencePersisted: true },
+        { presence: "present", onRouterSubnet, addressConfigured: true, silencePersisted: true },
         "192.168.2.1",
       );
       expect(cause).toBe("configuredAddressSilent");
@@ -153,7 +189,7 @@ describe("diagnoseRouterUnreachable with an address the user chose", () => {
   it("still reports bypass ahead of the setting", () => {
     expect(
       diagnoseRouterUnreachable({
-        routerPresent: false,
+        presence: "absent",
         onRouterSubnet: true,
         addressConfigured: true,
         silencePersisted: true,
@@ -164,11 +200,12 @@ describe("diagnoseRouterUnreachable with an address the user chose", () => {
 
 describe("diagnoseRouterUnreachable before the outage settles", () => {
   it("names no cause at all, however strong the signals", () => {
-    for (const routerPresent of [true, false, null]) {
+    // Bypass is excluded: it is a fact from the dish, so it is named at once.
+    for (const presence of ["present", "absent", null] as const) {
       for (const addressConfigured of [true, false]) {
         expect(
           diagnoseRouterUnreachable({
-            routerPresent,
+            presence,
             onRouterSubnet: true,
             addressConfigured,
             silencePersisted: false,
@@ -176,6 +213,19 @@ describe("diagnoseRouterUnreachable before the outage settles", () => {
         ).toBe("checking");
       }
     }
+  });
+
+  it("names bypass immediately, without waiting for the silence to settle", () => {
+    // The alert list stops raising the unreachability the moment the dish reports
+    // the role, so a panel that waited would contradict it for 15 seconds.
+    expect(
+      diagnoseRouterUnreachable({
+        presence: "bypassed",
+        onRouterSubnet: true,
+        addressConfigured: false,
+        silencePersisted: false,
+      }).cause,
+    ).toBe("bypassed");
   });
 });
 
@@ -195,7 +245,7 @@ describe("viewerOnRouterSubnet with a configured address", () => {
 it("never suggests the address the router already answers on", () => {
   for (const routerAddress of ["192.168.1.1", "192.168.2.1", "10.0.0.1"]) {
     const { message } = diagnoseRouterUnreachable(
-      { ...AT_DEFAULT_ADDRESS_AND_PERSISTENT, routerPresent: true, onRouterSubnet: true },
+      { ...AT_DEFAULT_ADDRESS_AND_PERSISTENT, presence: "present", onRouterSubnet: true },
       routerAddress,
     );
     const suggestion = /different address \(like ([\d.]+)\)/.exec(message)?.[1];

--- a/src/lib/routerDiagnosis.ts
+++ b/src/lib/routerDiagnosis.ts
@@ -20,9 +20,16 @@
 //   • the viewer's own LAN address says whether the router's address is local to
 //     this machine or somewhere it would have to route to.
 //
+// Role BYPASSED                         → switched off on purpose; expected.
 // Router up + we are inside its subnet  → something else here holds the address.
 // Router up + we are outside it         → we are simply not on its network.
-// No router                             → bypass mode, or the router is off.
+// No router at all                      → no router on this kit, or it is off.
+//
+// Bypass is read from the dish's role, never from the router's absence: probed
+// on a Gen 3 kit on 2026-08-21, a bypassed router stays listed downstream with
+// its role changed to BYPASSED. Read as an absence it lands on one of the rows
+// above instead, which sends the user to join a WiFi that bypass has switched
+// off.
 //
 // That table reads the address as a fact about the kit, which holds only for the
 // factory default. An address the user set is a claim about where the router is,
@@ -31,6 +38,7 @@
 // neighbouring device of holding an address the router was never on.
 
 import { ROUTER_LAN_ADDRESS } from "@core/dishClient";
+import type { RouterPresence } from "@core/routerPresence";
 
 export type RouterUnreachableCause =
   /** Too early to say. An outage that heals on its own must not be described as
@@ -43,7 +51,9 @@ export type RouterUnreachableCause =
   | "configuredAddressSilent"
   /** The router is up, but this device is not on its network. */
   | "differentNetwork"
-  /** The kit has no router: bypass mode, or the router is powered off. */
+  /** The kit's router is in bypass mode, so it serves nothing by design. */
+  | "bypassed"
+  /** The kit has no router at all, or it is powered off. */
   | "noRouter"
   /** Not enough signal to choose between the above. */
   | "unknown";
@@ -56,10 +66,10 @@ export interface RouterUnreachable {
 }
 
 export interface RouterUnreachableSignals {
-  /** Whether the dish reports a router downstream of it (lib/lanPresence's
-   *  `dishSeesRouter`). `null` when the dish is not answering either, which is
-   *  no evidence in either direction. */
-  routerPresent: boolean | null;
+  /** What the dish says about the routers downstream of it (core/routerPresence).
+   *  `null` when the dish is not answering either, which is no evidence in any
+   *  direction. */
+  presence: RouterPresence | null;
   /** Whether the viewer's own address sits in the router's subnet. `null` when
    *  the host cannot resolve its own IPv4 — under the extension, and on an
    *  IPv6-only viewer — which costs precision, not correctness. */
@@ -136,10 +146,14 @@ function messagesFor(routerAddress: string): Record<RouterUnreachableCause, stri
       `Your Starlink router is running, but this device isn't on the network ${routerAddress} ` +
       `belongs to. Connect to your Starlink WiFi, or if the router's subnet was changed, point ` +
       `Dishylink's router address at where it is now.`,
+    bypassed:
+      `Bypass mode is on, so the Starlink router is switched off and a third-party router runs ` +
+      `your network. WiFi, the client list and the router's own settings all come from it, so ` +
+      `there's nothing to show here. Everything on the dish is unaffected.`,
     noRouter:
-      `The dish isn't reporting a Starlink router — it's in bypass mode, or the router is off. ` +
-      `WiFi and connected devices come from the router, so there's nothing to show here. ` +
-      `Everything on the dish is unaffected.`,
+      `The dish isn't reporting a Starlink router, so this kit either doesn't have one or it's ` +
+      `powered off. WiFi and connected devices come from the router, so there's nothing to show ` +
+      `here. Everything on the dish is unaffected.`,
     unknown:
       `Couldn't reach the Starlink router at ${routerAddress}. Another device may be using ` +
       `that address, the router may be in bypass mode or on a different network, or it may be ` +
@@ -156,9 +170,14 @@ export function diagnoseRouterUnreachable(
   signals: RouterUnreachableSignals,
   routerAddress: string = ROUTER_LAN_ADDRESS,
 ): RouterUnreachable {
-  const { routerPresent, onRouterSubnet, addressConfigured, silencePersisted } = signals;
+  const { presence, onRouterSubnet, addressConfigured, silencePersisted } = signals;
+  const routerPresent = presence === null ? null : presence !== "absent";
   let cause: RouterUnreachableCause = "unknown";
-  if (!silencePersisted) {
+  // Ahead of the settling wait: the other causes are inferences a short outage
+  // can invalidate, while bypass is the dish stating a fact.
+  if (presence === "bypassed") {
+    cause = "bypassed";
+  } else if (!silencePersisted) {
     cause = "checking";
   } else if (routerPresent === false) {
     cause = "noRouter";


### PR DESCRIPTION
Adds bypass mode and router factory reset, and makes both work on the kit
that needs them most: one whose router answers nothing on the local
network.

## Bypass

The switch reads the LAN before the account. Telemetry was measured
lagging a flip by minutes, so ranking it first left the row insisting on
bypass while the WiFi was already back. A router answering locally, or the
dish naming the role, settles it in seconds; the account is consulted only
when neither can. Both recorders carry the dish's reading through, so a
bypassed router's silence is read as expected rather than raised as an
alert.

## Factory reset

For the dish and for the router. A router in bypass is invisible on the
local network by definition, so its reset goes through the linked account,
which is the only exit bypass leaves. Both sit behind an armed slide and a
stated warning.

## Config writes over the cloud gateway

A refused write is Starlink holding no session to the router, not a bad
request, and it was reported as a rejection. It now fails with the true
reason and retries once from nothing, because resending the same bytes
cannot help: a target learned during a flip can name a mesh node that is
never connected. A write that severs the network carrying its own reply is
no longer read as a refusal, which only the far end can give.

## Also here

- The extension's toolbar badge takes a setting: all alerts, only faults a
  device reported about itself, or nothing. Being away from your Starlink
  is indistinguishable from a device that has failed, so the middle option
  leaves both out.
- A rule that runs Mon-Fri now says it is not scheduled today, and when it
  resumes, instead of "Active, closes in 1 day".
- A group is no longer drawn as paused, or its bar reddened, when one of
  its devices is out of bytes and the rest are still online.
- Transport failures no longer discard the cached account, which was
  swinging every caption keyed on it once per retry.
- The modal scrim moved off the scrolling overlay, so panels no longer
  flicker while a list inside them is scrolled.