### PR TITLE
Add auto-generated outage post-mortem reports

### DIFF
--- a/collector/alertStore.mts
+++ b/collector/alertStore.mts
@@ -98,13 +98,23 @@ export class AlertStore {
     this.flush();
   }
 
-  close(source: AlertSource, key: string, endMs: number): void {
-    if (!this.isOpen(source, key)) return;
+  /**
+   * Close the open episode for (source, key) and return it. A caller that
+   * cares what just ended (the outage post-mortem) acts on this episode rather
+   * than re-searching `all()`: a long outage can have started outside the
+   * 48 h window `all()` serves, and closed episodes age out of it the moment
+   * they close.
+   */
+  close(source: AlertSource, key: string, endMs: number): AlertEpisode | null {
+    if (!this.isOpen(source, key)) return null;
+    let closed: AlertEpisode | null = null;
     for (const episode of this.episodes) {
       if (episode.source === source && episode.key === key && episode.endMs === null) {
         episode.endMs = endMs;
+        closed = episode;
       }
     }
     this.flush();
+    return closed;
   }
 }

--- a/collector/alertStore.test.mts
+++ b/collector/alertStore.test.mts
@@ -139,3 +139,35 @@ describe("AlertStore retention", () => {
     expect(served[0].endMs).toBeNull();
   });
 });
+
+describe("AlertStore.close returns the episode it closed", () => {
+  it("returns the closed episode even after it has aged out of all()", () => {
+    // The episode that matters here: closed long past the 48 h window `all()`
+    // serves. The historian's report path must see it anyway.
+    const ancientStart = Date.now() - 49 * 24 * 3_600_000;
+    const now = Date.now();
+    const store = new AlertStore(file);
+    store.open("system", "dishUnreachable", ancientStart);
+    const closed = store.close("system", "dishUnreachable", now);
+    expect(closed).toMatchObject({
+      source: "system",
+      key: "dishUnreachable",
+      startMs: ancientStart,
+      endMs: now,
+    });
+    // and it has indeed aged out of the served list
+    expect(store.all()).toHaveLength(0);
+  });
+
+  it("returns null when nothing was open to close", () => {
+    const store = new AlertStore(file);
+    expect(store.close("system", "starlinkOutage", Date.now())).toBeNull();
+  });
+
+  it("returns null for a second close of the same episode", () => {
+    const store = new AlertStore(file);
+    store.open("system", "starlinkOutage", Date.now() - 60_000);
+    store.close("system", "starlinkOutage", Date.now());
+    expect(store.close("system", "starlinkOutage", Date.now() + 60_000)).toBeNull();
+  });
+});

--- a/collector/historian.mts
+++ b/collector/historian.mts
@@ -78,7 +78,7 @@ import { parseScheduleParam } from "../core/schedule.ts";
 import { CONNECT_ACCOUNT_ADVICE, dataLimitAlertSpec } from "../core/dataMeterAlert.ts";
 import { ThroughputTracker } from "../core/throughputTracker.ts";
 import { usageKey } from "../core/clientUsage.ts";
-import { AlertStore } from "./alertStore.mts";
+import { AlertStore, type AlertEpisode } from "./alertStore.mts";
 import { AlertEngine, type AlertObservation, type AlertTransition } from "../core/alertEngine.ts";
 import { ObstructionStore, packCells } from "./obstructionStore.mts";
 
@@ -951,9 +951,12 @@ export function recordAlertTransitions(transitions: AlertTransition[]): void {
   if (transitions.length === 0) return;
   for (const transition of transitions) {
     const { source, key, atMs, kind, spec } = transition;
+    // `close` hands back the episode it closed: an outage can start before the
+    // alert log's 48 h window, and `all()` only serves that window.
+    let closedEpisode: AlertEpisode | null = null;
     if (kind === "fired")
       alertStore.open(source, key, atMs, { label: spec.firing, severity: spec.severity });
-    else alertStore.close(source, key, atMs);
+    else closedEpisode = alertStore.close(source, key, atMs);
     // The service's diary. It runs unattended under launchd with no window and
     // no operator, so "did it see the outage?" is answerable only from what it
     // wrote down. Every transition is logged, not a chosen few, so an
@@ -977,22 +980,16 @@ export function recordAlertTransitions(transitions: AlertTransition[]): void {
       source === "system" &&
       (key === "starlinkOutage" || key === "dishUnreachable")
     ) {
-      const episode = alertStore
-        .all()
-        .find(
-          (candidate) =>
-            candidate.source === source && candidate.key === key && candidate.endMs === atMs,
-        );
-      if (episode) {
+      if (closedEpisode) {
         // The per-minute fallback rows for the same five-minute window: the
         // whole-minute bucket that covers the drop second is left out, since
         // it mixes pre-drop and dropped seconds.
-        const beforeStartSec = Math.floor((episode.startMs - BEFORE_WINDOW_MS) / 60_000) * 60;
-        const beforeEndSec = Math.floor(episode.startMs / 60_000) * 60;
+        const beforeStartSec = Math.floor((closedEpisode.startMs - BEFORE_WINDOW_MS) / 60_000) * 60;
+        const beforeEndSec = Math.floor(closedEpisode.startMs / 60_000) * 60;
         const added = postmortemStore.add(
           buildOutageReport({
             source: key,
-            startMs: episode.startMs,
+            startMs: closedEpisode.startMs,
             endMs: atMs,
             generatedAtMs: Date.now(),
             dishEvents: eventStore.all(),

--- a/collector/historian.mts
+++ b/collector/historian.mts
@@ -49,6 +49,8 @@ import { EnergyStore, foldSamplesToMinutes, type MinuteBucket } from "./energySt
 import { energyRangeBounds, RANGES, summarizeEnergy, type Range } from "../core/energySummary.ts";
 import { ThermalStore } from "./thermalStore.mts";
 import { EventStore } from "./eventStore.mts";
+import { PostmortemStore } from "./postmortemStore.mts";
+import { buildOutageReport, BEFORE_WINDOW_MS } from "../core/postmortem.ts";
 import { ClientStore, type ClientReading } from "./clientStore.mts";
 import { ClientWindow } from "./clientWindow.mts";
 import { resolveRows, foldMinuteCollisions } from "../core/clientHistory.ts";
@@ -114,6 +116,7 @@ const CLIENT_TOTALS_FILE = join(DATA_DIR, "client-totals.json");
 const METERS_FILE = join(DATA_DIR, "meters.json");
 const DEVICE_GROUPS_FILE = join(DATA_DIR, "device-groups.json");
 const ALERTS_FILE = join(DATA_DIR, "alerts.ndjson");
+const POSTMORTEM_FILE = join(DATA_DIR, "postmortems.ndjson");
 const OBSTRUCTION_FILE = join(DATA_DIR, "obstruction.ndjson");
 const LOCK_FILE = join(DATA_DIR, "historian.lock");
 const PORT = Number(process.env.HISTORIAN_PORT ?? 8088);
@@ -299,6 +302,7 @@ async function getStatusAlerts(): Promise<{
   alerts: Record<string, boolean>;
   ethSpeedMbps?: number;
   routerPresence: RouterPresence;
+  snowMeltActive: boolean | null;
 }> {
   const json = (await deviceCall(DISH_URL, GET_STATUS_FIELD)) as {
     dishGetStatus?: DishStatusJson;
@@ -310,6 +314,9 @@ async function getStatusAlerts(): Promise<{
     // needs the negotiated speed to tell a real dead link from a latched flag.
     ethSpeedMbps: status?.ethSpeedMbps,
     routerPresence: routerPresence(status),
+    // `=== true` is the check (see DishStatusJson.snowMeltActive): toJson omits
+    // a false field, so absence is not recorded as "off".
+    snowMeltActive: status?.snowMeltActive === true ? true : null,
   };
 }
 
@@ -354,6 +361,10 @@ async function getRouterStatus(): Promise<{
  */
 let latestRouterLatencyMs: number | null = null;
 let latestRouterPingSuccessPercent: number | null = null;
+// Whether the dish's snow-melt heater was running, read from the same get_status
+// reply getStatusAlerts decodes each cycle. Null when the reply said nothing —
+// proto3 JSON omits a false field, so this is "not known active", never "off".
+let latestSnowMeltActive: boolean | null = null;
 
 /**
  * Wi-Fi radio temperatures from the router. Only `temp2` is ever populated —
@@ -834,6 +845,7 @@ const obstructionStore = new ObstructionStore(OBSTRUCTION_FILE);
 const clientStore = new ClientStore(CLIENTS_FILE);
 const clientWindow = new ClientWindow(CLIENT_SAMPLES_FILE);
 const alertStore = new AlertStore(ALERTS_FILE);
+const postmortemStore = new PostmortemStore(POSTMORTEM_FILE);
 
 /**
  * Decides what changed; this file only writes it down and passes it on. Seeded
@@ -858,7 +870,7 @@ const alertEngine = new AlertEngine(
  * offline reach the user with no window open, which is the entire point of
  * running a recorder rather than a dashboard.
  */
-const alertListeners = new Set<(transitions: AlertTransition[]) => void>();
+export const alertListeners = new Set<(transitions: AlertTransition[]) => void>();
 
 export function onAlertTransitions(listener: (transitions: AlertTransition[]) => void): () => void {
   alertListeners.add(listener);
@@ -935,7 +947,7 @@ export function setLiveThroughputEnabled(enabled: boolean): void {
 }
 
 /** Persist a cycle's transitions, then hand them to whoever is listening. */
-function recordAlertTransitions(transitions: AlertTransition[]): void {
+export function recordAlertTransitions(transitions: AlertTransition[]): void {
   if (transitions.length === 0) return;
   for (const transition of transitions) {
     const { source, key, atMs, kind, spec } = transition;
@@ -954,6 +966,43 @@ function recordAlertTransitions(transitions: AlertTransition[]): void {
     if (source === "dish" && THERMAL_ALERT_KEYS.includes(key)) {
       if (kind === "fired") thermalStore.open(key, atMs);
       else thermalStore.close(key, atMs);
+    }
+    // The post-mortem: when a link outage ends, freeze what the recording
+    // knows about it now — the 1 s sample window that answers "the five
+    // minutes before the drop" ages out within hours, so the report is
+    // generated at the close, not on demand. Only these two keys are a link
+    // outage; thermal episodes ride along in the report but never trigger one.
+    if (
+      kind === "cleared" &&
+      source === "system" &&
+      (key === "starlinkOutage" || key === "dishUnreachable")
+    ) {
+      const episode = alertStore
+        .all()
+        .find(
+          (candidate) =>
+            candidate.source === source && candidate.key === key && candidate.endMs === atMs,
+        );
+      if (episode) {
+        // The per-minute fallback rows for the same five-minute window: the
+        // whole-minute bucket that covers the drop second is left out, since
+        // it mixes pre-drop and dropped seconds.
+        const beforeStartSec = Math.floor((episode.startMs - BEFORE_WINDOW_MS) / 60_000) * 60;
+        const beforeEndSec = Math.floor(episode.startMs / 60_000) * 60;
+        const added = postmortemStore.add(
+          buildOutageReport({
+            source: key,
+            startMs: episode.startMs,
+            endMs: atMs,
+            generatedAtMs: Date.now(),
+            dishEvents: eventStore.all(),
+            samples: latestSamples,
+            minuteBuckets: store.readRange(beforeStartSec, beforeEndSec),
+            thermal: thermalStore.all(),
+          }),
+        );
+        if (added) console.log(`[historian] post-mortem report generated for ${source}:${key}`);
+      }
     }
   }
   for (const listener of alertListeners) listener(transitions);
@@ -1017,6 +1066,9 @@ function compactSample(sample: TelemetrySample): TelemetrySample {
     routerPingSuccessPercent: Number.isFinite(sample.routerPingSuccessPercent)
       ? Math.round(sample.routerPingSuccessPercent! * 100) / 100
       : null,
+    // A snapshot written before the field existed restores it as undefined,
+    // which must not come back as anything but null.
+    snowMeltActive: sample.snowMeltActive === true ? true : null,
   };
 }
 
@@ -1110,6 +1162,7 @@ async function pollAlerts(): Promise<void> {
   const observation: AlertObservation = {};
   try {
     const dishStatus = await getStatusAlerts();
+    latestSnowMeltActive = dishStatus.snowMeltActive;
     observation.dish = {
       alerts: dishStatus.alerts,
       ethSpeedMbps: dishStatus.ethSpeedMbps,
@@ -1122,6 +1175,7 @@ async function pollAlerts(): Promise<void> {
     // not a cleared alert — and raises the unreachability itself, so it survives
     // in history instead of only being a console warning.
     observation.dish = { alerts: null, atMs: Date.now() };
+    latestSnowMeltActive = null;
   }
   try {
     // One status reply, two consumers: the alert set, and the ping the sample
@@ -1404,6 +1458,7 @@ async function poll(): Promise<void> {
     {
       latencyMs: latestRouterLatencyMs,
       pingSuccessPercent: latestRouterPingSuccessPercent,
+      snowMeltActive: latestSnowMeltActive,
     },
     window,
   );
@@ -1761,6 +1816,13 @@ export function handleRequest(request: IncomingMessage, response: ServerResponse
   if (url.pathname === "/api/outages") {
     response.setHeader("Content-Type", "application/json");
     response.end(JSON.stringify({ events: eventStore.all() }));
+    return;
+  }
+  // Auto-generated post-mortems for ended outages. Each report is the shareable
+  // artifact itself: self-contained, frozen at generation, newest first.
+  if (url.pathname === "/api/outages/reports") {
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({ reports: postmortemStore.all() }));
     return;
   }
   if (url.pathname === "/api/obstruction/snapshots") {

--- a/collector/historian.postmortem.test.mts
+++ b/collector/historian.postmortem.test.mts
@@ -1,0 +1,168 @@
+// The recorder's post-mortem path, end to end: an open outage episode, the dish
+// event and pre-drop samples seeded on disk, a `cleared` transition — and the
+// report is written and served, with its numbers folded from the recordings
+// around the outage.
+//
+// Like historian.meters.test.mts: the module claims a data directory and starts
+// its poll timers when evaluated, so HISTORIAN_DATA_DIR moves the claim to a
+// temp directory, HISTORIAN_EMBED keeps the HTTP port shut, and fake timers
+// installed before the import mean none of the intervals it registers fire.
+
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { SYSTEM_ALERTS } from "../core/alertDefinitions.ts";
+import type { TelemetrySample } from "../core/telemetry.ts";
+
+const DATA_DIR = mkdtempSync(join(tmpdir(), "historian-postmortem-"));
+const POSTMORTEMS_FILE = join(DATA_DIR, "postmortems.ndjson");
+
+const NOW = Date.now();
+const START = NOW - 3 * 60_000; // the drop, three minutes ago
+const END = NOW; // the close, now
+const WINDOW_START = START - 5 * 60_000;
+
+// The recorder's own episode: opened when the drop was detected, still open on
+// disk so the engine restores it across the restart this import represents.
+writeFileSync(
+  join(DATA_DIR, "alerts.ndjson"),
+  JSON.stringify({ source: "system", key: "starlinkOutage", startMs: START, endMs: null }) + "\n",
+);
+
+// The dish's own event log entry for the same outage, for the cause.
+writeFileSync(
+  join(DATA_DIR, "events.ndjson"),
+  JSON.stringify({
+    startMs: START - 2_000,
+    durationMs: 182_000,
+    cause: "EVENT_REASON_OUTAGE_NO_PINGS",
+    severity: "warning",
+  }) + "\n",
+);
+
+// The 1 s sample window the recorder would be holding: a healthy five minutes
+// before the drop (latency 40 ms, 100 Mbps down), snow melt asserted on the
+// first half only — enough to answer "was snow melt active?".
+function sample(timestampMs: number, snowMelt: boolean | null): TelemetrySample {
+  return {
+    timestampMs,
+    latencyMs: 40,
+    dropRate: 0,
+    downlinkBps: 100_000_000,
+    uplinkBps: 10_000_000,
+    powerW: 80,
+    routerLatencyMs: null,
+    routerPingSuccessPercent: null,
+    snowMeltActive: snowMelt,
+  };
+}
+const samples: TelemetrySample[] = Array.from({ length: 300 }, (_, second) =>
+  sample(WINDOW_START + second * 1000, second < 150 ? true : null),
+);
+writeFileSync(join(DATA_DIR, "samples.json"), JSON.stringify(samples));
+
+process.env.HISTORIAN_DATA_DIR = DATA_DIR;
+process.env.HISTORIAN_EMBED = "1";
+
+vi.useFakeTimers();
+const historian = await import("./historian.mts");
+
+function call(method: string, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve) => {
+    const chunks: string[] = [];
+    const response = {
+      statusCode: 200,
+      setHeader() {},
+      write(chunk: string) {
+        chunks.push(chunk);
+      },
+      end(body?: string) {
+        if (body) chunks.push(body);
+        resolve({ status: response.statusCode, body: chunks.join("") });
+      },
+    };
+    historian.handleRequest(
+      { url: path, method, headers: {} } as IncomingMessage,
+      response as unknown as ServerResponse,
+    );
+  });
+}
+
+describe("the recorder's post-mortem path", () => {
+  it("generates a report the moment the outage episode clears, and serves it", async () => {
+    historian.recordAlertTransitions([
+      {
+        kind: "cleared",
+        source: "system",
+        key: "starlinkOutage",
+        atMs: END,
+        spec: SYSTEM_ALERTS.starlinkOutage,
+      },
+    ]);
+
+    const persisted = JSON.parse(readFileSync(POSTMORTEMS_FILE, "utf8")) as Record<string, unknown>;
+    expect(persisted).toMatchObject({
+      id: `system:starlinkOutage:${START}`,
+      source: "starlinkOutage",
+      startMs: START,
+      endMs: END,
+      durationMs: END - START,
+      cause: "NO_PINGS",
+    });
+
+    // The five minutes before the drop, from the sample window.
+    expect(persisted.beforeDrop).toMatchObject({
+      coverageSeconds: 300,
+      latencyAvgMs: 40,
+      downlinkAvgBps: 100_000_000,
+      uplinkAvgBps: 10_000_000,
+      snowMelt: "active",
+      source: "samples",
+    });
+
+    // The episode is closed on disk too — a report is only ever generated
+    // against the recording that saw the outage end.
+    const episodes = readFileSync(join(DATA_DIR, "alerts.ndjson"), "utf8")
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+    expect(episodes).toHaveLength(1);
+    expect(episodes[0]).toMatchObject({ source: "system", key: "starlinkOutage", endMs: END });
+
+    const { status, body } = await call("GET", "/api/outages/reports");
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toMatchObject({
+      reports: [{ id: `system:starlinkOutage:${START}` }],
+    });
+  });
+
+  it("will not regenerate a report for the same episode", () => {
+    historian.recordAlertTransitions([
+      {
+        kind: "cleared",
+        source: "system",
+        key: "starlinkOutage",
+        atMs: END,
+        spec: SYSTEM_ALERTS.starlinkOutage,
+      },
+    ]);
+    expect(readFileSync(POSTMORTEMS_FILE, "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  it("ignores a thermal episode clearing — heat is report content, not a report trigger", async () => {
+    const before = readFileSync(POSTMORTEMS_FILE, "utf8").trim().split("\n").length;
+    historian.recordAlertTransitions([
+      {
+        kind: "cleared",
+        source: "dish",
+        key: "thermalThrottle",
+        atMs: END,
+        spec: SYSTEM_ALERTS.starlinkOutage,
+      },
+    ]);
+    const { body } = await call("GET", "/api/outages/reports");
+    expect((JSON.parse(body) as { reports: unknown[] }).reports).toHaveLength(before);
+  });
+});

--- a/collector/historian.postmortem.test.mts
+++ b/collector/historian.postmortem.test.mts
@@ -165,4 +165,49 @@ describe("the recorder's post-mortem path", () => {
     const { body } = await call("GET", "/api/outages/reports");
     expect((JSON.parse(body) as { reports: unknown[] }).reports).toHaveLength(before);
   });
+
+  it("still reports an outage whose episode started outside the 48 h alert window", () => {
+    // The episode is long (started yesterday), so it has aged out of the alert
+    // log's served window by the time it clears — the report must not depend on
+    // `AlertStore.all()` for the episode lookup.
+    const oldStart = END - 49 * 3_600_000;
+    historian.recordAlertTransitions([
+      {
+        kind: "fired",
+        source: "system",
+        key: "dishUnreachable",
+        atMs: oldStart,
+        spec: SYSTEM_ALERTS.dishUnreachable,
+      },
+    ]);
+    historian.recordAlertTransitions([
+      {
+        kind: "cleared",
+        source: "system",
+        key: "dishUnreachable",
+        atMs: END,
+        spec: SYSTEM_ALERTS.dishUnreachable,
+      },
+    ]);
+
+    const rows = readFileSync(POSTMORTEMS_FILE, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(rows).toHaveLength(2); // the seeded outage plus this one
+    const report = rows.find((row) => row.id === `system:dishUnreachable:${oldStart}`);
+    expect(report).toMatchObject({
+      source: "dishUnreachable",
+      startMs: oldStart,
+      endMs: END,
+      durationMs: END - oldStart,
+    });
+    // The pre-drop window has no samples or minute rows this far back: the
+    // honest zero-invention fallback, not a swallowed report.
+    expect(report!.beforeDrop).toMatchObject({
+      coverageSeconds: 0,
+      latencyAvgMs: null,
+      source: "minute-buckets",
+    });
+  });
 });

--- a/collector/postmortemStore.mts
+++ b/collector/postmortemStore.mts
@@ -1,0 +1,64 @@
+// Durable log of auto-generated outage post-mortem reports.
+//
+// One line per ended outage, written the moment the recorder sees the outage
+// end. Reports are few (a healthy setup produces none for weeks), so this keeps
+// the whole log in memory and rewrites the file on change — same shape as
+// eventStore, whose 48-hour window this intentionally outlives: a report is a
+// self-contained, shareable artifact, so it stays reachable (and copyable) long
+// after the events panel has rolled past the outage that produced it.
+
+import {
+  ensureParentDirectory,
+  readJsonLines,
+  writeJsonLinesAtomically,
+} from "./jsonLinesFile.mts";
+import type { OutageReport } from "../core/postmortem.ts";
+
+// 30 days. Self-contained and small, so a month costs a handful of rows; the
+// events panel beside it is 48 h, which is why the report lives longer.
+const RETENTION_MS = 30 * 24 * 3_600_000;
+
+export class PostmortemStore {
+  private reports = new Map<string, OutageReport>();
+
+  constructor(private readonly filePath: string) {
+    ensureParentDirectory(filePath);
+    for (const report of readJsonLines<OutageReport>(filePath)) {
+      this.reports.set(report.id, report);
+    }
+  }
+
+  private flush(): void {
+    const cutoffMs = Date.now() - RETENTION_MS;
+    for (const [id, report] of this.reports) {
+      if (report.endMs < cutoffMs) this.reports.delete(id);
+    }
+    // Oldest first on disk, so the log reads chronologically.
+    const ordered = [...this.reports.values()].sort((a, b) => a.endMs - b.endMs);
+    writeJsonLinesAtomically(this.filePath, ordered);
+  }
+
+  /**
+   * Persist a report. Returns whether it was new; an episode can only close
+   * once, so a second add for the same id is a regeneration bug, not an update —
+   * the first frozen report stands.
+   */
+  add(report: OutageReport): boolean {
+    if (this.reports.has(report.id)) return false;
+    this.reports.set(report.id, report);
+    this.flush();
+    return true;
+  }
+
+  /**
+   * Reports newest-first, for the API. The retention cutoff is applied here as
+   * well as in flush — flush only runs when a report is added, so a quiet
+   * stretch (the usual case) would otherwise serve rows past the window.
+   */
+  all(): OutageReport[] {
+    const cutoffMs = Date.now() - RETENTION_MS;
+    return [...this.reports.values()]
+      .filter((report) => report.endMs >= cutoffMs)
+      .sort((a, b) => b.endMs - a.endMs);
+  }
+}

--- a/collector/postmortemStore.test.mts
+++ b/collector/postmortemStore.test.mts
@@ -1,0 +1,96 @@
+// The post-mortem store pins one product decision and one invariant: a report
+// outlives the 48 h events panel beside it (30-day window), and a report for an
+// episode that has already been reported is never written twice — an episode
+// closes once, so a second add for the same id is a regeneration bug.
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PostmortemStore } from "./postmortemStore.mts";
+import type { OutageReport } from "../core/postmortem.ts";
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+  dir = join(tmpdir(), `postmortems-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  file = join(dir, "postmortems.ndjson");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const HOUR_MS = 3_600_000;
+
+function report(endMs: number, overrides: Partial<OutageReport> = {}): OutageReport {
+  return {
+    id: `system:starlinkOutage:${endMs - 60_000}`,
+    source: "starlinkOutage",
+    startMs: endMs - 60_000,
+    endMs,
+    durationMs: 60_000,
+    cause: "NO_PINGS",
+    beforeDrop: {
+      windowStartMs: endMs - 366_000,
+      windowEndMs: endMs - 60_000,
+      coverageSeconds: 300,
+      latencyAvgMs: 40,
+      downlinkAvgBps: 100_000_000,
+      uplinkAvgBps: 10_000_000,
+      dropRateAvg: 0,
+      snowMelt: "unknown",
+      source: "samples",
+    },
+    thermal: [],
+    generatedAtMs: endMs + 1_000,
+    ...overrides,
+  };
+}
+
+describe("PostmortemStore retention", () => {
+  it("keeps reports from within the last 30 days", () => {
+    const store = new PostmortemStore(file);
+    store.add(report(Date.now() - 29 * 24 * HOUR_MS, { id: "A" }));
+    expect(store.all()).toHaveLength(1);
+  });
+
+  it("drops reports older than 30 days on the next write", () => {
+    const store = new PostmortemStore(file);
+    store.add(report(Date.now() - 31 * 24 * HOUR_MS, { id: "old" }));
+    store.add(report(Date.now(), { id: "new" }));
+
+    const remaining = store.all();
+    expect(remaining.map((row) => row.id)).toEqual(["new"]);
+    // and the pruned row is gone from disk too, not just memory
+    expect(readFileSync(file, "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  it("hides an aged-out report when nothing has been written since", () => {
+    // Seeded directly: add() flushes, and flush prunes on the same cutoff, so
+    // writing an already-old report would prune it immediately and prove nothing.
+    writeFileSync(file, JSON.stringify(report(Date.now() - 40 * 24 * HOUR_MS)) + "\n");
+    expect(new PostmortemStore(file).all()).toHaveLength(0);
+  });
+});
+
+describe("PostmortemStore.add", () => {
+  it("serves reports newest-first, surviving a reopen", () => {
+    const store = new PostmortemStore(file);
+    store.add(report(Date.now() - 2 * 60_000, { id: "older" }));
+    store.add(report(Date.now(), { id: "newer" }));
+
+    const reopened = new PostmortemStore(file);
+    expect(reopened.all().map((row) => row.id)).toEqual(["newer", "older"]);
+  });
+
+  it("refuses to regenerate a report for an episode already reported", () => {
+    const store = new PostmortemStore(file);
+    const row = report(Date.now());
+    expect(store.add(row)).toBe(true);
+    expect(store.add(row)).toBe(false);
+    expect(store.all()).toHaveLength(1);
+  });
+});

--- a/core/dishClient.ts
+++ b/core/dishClient.ts
@@ -157,6 +157,10 @@ export interface DishStatusJson {
   dlBandwidthRestrictedReason?: string;
   ulBandwidthRestrictedReason?: string;
   isSnrAboveNoiseFloor?: boolean;
+  /** Whether the dish's snow-melt heater is running. Compared with `=== true`
+   *  where it is read: proto3 JSON omits a false field, so absence means "not
+   *  known to be active", never "off". */
+  snowMeltActive?: boolean;
   /** Set when SNR has stayed low long enough to look like weather, not a blip —
    *  the flag behind the dish's own RAIN_SNR_PERSISTENTLY_LOW alert. Absent
    *  (proto3 drops false) means the signal is holding. */

--- a/core/postmortem.test.ts
+++ b/core/postmortem.test.ts
@@ -1,0 +1,237 @@
+// The post-mortem synthesis is the whole feature in miniature: inputs already
+// recorded, folded into one self-contained report the moment an outage ends.
+// These pin the rules that make a report honest — which recording feeds the
+// "five minutes before" numbers, what "snow melt" may assert, which dish event
+// gets blamed, and what thermal state counts as touching the outage.
+
+import { describe, expect, it } from "vitest";
+import { BEFORE_WINDOW_MS, buildOutageReport, type OutageReportInput } from "./postmortem";
+import type { MinuteBucket } from "./energyBuckets";
+import type { TelemetrySample } from "./telemetry";
+
+const START = 1_785_000_000_000; // arbitrary epoch ms
+const END = START + 180_000;
+const WINDOW_START = START - BEFORE_WINDOW_MS;
+
+function sample(timestampMs: number, overrides: Partial<TelemetrySample> = {}): TelemetrySample {
+  return {
+    timestampMs,
+    latencyMs: 40,
+    dropRate: 0,
+    downlinkBps: 100_000_000,
+    uplinkBps: 10_000_000,
+    powerW: 80,
+    routerLatencyMs: null,
+    routerPingSuccessPercent: null,
+    snowMeltActive: null,
+    ...overrides,
+  };
+}
+
+/** A fully covered five-minute window at 1 Hz, ending at the drop. */
+function fullWindow(): TelemetrySample[] {
+  return Array.from({ length: 300 }, (_, second) => sample(WINDOW_START + second * 1000));
+}
+
+function bucket(minuteSec: number, samples = 60, downlinkBits = 6e9): MinuteBucket {
+  return { minute: minuteSec, wattSeconds: samples * 80, samples, downlinkBits, uplinkBits: 6e8 };
+}
+
+function input(overrides: Partial<OutageReportInput> = {}): OutageReportInput {
+  return {
+    source: "starlinkOutage",
+    startMs: START,
+    endMs: END,
+    generatedAtMs: END + 1000,
+    dishEvents: [
+      {
+        startMs: START - 2_000,
+        durationMs: 185_000,
+        cause: "EVENT_REASON_OUTAGE_NO_PINGS",
+        severity: "warning",
+      },
+    ],
+    samples: fullWindow(),
+    minuteBuckets: [],
+    thermal: [],
+    ...overrides,
+  };
+}
+
+describe("buildOutageReport identity", () => {
+  it("keys the report to the episode and states its span", () => {
+    const report = buildOutageReport(input());
+    expect(report.id).toBe(`system:starlinkOutage:${START}`);
+    expect(report.startMs).toBe(START);
+    expect(report.endMs).toBe(END);
+    expect(report.durationMs).toBe(180_000);
+    expect(report.source).toBe("starlinkOutage");
+  });
+});
+
+describe("the five minutes before the drop", () => {
+  it("averages the 1 s samples that cover the window", () => {
+    const report = buildOutageReport(input());
+    expect(report.beforeDrop).toMatchObject({
+      windowStartMs: WINDOW_START,
+      windowEndMs: START,
+      coverageSeconds: 300,
+      latencyAvgMs: 40,
+      downlinkAvgBps: 100_000_000,
+      uplinkAvgBps: 10_000_000,
+      dropRateAvg: 0,
+      source: "samples",
+    });
+  });
+
+  it("drops null latencies from the mean instead of averaging them in", () => {
+    const window = fullWindow();
+    window[0] = sample(WINDOW_START, { latencyMs: null });
+    window[1] = sample(WINDOW_START + 1000, { latencyMs: null });
+    const report = buildOutageReport(input({ samples: window }));
+    expect(report.beforeDrop.latencyAvgMs).toBe(40); // 298 readings, not 300/300 count
+  });
+
+  it("reports the honesty number when the window is only partly covered", () => {
+    // The recorder restarted two minutes into the window: seconds 120–300 only.
+    const window = Array.from({ length: 180 }, (_, second) =>
+      sample(WINDOW_START + (120 + second) * 1000),
+    );
+    const report = buildOutageReport(input({ samples: window }));
+    expect(report.beforeDrop.coverageSeconds).toBe(180);
+    expect(report.beforeDrop.source).toBe("samples");
+  });
+
+  it("falls back to the per-minute rows once the window has aged past the samples", () => {
+    const report = buildOutageReport(
+      input({
+        samples: [],
+        minuteBuckets: [
+          bucket(WINDOW_START, 60, 6e9),
+          bucket(WINDOW_START + 60_000, 60, 6e9),
+          bucket(WINDOW_START + 120_000, 60, 6e9),
+          bucket(WINDOW_START + 180_000, 60, 6e9),
+          bucket(WINDOW_START + 240_000, 60, 6e9),
+        ],
+      }),
+    );
+    expect(report.beforeDrop).toMatchObject({
+      coverageSeconds: 300,
+      // 30 Gb over 300 recorded seconds — the minute rows have no latency.
+      downlinkAvgBps: 100_000_000,
+      uplinkAvgBps: 10_000_000,
+      latencyAvgMs: null,
+      dropRateAvg: null,
+      snowMelt: "unknown",
+      source: "minute-buckets",
+    });
+  });
+
+  it("handles an outage nobody recorded around: coverage zero, no invented numbers", () => {
+    const report = buildOutageReport(input({ samples: [], minuteBuckets: [] }));
+    expect(report.beforeDrop).toMatchObject({
+      coverageSeconds: 0,
+      latencyAvgMs: null,
+      downlinkAvgBps: null,
+      uplinkAvgBps: null,
+      source: "minute-buckets",
+    });
+  });
+
+  it("ignores the whole-minute bucket the drop second falls in", () => {
+    // The drop minute mixes pre-drop and dropped seconds; only the minutes
+    // whose start lies inside the window count. The window spans 11:55:00–12:00:00.
+    const dropMinuteSec = Math.floor(START / 60_000) * 60;
+    const report = buildOutageReport(
+      input({
+        samples: [],
+        minuteBuckets: [
+          bucket(WINDOW_START, 60, 6e9),
+          ...Array.from({ length: 4 }, (_, i) => bucket(WINDOW_START + (i + 1) * 60_000, 60, 6e9)),
+          bucket(dropMinuteSec, 60, 6e9), // must not count — it starts after the window
+        ],
+      }),
+    );
+    expect(report.beforeDrop.coverageSeconds).toBe(300);
+    expect(report.beforeDrop.downlinkAvgBps).toBe(100_000_000);
+  });
+});
+
+describe("snow melt — what may be asserted", () => {
+  it("says active when any sample in the window was stamped active", () => {
+    const window = fullWindow();
+    window[150] = sample(window[150].timestampMs, { snowMeltActive: true });
+    expect(buildOutageReport(input({ samples: window })).beforeDrop.snowMelt).toBe("active");
+  });
+
+  it("says off when every recorded reading was false", () => {
+    const report = buildOutageReport(
+      input({
+        samples: fullWindow().map((s) => ({ ...s, snowMeltActive: false })),
+      }),
+    );
+    expect(report.beforeDrop.snowMelt).toBe("off");
+  });
+
+  it("says unknown when the reply never asserted anything — the field is absent while false", () => {
+    const report = buildOutageReport(input({ samples: fullWindow() }));
+    expect(report.beforeDrop.snowMelt).toBe("unknown");
+  });
+});
+
+describe("the cause", () => {
+  it("takes the canonical cause of the dish event overlapping the outage", () => {
+    const report = buildOutageReport(input());
+    expect(report.cause).toBe("NO_PINGS");
+  });
+
+  it("reports no cause when the dish never logged an overlapping event", () => {
+    const report = buildOutageReport(input({ dishEvents: [] }));
+    expect(report.cause).toBeNull();
+  });
+
+  it("ties to the event whose start is nearest the recorder's start stamp", () => {
+    // Both overlap: one begins 4 min before the drop (a slow bleed), one 1 s
+    // before — the recorder's start matches the sudden one, which is the cause.
+    const report = buildOutageReport(
+      input({
+        dishEvents: [
+          {
+            startMs: START - 240_000,
+            durationMs: 300_000,
+            cause: "EVENT_REASON_OUTAGE_OBSTRUCTED",
+            severity: "warning",
+          },
+          {
+            startMs: START - 1_000,
+            durationMs: 181_000,
+            cause: "EVENT_REASON_OUTAGE_NO_PINGS",
+            severity: "warning",
+          },
+        ],
+      }),
+    );
+    expect(report.cause).toBe("NO_PINGS");
+  });
+});
+
+describe("thermal state touching the outage", () => {
+  it("includes episodes that overlap the window widened five minutes before the drop", () => {
+    const report = buildOutageReport(
+      input({
+        thermal: [
+          // Ended four minutes before the drop — before the widened window.
+          { alertKey: "thermalThrottle", startMs: START - 600_000, endMs: START - 480_000 },
+          // Began inside the widened window and ran into the outage.
+          { alertKey: "thermalShutdown", startMs: START - 240_000, endMs: END + 30_000 },
+          // Still running at generation time — frozen as it was.
+          { alertKey: "powerSupplyThermalThrottle", startMs: START - 30_000, endMs: null },
+        ],
+      }),
+    );
+    expect(report.thermal.map((episode) => episode.alertKey)).toEqual([
+      "thermalShutdown",
+      "powerSupplyThermalThrottle",
+    ]);
+  });
+});

--- a/core/postmortem.test.ts
+++ b/core/postmortem.test.ts
@@ -107,11 +107,11 @@ describe("the five minutes before the drop", () => {
       input({
         samples: [],
         minuteBuckets: [
-          bucket(WINDOW_START, 60, 6e9),
-          bucket(WINDOW_START + 60_000, 60, 6e9),
-          bucket(WINDOW_START + 120_000, 60, 6e9),
-          bucket(WINDOW_START + 180_000, 60, 6e9),
-          bucket(WINDOW_START + 240_000, 60, 6e9),
+          bucket(WINDOW_START / 1000, 60, 6e9),
+          bucket(WINDOW_START / 1000 + 60, 60, 6e9),
+          bucket(WINDOW_START / 1000 + 120, 60, 6e9),
+          bucket(WINDOW_START / 1000 + 180, 60, 6e9),
+          bucket(WINDOW_START / 1000 + 240, 60, 6e9),
         ],
       }),
     );
@@ -146,13 +146,40 @@ describe("the five minutes before the drop", () => {
       input({
         samples: [],
         minuteBuckets: [
-          bucket(WINDOW_START, 60, 6e9),
-          ...Array.from({ length: 4 }, (_, i) => bucket(WINDOW_START + (i + 1) * 60_000, 60, 6e9)),
-          bucket(dropMinuteSec, 60, 6e9), // must not count — it starts after the window
+          bucket(WINDOW_START / 1000, 60, 6e9),
+          ...Array.from({ length: 4 }, (_, i) =>
+            bucket(WINDOW_START / 1000 + (i + 1) * 60, 60, 6e9),
+          ),
+          bucket(dropMinuteSec, 60, 6e9), // must not count — it covers the drop second
         ],
       }),
     );
     expect(report.beforeDrop.coverageSeconds).toBe(300);
+    expect(report.beforeDrop.downlinkAvgBps).toBe(100_000_000);
+  });
+
+  it("excludes the drop-second bucket even when the caller hands it in — the drop rarely lands on a minute boundary", () => {
+    // Drop at :37 of the minute: the drop-minute bucket starts before the drop
+    // stamp, so a naive `bucket.minute < startMs` cut would let it through and
+    // average its mixed pre-drop/dropped seconds.
+    const startMs = START + 37_000;
+    const dropMinuteSec = Math.floor(startMs / 60_000) * 60;
+    const report = buildOutageReport(
+      input({
+        startMs,
+        endMs: startMs + 180_000,
+        samples: [],
+        minuteBuckets: [
+          bucket(dropMinuteSec - 60, 60, 6e9),
+          bucket(dropMinuteSec - 120, 60, 6e9),
+          bucket(dropMinuteSec - 180, 60, 6e9),
+          bucket(dropMinuteSec - 240, 60, 6e9),
+          // The drop minute, with a volume that would skew the average if it leaked in.
+          bucket(dropMinuteSec, 60, 297e9),
+        ],
+      }),
+    );
+    expect(report.beforeDrop.coverageSeconds).toBe(240);
     expect(report.beforeDrop.downlinkAvgBps).toBe(100_000_000);
   });
 });
@@ -164,13 +191,13 @@ describe("snow melt — what may be asserted", () => {
     expect(buildOutageReport(input({ samples: window })).beforeDrop.snowMelt).toBe("active");
   });
 
-  it("says off when every recorded reading was false", () => {
+  it("reports unknown for recorded falses too — the producer never emits them, so 'off' would be an invention", () => {
     const report = buildOutageReport(
       input({
         samples: fullWindow().map((s) => ({ ...s, snowMeltActive: false })),
       }),
     );
-    expect(report.beforeDrop.snowMelt).toBe("off");
+    expect(report.beforeDrop.snowMelt).toBe("unknown");
   });
 
   it("says unknown when the reply never asserted anything — the field is absent while false", () => {

--- a/core/postmortem.ts
+++ b/core/postmortem.ts
@@ -1,0 +1,225 @@
+// Outage post-mortem synthesis.
+//
+// Everything the report states is already recorded — the recorder never asks the
+// devices anything new. The moment a link outage ends (the recorder's own
+// starlinkOutage / dishUnreachable episode clears), this folds the recordings
+// around it into one self-contained summary: when it happened and for how long,
+// what the dish's own event log says caused it, the latency/throughput of the
+// five minutes before the drop, whether snow melt was running, and any thermal
+// state touching the outage.
+//
+// Pure and IO-free, so the recorder and the UI agree on what an outage means:
+// the recorder generates the report and the dashboard renders the same shape
+// the API serves.
+
+import { canonicalCause, type OutageEvent, type TelemetrySample } from "./telemetry";
+import type { MinuteBucket } from "./energyBuckets";
+
+/** How far back before the drop the report looks for "what the link was doing". */
+export const BEFORE_WINDOW_MS = 5 * 60_000;
+
+/** The names of the recorder's own episodes that mean a link outage. The dish's
+ *  event-log entries (eventStore) describe what happened; these episodes are
+ *  what the recorder can time precisely, because it opens and closes them. */
+export type OutageSourceKey = "starlinkOutage" | "dishUnreachable";
+
+export interface BeforeDropStats {
+  /** The five minutes of recording before the link dropped, [start, drop). */
+  windowStartMs: number;
+  windowEndMs: number;
+  /** Seconds of the window actually covered by a recording — the honesty number
+   *  behind every average. 300 is a fully covered window at 1 Hz. */
+  coverageSeconds: number;
+  /** Mean dish → PoP ping latency (ms). Null once the outage is older than the
+   *  6 h sample window: the per-minute rows that reach back further carry no
+   *  latency. */
+  latencyAvgMs: number | null;
+  downlinkAvgBps: number | null;
+  uplinkAvgBps: number | null;
+  /** Mean share of pings dropped across the covered seconds (0–1). */
+  dropRateAvg: number | null;
+  /** Tri-state on purpose: get_status omits a false snowMeltActive field, so
+   *  "active" is the only state the dish ever asserts outright — "off" needs a
+   *  recorded false, and a window with no reading at all is "unknown". */
+  snowMelt: "active" | "off" | "unknown";
+  /** Which recording fed the numbers: the 1 s sample window when it reaches
+   *  back to the pre-drop minutes, else the per-minute energy rows. */
+  source: "samples" | "minute-buckets";
+}
+
+/** One thermal episode touching the outage, from the thermal log. */
+export interface ReportThermalEpisode {
+  alertKey: string;
+  startMs: number;
+  /** Null while still running — the report freezes the episode as it was. */
+  endMs: number | null;
+}
+
+/** The auto-generated summary of one ended outage. This JSON is the shareable
+ *  artifact: it is self-contained (every number it states was frozen at
+ *  generation time) and rides the `/api/outages/reports` list newest-first. */
+export interface OutageReport {
+  /** Identity of the closed episode that ended the outage —
+   *  `system:starlinkOutage:<startMs>` — keyed so a report is never generated
+   *  twice for the same outage. */
+  id: string;
+  /** Which recorder episode ended: sample-based (eight consecutive dropped
+   *  seconds) or dish-unreachable. */
+  source: OutageSourceKey;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  /** Canonical cause token from the dish's own event log (see canonicalCause),
+   *  when an event overlaps the outage; null when the dish never reported one. */
+  cause: string | null;
+  beforeDrop: BeforeDropStats;
+  /** Thermal episodes touching [start − 5 min, end]: a shutdown that began
+   *  before the drop — the classic staged failure — still shows. */
+  thermal: ReportThermalEpisode[];
+  generatedAtMs: number;
+}
+
+export interface OutageReportInput {
+  source: OutageSourceKey;
+  startMs: number;
+  endMs: number;
+  /** The dish's event-log entries held by the event store, for the cause. */
+  dishEvents: OutageEvent[];
+  /** The recorder's 1 s sample window (covers ~6 h; silence inside it occupies
+   *  room, so a long outage leaves the pre-drop seconds only while recent). */
+  samples: TelemetrySample[];
+  /** Per-minute energy rows for the window — the fallback for outages that have
+   *  aged past the sample window. Minutes are the whole-minute span their
+   *  bucket covers; the caller hands over the ones overlapping the window. */
+  minuteBuckets: MinuteBucket[];
+  /** The thermal log, whole — overlap with the outage is judged here. */
+  thermal: ReportThermalEpisode[];
+  generatedAtMs: number;
+}
+
+/** Below this many sample-seconds covering the window, the sample window is no
+ *  longer the honest source: it usually means the window's start has aged out,
+ *  and the per-minute rows describe it better. Whole-minute rows cover the
+ *  window with ~300 s either way. */
+const MIN_SAMPLE_COVERAGE_SECONDS = 60;
+
+/** The cause the dish's event log assigns, or null when none of its events
+ *  overlaps the outage. The recorder detects the drop up to a few seconds after
+ *  the dish's own start stamp, so the match tolerates that, and ties go to the
+ *  event whose start is nearest the recorder's. */
+function causeOf(dishEvents: OutageEvent[], startMs: number, endMs: number): string | null {
+  const overlapping = dishEvents.filter(
+    (event) =>
+      // Interval overlap, with the recorder's start tolerance and the same
+      // five-minute lookback the thermal check uses.
+      Math.max(event.startMs, startMs - BEFORE_WINDOW_MS) <=
+      Math.min(event.startMs + Math.max(event.durationMs, 0), endMs),
+  );
+  if (overlapping.length === 0) return null;
+  return canonicalCause(
+    overlapping.sort((a, b) => Math.abs(a.startMs - startMs) - Math.abs(b.startMs - startMs))[0]
+      .cause,
+  );
+}
+
+/** Window tri-state: any asserted active wins; a recorded false everywhere is
+ *  "off"; silence everywhere is "unknown" (see BeforeDropStats.snowMelt). */
+function snowMeltOf(samples: TelemetrySample[]): "active" | "off" | "unknown" {
+  let sawReading = false;
+  for (const sample of samples) {
+    if (sample.snowMeltActive === null || sample.snowMeltActive === undefined) continue;
+    sawReading = true;
+    if (sample.snowMeltActive === true) return "active";
+  }
+  return sawReading ? "off" : "unknown";
+}
+
+function mean(values: number[]): number | null {
+  return values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+/** The five minutes before the drop from the 1 s window: averages over the
+ *  seconds it actually covered. Null fields mean the field exists on the
+ *  samples but every reading for the window was null, not "not recorded". */
+function beforeDropFromSamples(samples: TelemetrySample[], startMs: number): BeforeDropStats {
+  const windowStartMs = startMs - BEFORE_WINDOW_MS;
+  const inWindow = samples.filter(
+    (sample) => sample.timestampMs >= windowStartMs && sample.timestampMs < startMs,
+  );
+  const latencies = inWindow.flatMap((sample) =>
+    sample.latencyMs === null ? [] : [sample.latencyMs],
+  );
+  return {
+    windowStartMs,
+    windowEndMs: startMs,
+    coverageSeconds: inWindow.length,
+    latencyAvgMs: mean(latencies),
+    downlinkAvgBps: mean(inWindow.map((sample) => sample.downlinkBps)),
+    uplinkAvgBps: mean(inWindow.map((sample) => sample.uplinkBps)),
+    dropRateAvg: mean(inWindow.map((sample) => sample.dropRate)),
+    snowMelt: snowMeltOf(inWindow),
+    source: "samples",
+  };
+}
+
+/** The fallback for outages that have aged past the sample window: the
+ *  per-minute rows sum the same downlink/uplink bits (one row per wall-clock
+ *  minute) with the seconds they covered. Latency and snow melt are not in
+ *  those rows, so they stay null/unknown rather than being invented. */
+function beforeDropFromBuckets(buckets: MinuteBucket[], startMs: number): BeforeDropStats {
+  const windowStartMs = startMs - BEFORE_WINDOW_MS;
+  const inWindow = buckets.filter(
+    (bucket) => bucket.minute >= windowStartMs && bucket.minute < startMs,
+  );
+  const coverageSeconds = inWindow.reduce((sum, bucket) => sum + bucket.samples, 0);
+  const downlinkBits = inWindow.reduce((sum, bucket) => sum + (bucket.downlinkBits ?? 0), 0);
+  const uplinkBits = inWindow.reduce((sum, bucket) => sum + (bucket.uplinkBits ?? 0), 0);
+  return {
+    windowStartMs,
+    windowEndMs: startMs,
+    coverageSeconds,
+    latencyAvgMs: null,
+    downlinkAvgBps: coverageSeconds > 0 ? downlinkBits / coverageSeconds : null,
+    uplinkAvgBps: coverageSeconds > 0 ? uplinkBits / coverageSeconds : null,
+    dropRateAvg: null,
+    snowMelt: "unknown",
+    source: "minute-buckets",
+  };
+}
+
+/** Fold the recordings around one ended outage into the report. Pure — the
+ *  caller supplies everything; this decides what the outage means. */
+export function buildOutageReport(input: OutageReportInput): OutageReport {
+  const { source, startMs, endMs, dishEvents, samples, minuteBuckets, thermal, generatedAtMs } =
+    input;
+  const windowStartMs = startMs - BEFORE_WINDOW_MS;
+  const sampleCoverage = samples.filter(
+    (sample) => sample.timestampMs >= windowStartMs && sample.timestampMs < startMs,
+  ).length;
+
+  const beforeDrop =
+    sampleCoverage >= MIN_SAMPLE_COVERAGE_SECONDS
+      ? beforeDropFromSamples(samples, startMs)
+      : beforeDropFromBuckets(minuteBuckets, startMs);
+
+  return {
+    id: `system:${source}:${startMs}`,
+    source,
+    startMs,
+    endMs,
+    durationMs: endMs - startMs,
+    cause: causeOf(dishEvents, startMs, endMs),
+    beforeDrop,
+    thermal: thermal
+      .filter(
+        (episode) =>
+          episode.startMs <= endMs && (episode.endMs === null || episode.endMs >= windowStartMs),
+      )
+      .map(({ alertKey, startMs: episodeStartMs, endMs: episodeEndMs }) => ({
+        alertKey,
+        startMs: episodeStartMs,
+        endMs: episodeEndMs,
+      })),
+    generatedAtMs,
+  };
+}

--- a/core/postmortem.ts
+++ b/core/postmortem.ts
@@ -28,7 +28,9 @@ export interface BeforeDropStats {
   windowStartMs: number;
   windowEndMs: number;
   /** Seconds of the window actually covered by a recording — the honesty number
-   *  behind every average. 300 is a fully covered window at 1 Hz. */
+   *  behind every average. 300 is a fully covered window at 1 Hz; the
+   *  minute-row fallback counts whole minutes only, so its fully covered window
+   *  is 240–300 s depending on where in the minute the drop landed. */
   coverageSeconds: number;
   /** Mean dish → PoP ping latency (ms). Null once the outage is older than the
    *  6 h sample window: the per-minute rows that reach back further carry no
@@ -38,10 +40,12 @@ export interface BeforeDropStats {
   uplinkAvgBps: number | null;
   /** Mean share of pings dropped across the covered seconds (0–1). */
   dropRateAvg: number | null;
-  /** Tri-state on purpose: get_status omits a false snowMeltActive field, so
-   *  "active" is the only state the dish ever asserts outright — "off" needs a
-   *  recorded false, and a window with no reading at all is "unknown". */
-  snowMelt: "active" | "off" | "unknown";
+  /** Two-state on purpose: get_status omits a false snowMeltActive field, so
+   *  "active" is the only state the dish ever asserts outright, and the
+   *  recorder's only producer normalizes everything else to an absent field. A
+   *  window with no assertion — or with a recorded false, which the current
+   *  producer chain cannot even emit — reads "unknown", never "off". */
+  snowMelt: "active" | "unknown";
   /** Which recording fed the numbers: the 1 s sample window when it reaches
    *  back to the pre-drop minutes, else the per-minute energy rows. */
   source: "samples" | "minute-buckets";
@@ -90,7 +94,9 @@ export interface OutageReportInput {
   samples: TelemetrySample[];
   /** Per-minute energy rows for the window — the fallback for outages that have
    *  aged past the sample window. Minutes are the whole-minute span their
-   *  bucket covers; the caller hands over the ones overlapping the window. */
+   *  bucket covers; the caller hands over the ones overlapping the window, and
+   *  the drop-minute bucket is excluded here regardless of how it was asked
+   *  for. */
   minuteBuckets: MinuteBucket[];
   /** The thermal log, whole — overlap with the outage is judged here. */
   thermal: ReportThermalEpisode[];
@@ -99,8 +105,11 @@ export interface OutageReportInput {
 
 /** Below this many sample-seconds covering the window, the sample window is no
  *  longer the honest source: it usually means the window's start has aged out,
- *  and the per-minute rows describe it better. Whole-minute rows cover the
- *  window with ~300 s either way. */
+ *  and the per-minute rows describe it better. Whole-minute rows count only the
+ *  minutes fully inside the window — the partial minute the window starts in
+ *  and the drop-minute bucket are both left out — so a fully recorded window is
+ *  300 s only when the drop lands on a minute boundary; the usual drop reads
+ *  240 s (four whole minutes). */
 const MIN_SAMPLE_COVERAGE_SECONDS = 60;
 
 /** The cause the dish's event log assigns, or null when none of its events
@@ -122,16 +131,15 @@ function causeOf(dishEvents: OutageEvent[], startMs: number, endMs: number): str
   );
 }
 
-/** Window tri-state: any asserted active wins; a recorded false everywhere is
- *  "off"; silence everywhere is "unknown" (see BeforeDropStats.snowMelt). */
-function snowMeltOf(samples: TelemetrySample[]): "active" | "off" | "unknown" {
-  let sawReading = false;
+/** Window verdict: any asserted active wins; everything else — silence, or a
+ *  recorded false, which today's producer chain cannot even emit — reads
+ *  "unknown" (see BeforeDropStats.snowMelt). Claiming "off" would assert
+ *  something the reply never said. */
+function snowMeltOf(samples: TelemetrySample[]): "active" | "unknown" {
   for (const sample of samples) {
-    if (sample.snowMeltActive === null || sample.snowMeltActive === undefined) continue;
-    sawReading = true;
     if (sample.snowMeltActive === true) return "active";
   }
-  return sawReading ? "off" : "unknown";
+  return "unknown";
 }
 
 function mean(values: number[]): number | null {
@@ -168,8 +176,16 @@ function beforeDropFromSamples(samples: TelemetrySample[], startMs: number): Bef
  *  those rows, so they stay null/unknown rather than being invented. */
 function beforeDropFromBuckets(buckets: MinuteBucket[], startMs: number): BeforeDropStats {
   const windowStartMs = startMs - BEFORE_WINDOW_MS;
+  // Bucket minutes are whole-minute epoch seconds; the window bounds are ms.
+  const windowStartSec = windowStartMs / 1000;
+  // The whole-minute bucket the drop second falls in is excluded no matter how
+  // the caller asked: it mixes pre-drop and dropped seconds, and its start can
+  // precede the drop stamp (only a drop exactly on the minute boundary makes
+  // the naive `bucket.minute < startMs / 1000` cut). A bucket whose minute
+  // start lies inside the window is then a whole minute fully inside it.
+  const dropMinuteSec = Math.floor(startMs / 60_000) * 60;
   const inWindow = buckets.filter(
-    (bucket) => bucket.minute >= windowStartMs && bucket.minute < startMs,
+    (bucket) => bucket.minute >= windowStartSec && bucket.minute < dropMinuteSec,
   );
   const coverageSeconds = inWindow.reduce((sum, bucket) => sum + bucket.samples, 0);
   const downlinkBits = inWindow.reduce((sum, bucket) => sum + (bucket.downlinkBits ?? 0), 0);

--- a/core/telemetry.ts
+++ b/core/telemetry.ts
@@ -23,6 +23,11 @@ export interface TelemetrySample {
    *  fetched. NEVER sourced from get_ping (1009), which reboots the router.
    *  Stamped the same way and for the same reason as routerLatencyMs. */
   routerPingSuccessPercent: number | null;
+  /** Whether the dish's snow-melt heater was running, from get_status's
+   *  snowMeltActive — stamped the way routerLatencyMs is, because no ring
+   *  buffer replays it. True only when the reply said so: `toJson` omits a
+   *  false field, so absence is "not known to be active", never "off". */
+  snowMeltActive: boolean | null;
 }
 
 export interface OutageEvent {
@@ -303,6 +308,7 @@ export function decodeHistoryWindow(
       powerW: history.powerIn?.[ringIndex] ?? 0,
       routerLatencyMs: null,
       routerPingSuccessPercent: null,
+      snowMeltActive: null,
     });
   }
   return { samples, newestCounter };
@@ -357,10 +363,16 @@ export function decodeWifiHistoryEvents(wifiHistory: {
   return decodeEventLog((wifiHistory.eventLog?.events ?? []) as DishEventJson[]);
 }
 
-/** Readings the router reports live, which no ring buffer can replay. */
-export interface RouterReadings {
+/** Readings no ring buffer can replay, stamped onto the samples a poll appends:
+ *  the router's own ping to the PoP, and the dish's snow-melt heater. Each rides
+ *  a reply the poll already fetches — the devices are never polled for these. */
+export interface StampedReadings {
   latencyMs?: number | null;
   pingSuccessPercent?: number | null;
+  /** True when the dish's get_status said the heater was running. Absent means
+   *  the reply said nothing (proto3 JSON omits a false field), which is not
+   *  recorded as off. */
+  snowMeltActive?: boolean | null;
 }
 
 /**
@@ -536,16 +548,18 @@ export class TelemetryAccumulator {
   }
 
   /**
-   * `router` holds the latest readings taken from the router, stamped onto the
-   * samples this poll appends. The router is polled slower than the dish's 1 Hz
-   * ring, so one reading lands on the handful of samples it spans — a step-wise
-   * series, which is what a point-in-time value honestly is. A field left null
-   * stays null on those samples rather than repeating the last known value.
+   * `stamped` holds the latest readings taken alongside the history poll,
+   * stamped onto the samples this poll appends. Stamped readings come from
+   * status replies (the router's ping, the dish's snow-melt heater) rather than
+   * a replayable ring, so one reading lands on the handful of samples it spans
+   * — a step-wise series, which is what a point-in-time value honestly is. A
+   * field left null stays null on those samples rather than repeating the last
+   * known value.
    */
   ingest(
     history: DishHistoryJson,
     nowMs: number,
-    router: RouterReadings = {},
+    stamped: StampedReadings = {},
     /** Skips the decode below when a caller already has it (avoids re-unrolling
      *  the same ring buffer twice in one poll cycle). */
     precomputedWindow?: ReturnType<typeof decodeHistoryWindow>,
@@ -562,10 +576,11 @@ export class TelemetryAccumulator {
       newestSampleMs: this.samples.length ? this.samples[this.samples.length - 1].timestampMs : 0,
     });
     for (const sample of freshSamples) {
-      if (router.latencyMs != null) sample.routerLatencyMs = router.latencyMs;
-      if (router.pingSuccessPercent != null) {
-        sample.routerPingSuccessPercent = router.pingSuccessPercent;
+      if (stamped.latencyMs != null) sample.routerLatencyMs = stamped.latencyMs;
+      if (stamped.pingSuccessPercent != null) {
+        sample.routerPingSuccessPercent = stamped.pingSuccessPercent;
       }
+      if (stamped.snowMeltActive != null) sample.snowMeltActive = stamped.snowMeltActive;
     }
     this.samples.push(...freshSamples);
     this.newestCounter = window.newestCounter;

--- a/extension/lib/apiRouter.browser.test.ts
+++ b/extension/lib/apiRouter.browser.test.ts
@@ -25,6 +25,7 @@ function window(count: number, powerW: number): DishWindow {
     powerW,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   }));
   return { samples, newestCounter: count };
 }

--- a/extension/lib/apiRouter.test.ts
+++ b/extension/lib/apiRouter.test.ts
@@ -118,6 +118,7 @@ describe("routeApiRequest", () => {
       powerW,
       routerLatencyMs: null,
       routerPingSuccessPercent: null,
+      snowMeltActive: null,
     });
     await store.putSamples([sample(t - 2_000, 9), sample(t - 1_000, 10)], t);
     const reply = await routeApiRequest(store, "/api/samples?minutes=360", NOW);

--- a/extension/lib/history.browser.test.ts
+++ b/extension/lib/history.browser.test.ts
@@ -27,6 +27,7 @@ function sample(secondIntoMinute: number, powerW: number): TelemetrySample {
     powerW,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   };
 }
 

--- a/extension/lib/history.test.ts
+++ b/extension/lib/history.test.ts
@@ -21,6 +21,7 @@ function sample(secondIntoMinute: number, powerW: number): TelemetrySample {
     powerW,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   };
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useOutageNotifications } from "./hooks/useOutageNotifications";
 import { useThermalEvents } from "./hooks/useThermalEvents";
 import { useDeviceAlerts } from "./hooks/useDeviceAlerts";
 import { useOutageHistory, mergeOutages } from "./hooks/useOutageHistory";
+import { usePostmortemReports } from "./hooks/usePostmortemReports";
 import {
   notificationsOn as readNotificationsOn,
   notificationsBlockedReason as readNotificationsBlockedReason,
@@ -73,6 +74,7 @@ export default function App() {
     () => mergeOutages(telemetry.outageEvents, persistedOutages),
     [telemetry.outageEvents, persistedOutages],
   );
+  const outageReports = usePostmortemReports();
   const routerNetwork = useRouterNetwork(openPanel === "network" || openPanel === "settings");
   const routerUnreachable = useRouterUnreachable(
     routerNetwork.routerReachable,
@@ -151,6 +153,7 @@ export default function App() {
               averagePowerW={averagePowerW}
               outageEvents={outageEvents}
               thermalEvents={thermalEvents}
+              reports={outageReports}
               samples={samples}
               onOpenSatelliteView={openSkyView}
               onExpandTerminal={() => setOpenPanel("terminal")}

--- a/src/components/alerts/OutageLog.reports.test.tsx
+++ b/src/components/alerts/OutageLog.reports.test.tsx
@@ -111,3 +111,9 @@ test("unknown figures are worded as not recorded, never invented", () => {
   expect(text).not.toContain("Packet loss");
   expect(text).toContain("Snow melt: Unknown");
 });
+
+test("a dish-unreachable report with no dish cause is not mislabeled Link outage", () => {
+  const text = outageReportText(report({ source: "dishUnreachable", cause: null }));
+  expect(text).toContain("Dishylink outage report — Dish unreachable");
+  expect(text).not.toContain("— Link outage");
+});

--- a/src/components/alerts/OutageLog.reports.test.tsx
+++ b/src/components/alerts/OutageLog.reports.test.tsx
@@ -1,0 +1,113 @@
+// The post-mortem half of the outage card: ended outages list a report row, and
+// the report opens as the shareable card with the JSON one button away. The
+// report is frozen recorder output, so the card renders it verbatim — these pin
+// what a user can copy out of it.
+
+import { afterEach, expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+import { cleanup, render } from "vitest-browser-react";
+import type { OutageReport } from "@core/postmortem";
+import { OutageLog } from "./OutageLog";
+import { outageReportText } from "../../lib/outageReportText";
+
+afterEach(cleanup);
+
+const NOW = Date.now();
+
+function report(overrides: Partial<OutageReport> = {}): OutageReport {
+  return {
+    id: `system:starlinkOutage:${NOW - 180_000}`,
+    source: "starlinkOutage",
+    startMs: NOW - 180_000,
+    endMs: NOW,
+    durationMs: 180_000,
+    cause: "EVENT_REASON_OUTAGE_NO_PINGS",
+    beforeDrop: {
+      windowStartMs: NOW - 480_000,
+      windowEndMs: NOW - 180_000,
+      coverageSeconds: 300,
+      latencyAvgMs: 40.5,
+      downlinkAvgBps: 100_000_000,
+      uplinkAvgBps: 10_000_000,
+      dropRateAvg: 0.002,
+      snowMelt: "unknown",
+      source: "samples",
+    },
+    thermal: [{ alertKey: "thermalThrottle", startMs: NOW - 240_000, endMs: NOW - 120_000 }],
+    generatedAtMs: NOW + 1_000,
+    ...overrides,
+  };
+}
+
+test("a report row opens the shareable card with the frozen figures", async () => {
+  render(<OutageLog outageEvents={[]} reports={[report()]} />);
+
+  // The report row is the only button until the modal opens.
+  await page.getByRole("button", { name: /Ping Network Interruption/ }).click();
+  await expect.poll(() => document.body.textContent ?? "").toContain("Outage report");
+
+  const text = document.body.textContent ?? "";
+  // The card states the cause through the plain-English label, and the
+  // five-minutes-before figures verbatim.
+  expect(text).toContain("Ping Network Interruption");
+  expect(text).toContain("41 ms");
+  expect(text).toContain("100.0 Mbps");
+  expect(text).toContain("0.2%");
+  expect(text).toContain("Snow melt");
+  expect(text).toContain("Unknown");
+  expect(text).toContain("Thermal throttling");
+});
+
+test("Copy JSON writes the report itself, not a summary", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+  render(<OutageLog outageEvents={[]} reports={[report()]} />);
+  await page.getByRole("button", { name: /Ping Network Interruption/ }).click();
+  await page.getByRole("button", { name: "Copy JSON" }).click();
+
+  expect(writeText).toHaveBeenCalledOnce();
+  const written = JSON.parse(writeText.mock.calls[0][0] as string) as Record<string, unknown>;
+  expect(written.id).toBe(`system:starlinkOutage:${NOW - 180_000}`);
+  expect(written.beforeDrop).toMatchObject({
+    coverageSeconds: 300,
+    latencyAvgMs: 40.5,
+    snowMelt: "unknown",
+  });
+  expect(written.thermal).toEqual([
+    { alertKey: "thermalThrottle", startMs: NOW - 240_000, endMs: NOW - 120_000 },
+  ]);
+});
+
+test("the text card reads like something to paste", () => {
+  const text = outageReportText(report());
+  expect(text).toContain("Dishylink outage report — Ping Network Interruption");
+  expect(text).toContain("Latency: 41 ms");
+  expect(text).toContain("Downlink: 100.0 Mbps");
+  expect(text).toContain("Packet loss: 0.2%");
+  expect(text).toContain("Snow melt: Unknown");
+  expect(text).toContain("Thermal throttling:");
+});
+
+test("unknown figures are worded as not recorded, never invented", () => {
+  const text = outageReportText(
+    report({
+      cause: null,
+      beforeDrop: {
+        windowStartMs: NOW - 480_000,
+        windowEndMs: NOW - 180_000,
+        coverageSeconds: 0,
+        latencyAvgMs: null,
+        downlinkAvgBps: null,
+        uplinkAvgBps: null,
+        dropRateAvg: null,
+        snowMelt: "unknown",
+        source: "minute-buckets",
+      },
+    }),
+  );
+  expect(text).toContain("Dishylink outage report — Link outage");
+  expect(text).toContain("Latency: not recorded");
+  expect(text).not.toContain("Packet loss");
+  expect(text).toContain("Snow melt: Unknown");
+});

--- a/src/components/alerts/OutageLog.test.tsx
+++ b/src/components/alerts/OutageLog.test.tsx
@@ -22,7 +22,7 @@ type Setter = (events: OutageEvent[]) => void;
 function Harness({ initial, bind }: { initial: OutageEvent[]; bind: (set: Setter) => void }) {
   const [events, setEvents] = useState(initial);
   useEffect(() => bind(setEvents), [bind]);
-  return <OutageLog outageEvents={events} />;
+  return <OutageLog outageEvents={events} reports={[]} />;
 }
 
 test("an existing row keeps its DOM node when a newer event is prepended", async () => {

--- a/src/components/alerts/OutageLog.tsx
+++ b/src/components/alerts/OutageLog.tsx
@@ -1,12 +1,17 @@
-// Recent outage / event log from the dish's history buffer, newest first.
+// Recent outage / event log from the dish's history buffer, newest first, with
+// the recorder's auto-generated post-mortems for ended outages beneath it.
 // Layout mirrors the official app: time on the left, the event, then a tag/
 // duration on the right. Each cause carries a plain-English tooltip (the dish's
 // raw jargon explained) via outageEventMeta.
 
+import { useState } from "react";
 import { canonicalCause, outageEventMeta, type OutageEvent } from "@core/telemetry";
-import { formatClockTimeShort, formatEventDuration } from "../../lib/format";
+import type { OutageReport } from "@core/postmortem";
+import { formatClockTimeShort, formatDateTime, formatEventDuration } from "../../lib/format";
+import { causeLabel } from "../../lib/outageReportText";
 import { EmptyState } from "../ui/empty-state";
 import { InfoDot } from "../shared/InfoDot";
+import { OutageReportModal } from "./OutageReportModal";
 
 // Severity, not the event kind. The thermal episodes reach this list with human
 // labels and no catalogue entry (useThermalEvents), so a kind lookup returns the
@@ -19,7 +24,14 @@ const SEVERITY_COLOR_VAR: Record<OutageEvent["severity"], string> = {
   critical: "--status-critical",
 };
 
-export function OutageLog({ outageEvents }: { outageEvents: OutageEvent[] }) {
+export function OutageLog({
+  outageEvents,
+  reports,
+}: {
+  outageEvents: OutageEvent[];
+  reports: OutageReport[];
+}) {
+  const [openReport, setOpenReport] = useState<OutageReport | null>(null);
   const newestFirst = [...outageEvents].sort((a, b) => b.startMs - a.startMs);
   return (
     <div className='col-span-4 min-w-0 rounded-xl bg-card px-[18px] py-4'>
@@ -63,6 +75,39 @@ export function OutageLog({ outageEvents }: { outageEvents: OutageEvent[] }) {
           })}
         </div>
       )}
+      {reports.length > 0 && (
+        <div className='mt-3 border-t border-border pt-2.5'>
+          <div className='mb-1.5 flex items-center justify-between gap-3'>
+            <span className='text-[13px] font-semibold tracking-[0.005em] text-foreground'>
+              Outage reports
+            </span>
+            <span className='text-[12px] font-medium text-muted-foreground'>
+              {reports.length} ready
+            </span>
+          </div>
+          <div className='thin-scroll flex max-h-[150px] flex-col overflow-y-auto'>
+            {reports.map((report) => (
+              <button
+                className='grid cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-2.5 border-b border-border px-0.5 py-2 text-left text-[13px] font-medium last:border-b-0 hover:bg-[color-mix(in_srgb,var(--ink)_4%,var(--surface))]'
+                key={report.id}
+                onClick={() => setOpenReport(report)}
+                type='button'
+              >
+                <span className='font-mono text-[10.5px] whitespace-nowrap text-muted-foreground tabular-nums'>
+                  {formatDateTime(report.startMs)}
+                </span>
+                <span className='overflow-hidden text-ellipsis whitespace-nowrap text-foreground'>
+                  {causeLabel(report)}
+                </span>
+                <span className='font-mono text-[10.5px] whitespace-nowrap text-muted-foreground tabular-nums'>
+                  {formatEventDuration(report.durationMs)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      {openReport && <OutageReportModal report={openReport} onClose={() => setOpenReport(null)} />}
     </div>
   );
 }

--- a/src/components/alerts/OutageReportModal.tsx
+++ b/src/components/alerts/OutageReportModal.tsx
@@ -17,13 +17,9 @@ import {
   causeLabel,
   outageReportText,
   SNOW_MELT_LABEL,
+  SOURCE_LABEL,
   THERMAL_LABEL,
 } from "../../lib/outageReportText";
-
-const KEY_LABEL: Record<OutageReport["source"], string> = {
-  starlinkOutage: "Link outage",
-  dishUnreachable: "Dish unreachable",
-};
 
 export function OutageReportModal({
   report,
@@ -59,7 +55,7 @@ export function OutageReportModal({
           </div>
           <span className='text-[12.5px] text-muted-foreground'>
             {formatDateTime(report.startMs)} → {formatClockTimeShort(report.endMs)}
-            <span className='text-muted-foreground/70'> · {KEY_LABEL[report.source]}</span>
+            <span className='text-muted-foreground/70'> · {SOURCE_LABEL[report.source]}</span>
           </span>
         </div>
 

--- a/src/components/alerts/OutageReportModal.tsx
+++ b/src/components/alerts/OutageReportModal.tsx
@@ -1,0 +1,152 @@
+// The shareable form of an outage post-mortem: a human card rendered from the
+// recorder's frozen report, with the report JSON itself one button away. The
+// card is generated output, not live data — every figure was stamped the moment
+// the outage ended, so what is shown is exactly what gets copied.
+
+import { useState } from "react";
+import type { OutageReport } from "@core/postmortem";
+import { DetailsModal } from "../ui/details-modal";
+import { actionButton } from "../ui/action-button";
+import {
+  formatClockTimeShort,
+  formatDateTime,
+  formatEventDuration,
+  formatThroughputLabel,
+} from "../../lib/format";
+import {
+  causeLabel,
+  outageReportText,
+  SNOW_MELT_LABEL,
+  THERMAL_LABEL,
+} from "../../lib/outageReportText";
+
+const KEY_LABEL: Record<OutageReport["source"], string> = {
+  starlinkOutage: "Link outage",
+  dishUnreachable: "Dish unreachable",
+};
+
+export function OutageReportModal({
+  report,
+  onClose,
+}: {
+  report: OutageReport;
+  onClose: () => void;
+}) {
+  const [copyState, setCopyState] = useState<"idle" | "json" | "text" | "failed">("idle");
+  const { beforeDrop } = report;
+
+  const copy = async (kind: "json" | "text") => {
+    try {
+      await navigator.clipboard.writeText(
+        kind === "json" ? JSON.stringify(report, null, 2) : outageReportText(report),
+      );
+      setCopyState(kind);
+    } catch {
+      setCopyState("failed");
+    }
+    window.setTimeout(() => setCopyState("idle"), 2500);
+  };
+
+  return (
+    <DetailsModal title='Outage report' onClose={onClose} size='default'>
+      <div className='mt-2 flex flex-col gap-4'>
+        <div className='flex flex-col gap-1'>
+          <div className='flex items-baseline justify-between gap-3'>
+            <span className='text-[16px] font-semibold text-foreground'>{causeLabel(report)}</span>
+            <span className='font-mono text-[12px] whitespace-nowrap text-muted-foreground tabular-nums'>
+              {formatEventDuration(report.durationMs)}
+            </span>
+          </div>
+          <span className='text-[12.5px] text-muted-foreground'>
+            {formatDateTime(report.startMs)} → {formatClockTimeShort(report.endMs)}
+            <span className='text-muted-foreground/70'> · {KEY_LABEL[report.source]}</span>
+          </span>
+        </div>
+
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase'>
+            Five minutes before the drop
+          </span>
+          <div className='grid grid-cols-2 gap-x-4 gap-y-1 text-[13px]'>
+            <span className='text-muted-foreground'>Latency</span>
+            <span className='text-right font-mono text-foreground tabular-nums'>
+              {beforeDrop.latencyAvgMs === null
+                ? "not recorded"
+                : `${Math.round(beforeDrop.latencyAvgMs)} ms`}
+            </span>
+            <span className='text-muted-foreground'>Downlink</span>
+            <span className='text-right font-mono text-foreground tabular-nums'>
+              {beforeDrop.downlinkAvgBps === null
+                ? "not recorded"
+                : formatThroughputLabel(beforeDrop.downlinkAvgBps)}
+            </span>
+            <span className='text-muted-foreground'>Uplink</span>
+            <span className='text-right font-mono text-foreground tabular-nums'>
+              {beforeDrop.uplinkAvgBps === null
+                ? "not recorded"
+                : formatThroughputLabel(beforeDrop.uplinkAvgBps)}
+            </span>
+            {beforeDrop.dropRateAvg !== null && (
+              <>
+                <span className='text-muted-foreground'>Packet loss</span>
+                <span className='text-right font-mono text-foreground tabular-nums'>
+                  {(beforeDrop.dropRateAvg * 100).toFixed(1)}%
+                </span>
+              </>
+            )}
+            <span className='text-muted-foreground'>Snow melt</span>
+            <span className='text-right font-mono text-foreground tabular-nums'>
+              {SNOW_MELT_LABEL[beforeDrop.snowMelt]}
+            </span>
+          </div>
+          <span className='text-[11.5px] text-muted-foreground/80'>
+            {beforeDrop.coverageSeconds} s of the window recorded
+          </span>
+        </div>
+
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase'>
+            Thermal
+          </span>
+          {report.thermal.length === 0 ? (
+            <span className='text-[13px] text-foreground'>None</span>
+          ) : (
+            <div className='flex flex-col gap-0.5'>
+              {report.thermal.map((episode) => (
+                <div
+                  className='flex items-baseline justify-between gap-3 text-[13px]'
+                  key={`${episode.alertKey}:${episode.startMs}`}
+                >
+                  <span className='text-foreground'>
+                    {THERMAL_LABEL[episode.alertKey] ?? episode.alertKey}
+                  </span>
+                  <span className='font-mono text-[11.5px] whitespace-nowrap text-muted-foreground tabular-nums'>
+                    {formatClockTimeShort(episode.startMs)} →{" "}
+                    {episode.endMs === null ? "now" : formatClockTimeShort(episode.endMs)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className='flex gap-2 border-t border-border pt-3'>
+          <button className={actionButton("subtle")} onClick={() => void copy("json")}>
+            {copyState === "json"
+              ? "Copied ✓"
+              : copyState === "failed"
+                ? "Copy failed"
+                : "Copy JSON"}
+          </button>
+          <button className={actionButton("subtle")} onClick={() => void copy("text")}>
+            {copyState === "text"
+              ? "Copied ✓"
+              : copyState === "failed"
+                ? "Copy failed"
+                : "Copy text"}
+          </button>
+        </div>
+      </div>
+    </DetailsModal>
+  );
+}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { DishStatusJson, DishObstructionMapJson } from "@core/dishClient";
 import { readRouterLatencyMs, type OutageEvent, type TelemetrySample } from "@core/telemetry";
+import type { OutageReport } from "@core/postmortem";
 import type { DishConnectionState } from "../../hooks/useDishTelemetry";
 import type { LiveSparklines } from "../../hooks/useLiveReadings";
 import { StatTile, type StatTileProps as StatTileConfig } from "./StatTile";
@@ -59,6 +60,7 @@ interface DashboardViewProps {
   averagePowerW: number;
   outageEvents: OutageEvent[];
   thermalEvents: OutageEvent[];
+  reports: OutageReport[];
   samples: TelemetrySample[];
   onOpenSatelliteView: () => void;
   onExpandTerminal: () => void;
@@ -82,6 +84,7 @@ export function DashboardView({
   averagePowerW,
   outageEvents,
   thermalEvents,
+  reports,
   samples,
   onOpenSatelliteView,
   onExpandTerminal,
@@ -257,7 +260,7 @@ export function DashboardView({
         </SectionCard>
 
         {/* Outage log */}
-        <OutageLog outageEvents={[...outageEvents, ...thermalEvents]} />
+        <OutageLog outageEvents={[...outageEvents, ...thermalEvents]} reports={reports} />
 
         {/* Terminal card */}
         {status ? (

--- a/src/components/network/NetworkPanel.cloud.test.tsx
+++ b/src/components/network/NetworkPanel.cloud.test.tsx
@@ -91,6 +91,7 @@ test("given: recorded readings older than the window, should: say so rather than
     powerW: 0,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   });
 
   const renderedPanel = await render(

--- a/src/components/shared/TelemetryChart.test.tsx
+++ b/src/components/shared/TelemetryChart.test.tsx
@@ -26,6 +26,7 @@ function minuteOfSamples(): TelemetrySample[] {
     powerW: 30,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   }));
 }
 

--- a/src/hooks/useDishTelemetry.ts
+++ b/src/hooks/useDishTelemetry.ts
@@ -19,7 +19,7 @@ import {
   readRouterPingSuccessPercent,
   type TelemetrySample,
   type OutageEvent,
-  type RouterReadings,
+  type StampedReadings,
 } from "@core/telemetry";
 
 /**
@@ -142,7 +142,7 @@ export function useDishTelemetry(): DishTelemetry {
     // never be sourced from get_ping (1009), which rebooted the router at every
     // cadence it was tried at (2026-07-20). A browser tab must never be what
     // destabilises the router it is monitoring.
-    const routerReadings: RouterReadings = { latencyMs: null, pingSuccessPercent: null };
+    const routerReadings: StampedReadings = { latencyMs: null, pingSuccessPercent: null };
     const unsubscribeRouterStatus = subscribeRouterStatus(({ status, reachable }) => {
       // An unreachable router leaves the series empty rather than repeating a
       // stale reading; it is not an app error.

--- a/src/hooks/usePostmortemReports.ts
+++ b/src/hooks/usePostmortemReports.ts
@@ -1,0 +1,40 @@
+// Outage post-mortems from the historian's durable log.
+//
+// The recorder generates one self-contained summary the moment an outage
+// episode closes, and this reads them back. Like useOutageHistory: empty while
+// the historian is down, refreshed on the same slow beat — a report appears
+// within half a minute of the outage ending.
+
+import { useEffect, useMemo, useState } from "react";
+import type { OutageReport } from "@core/postmortem";
+import { apiRequest } from "../lib/apiHost";
+
+const REFRESH_MS = 30_000;
+
+export function usePostmortemReports(): OutageReport[] {
+  const [reports, setReports] = useState<OutageReport[]>([]);
+
+  useEffect(() => {
+    let disposed = false;
+    const load = async () => {
+      try {
+        const response = await apiRequest("/api/outages/reports", {
+          signal: AbortSignal.timeout(4_000),
+        });
+        if (!response.ok) return;
+        const body = (await response.json()) as { reports?: OutageReport[] };
+        if (!disposed) setReports(body.reports ?? []);
+      } catch {
+        // historian down: the dish's own events still populate the log
+      }
+    };
+    load();
+    const timerId = window.setInterval(load, REFRESH_MS);
+    return () => {
+      disposed = true;
+      window.clearInterval(timerId);
+    };
+  }, []);
+
+  return useMemo(() => reports, [reports]);
+}

--- a/src/hooks/useRouterNetwork.seed.test.ts
+++ b/src/hooks/useRouterNetwork.seed.test.ts
@@ -147,6 +147,7 @@ describe("appendClientSamples", () => {
             powerW: 0,
             routerLatencyMs: null,
             routerPingSuccessPercent: null,
+            snowMeltActive: null,
           },
         ],
       ],

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -169,6 +169,7 @@ export async function fetchPersistedClientHistory(): Promise<SeededClientHistory
         powerW: 0,
         routerLatencyMs: null,
         routerPingSuccessPercent: null,
+        snowMeltActive: null,
       });
       history.set(row.key, series);
     }
@@ -184,6 +185,7 @@ export async function fetchPersistedClientHistory(): Promise<SeededClientHistory
         powerW: 0,
         routerLatencyMs: null,
         routerPingSuccessPercent: null,
+        snowMeltActive: null,
       });
       history.set(sample.key, series);
       if (sample.atMs > newestSampleMs) newestSampleMs = sample.atMs;
@@ -231,6 +233,7 @@ export function appendClientSamples(
       powerW: 0,
       routerLatencyMs: null,
       routerPingSuccessPercent: null,
+      snowMeltActive: null,
     });
     history.set(sample.key, series);
     if (sample.atMs > newestMs) newestMs = sample.atMs;

--- a/src/lib/outageReportText.ts
+++ b/src/lib/outageReportText.ts
@@ -11,9 +11,10 @@ import {
   formatThroughputLabel,
 } from "./format";
 
+// Two-state because the report is: the dish never asserts "off" (proto3 JSON
+// omits a false snowMeltActive), so only "Active" or "Unknown" can ever occur.
 export const SNOW_MELT_LABEL: Record<OutageReport["beforeDrop"]["snowMelt"], string> = {
   active: "Active",
-  off: "Off",
   unknown: "Unknown",
 };
 
@@ -23,8 +24,16 @@ export const THERMAL_LABEL: Record<string, string> = {
   powerSupplyThermalThrottle: "Power supply throttling",
 };
 
+/** The episode name behind a report the dish's event log blames for nothing — a
+ *  dish-unreachable outage has no dish events at all (the dish wasn't
+ *  answering), so "Link outage" would misname it. */
+export const SOURCE_LABEL: Record<OutageReport["source"], string> = {
+  starlinkOutage: "Link outage",
+  dishUnreachable: "Dish unreachable",
+};
+
 export function causeLabel(report: OutageReport): string {
-  return report.cause ? outageEventMeta(report.cause).label : "Link outage";
+  return report.cause ? outageEventMeta(report.cause).label : SOURCE_LABEL[report.source];
 }
 
 /** The card as text: header, the five minutes before the drop, thermal state. */

--- a/src/lib/outageReportText.ts
+++ b/src/lib/outageReportText.ts
@@ -1,0 +1,56 @@
+// The outage post-mortem as plain text, for pasting into chat, email, a ticket…
+// Shared label maps live here too so the card and the copy can never disagree
+// about what a figure is called.
+
+import { outageEventMeta } from "@core/telemetry";
+import type { OutageReport } from "@core/postmortem";
+import {
+  formatClockTimeShort,
+  formatDateTime,
+  formatEventDuration,
+  formatThroughputLabel,
+} from "./format";
+
+export const SNOW_MELT_LABEL: Record<OutageReport["beforeDrop"]["snowMelt"], string> = {
+  active: "Active",
+  off: "Off",
+  unknown: "Unknown",
+};
+
+export const THERMAL_LABEL: Record<string, string> = {
+  thermalThrottle: "Thermal throttling",
+  thermalShutdown: "Thermal shutdown",
+  powerSupplyThermalThrottle: "Power supply throttling",
+};
+
+export function causeLabel(report: OutageReport): string {
+  return report.cause ? outageEventMeta(report.cause).label : "Link outage";
+}
+
+/** The card as text: header, the five minutes before the drop, thermal state. */
+export function outageReportText(report: OutageReport): string {
+  const { beforeDrop } = report;
+  const lines = [
+    `Dishylink outage report — ${causeLabel(report)}`,
+    `${formatDateTime(report.startMs)} → ${formatClockTimeShort(report.endMs)} · ${formatEventDuration(report.durationMs)}`,
+    "",
+    "5 minutes before the drop",
+    `Latency: ${beforeDrop.latencyAvgMs === null ? "not recorded" : `${Math.round(beforeDrop.latencyAvgMs)} ms`}`,
+    `Downlink: ${beforeDrop.downlinkAvgBps === null ? "not recorded" : formatThroughputLabel(beforeDrop.downlinkAvgBps)}`,
+    `Uplink: ${beforeDrop.uplinkAvgBps === null ? "not recorded" : formatThroughputLabel(beforeDrop.uplinkAvgBps)}`,
+    ...(beforeDrop.dropRateAvg === null
+      ? []
+      : [`Packet loss: ${(beforeDrop.dropRateAvg * 100).toFixed(1)}%`]),
+    `Snow melt: ${SNOW_MELT_LABEL[beforeDrop.snowMelt]}`,
+    `Recording: ${beforeDrop.coverageSeconds} s of the window`,
+    "",
+    "Thermal",
+    ...(report.thermal.length === 0
+      ? ["None"]
+      : report.thermal.map(
+          (episode) =>
+            `${THERMAL_LABEL[episode.alertKey] ?? episode.alertKey}: ${formatClockTimeShort(episode.startMs)} → ${episode.endMs === null ? "still running" : formatClockTimeShort(episode.endMs)}`,
+        )),
+  ];
+  return lines.join("\n");
+}

--- a/src/lib/readings.test.ts
+++ b/src/lib/readings.test.ts
@@ -20,6 +20,7 @@ function readings(endMs: number, count: number, value: number): TelemetrySample[
     powerW: value,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   }));
 }
 

--- a/src/lib/statDetails.test.ts
+++ b/src/lib/statDetails.test.ts
@@ -12,6 +12,7 @@ function sample(routerPingSuccessPercent: number | null): TelemetrySample {
     powerW: 30,
     routerLatencyMs: null,
     routerPingSuccessPercent,
+    snowMeltActive: null,
   };
 }
 
@@ -47,6 +48,7 @@ describe("coverageNote", () => {
       powerW: 30,
       routerLatencyMs: null,
       routerPingSuccessPercent: null,
+      snowMeltActive: null,
     }));
   }
 
@@ -97,6 +99,7 @@ describe("energyKWh", () => {
       powerW: watts,
       routerLatencyMs: null,
       routerPingSuccessPercent: null,
+      snowMeltActive: null,
     }));
   }
 

--- a/src/lib/telemetry.freshSamples.test.ts
+++ b/src/lib/telemetry.freshSamples.test.ts
@@ -20,6 +20,7 @@ function window(newestCounter: number, count: number, endMs: number) {
     powerW: 30,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   }));
   return { samples, newestCounter };
 }

--- a/src/lib/telemetry.retention.test.ts
+++ b/src/lib/telemetry.retention.test.ts
@@ -20,6 +20,7 @@ function readings(endMs: number, count: number): TelemetrySample[] {
     powerW: 30,
     routerLatencyMs: null,
     routerPingSuccessPercent: null,
+    snowMeltActive: null,
   }));
 }
 

--- a/src/lib/telemetry.routerLatency.test.ts
+++ b/src/lib/telemetry.routerLatency.test.ts
@@ -31,6 +31,11 @@ describe("decodeHistoryWindow", () => {
     expect(samples).toHaveLength(5);
     expect(samples.every((sample) => sample.routerLatencyMs === null)).toBe(true);
   });
+
+  it("leaves snow melt null — the ring says nothing about the heater either", () => {
+    const { samples } = decodeHistoryWindow(ring(5), Date.now());
+    expect(samples.every((sample) => sample.snowMeltActive === null)).toBe(true);
+  });
 });
 
 // Retention is a duration. Any span comfortably wider than these fixtures does,
@@ -79,6 +84,26 @@ describe("TelemetryAccumulator router latency stamping", () => {
     ]);
     expect(samples.slice(2).map((sample) => sample.routerPingSuccessPercent)).toEqual([null, null]);
     expect(samples.slice(2).map((sample) => sample.routerLatencyMs)).toEqual([19.1, 19.1]);
+  });
+});
+
+describe("TelemetryAccumulator snow melt stamping", () => {
+  it("stamps true on the samples the poll appends", () => {
+    const accumulator = new TelemetryAccumulator(RETENTION_MS);
+    const samples = accumulator.ingest(ring(3), Date.now(), { snowMeltActive: true });
+    expect(samples.map((sample) => sample.snowMeltActive)).toEqual([true, true, true]);
+  });
+
+  it("leaves samples null when get_status said nothing, rather than repeating the last reading", () => {
+    const accumulator = new TelemetryAccumulator(RETENTION_MS);
+    const nowMs = Date.now();
+    accumulator.ingest(ring(2), nowMs, { snowMeltActive: true });
+    // Next poll: two further samples, the reply carried no snowMeltActive field
+    // (proto3 JSON omits a false one, so absence is not "off" and not a repeat).
+    const samples = accumulator.ingest(ring(4), nowMs + 2000, {});
+
+    expect(samples.slice(0, 2).map((sample) => sample.snowMeltActive)).toEqual([true, true]);
+    expect(samples.slice(2).map((sample) => sample.snowMeltActive)).toEqual([null, null]);
   });
 });
 


### PR DESCRIPTION
When an outage episode clears, the recorder synthesizes a frozen report from
the recordings already on disk: the five minutes before the drop (latency,
throughput, snow melt), the dish's own cause, and any thermal state touching
the outage. 

Reports are served at `/api/outages/reports` and rendered as a
shareable card with one-click JSON/text copy. A 30-day window keeps them reachable after the 48 h events panel has rolled past.