### PR TITLE
Total every reported billing cycle behind an All stop

### DIFF
--- a/src/components/data-usage/CloudDataUsage.test.tsx
+++ b/src/components/data-usage/CloudDataUsage.test.tsx
@@ -108,4 +108,70 @@ describe("CloudDataUsage", () => {
     expect(text()).not.toContain("463");
     expect(text()).toContain("unlimited");
   });
+
+  test("offers an All stop that totals every reported cycle", async () => {
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        dataBuckets: [{ name: "Residential Data" }],
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-06-06T00:00:00+00:00",
+            endDate: "2026-07-06T00:00:00+00:00",
+            totalAmountGB: 463.49,
+            dailyData: [[1], [2]],
+          },
+          {
+            startDate: "2026-07-06T00:00:00+00:00",
+            endDate: "2026-08-06T00:00:00+00:00",
+            totalAmountGB: 304.24,
+            dailyData: [[3], [4]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    const all = await waitFor(
+      () =>
+        [...document.querySelectorAll("[data-slot='segmented-control-item']")].find(
+          (item) => item.textContent?.trim() === "All",
+        ) ?? null,
+      "All stop",
+    );
+    (all as HTMLElement).click();
+
+    // 463.49 + 304.24 = 767.73, and the per-cycle allowance line gives way to
+    // the span the total covers.
+    await waitFor(() => (text().includes("768") || text().includes("767") ? true : null), "total");
+    expect(text()).toContain("2 billing cycles");
+    expect(text()).not.toContain("Usage Limit");
+    // Cycles are named by month, not by the billing day, which is the same
+    // number on every one of them and so carries nothing per cycle.
+    expect(text()).toContain("Jul 2026");
+    expect(text()).not.toContain("Jul 6, 2026");
+  });
+
+  test("has no All stop with a single cycle — it would restate the figure on screen", async () => {
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-07-06T00:00:00+00:00",
+            endDate: "2026-08-06T00:00:00+00:00",
+            totalAmountGB: 304.24,
+            dailyData: [[3], [4]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    await waitFor(() => (text().includes("GB") ? true : null), "usage headline");
+    const labels = [...document.querySelectorAll("[data-slot='segmented-control-item']")].map(
+      (item) => item.textContent?.trim(),
+    );
+    expect(labels).not.toContain("All");
+  });
 });

--- a/src/components/data-usage/CloudDataUsage.tsx
+++ b/src/components/data-usage/CloudDataUsage.tsx
@@ -1,11 +1,17 @@
 // Starlink's own billing meter (the authoritative usage the portal shows),
 // read from the account session via /cloud/usage. Monthly cycles + daily bars,
-// laid out like the portal's Total Data Usage card. Distinct from the local
-// "Local session" tab, which is historian-recorded and honest about gaps.
+// laid out like the portal's Total Data Usage card, plus an "All" stop that
+// totals every reported cycle and charts them month by month. Distinct from the
+// local "Local session" tab, which is historian-recorded and honest about gaps.
 
 import { useMemo, useState } from "react";
 import { useCloudUsage } from "../../hooks/useCloudAccount";
-import { isUnlimited, formatAllowance, type UsageCycle } from "../../lib/starlinkCloud";
+import {
+  allTimeUsage,
+  isUnlimited,
+  formatAllowance,
+  type UsageCycle,
+} from "../../lib/starlinkCloud";
 import { formatGigabytes } from "../../lib/format";
 import { RangeBars, type RangeBarColumn } from "../shared/RangeBarChart";
 import { SegmentedControl } from "../ui/segmented-control";
@@ -15,6 +21,9 @@ import { Loading } from "../ui/loading";
 import { Explainer } from "../ui/explainer";
 import { ConnectAccount } from "../shared/ConnectAccount";
 
+/** The segmented control's value for the all-cycles view, distinct from any index. */
+const ALL_CYCLES = "all";
+
 function formatGB(gb: number): string {
   const { value, unit } = formatGigabytes(gb);
   return `${value} ${unit}`;
@@ -22,6 +31,33 @@ function formatGB(gb: number): string {
 
 function cycleMonthLabel(cycle: UsageCycle): string {
   return new Date(cycle.startDate).toLocaleDateString([], { month: "short", timeZone: "UTC" });
+}
+
+/** "Mar 2026" — how a cycle is named. The exact billing day repeats across every
+ *  cycle, so it is noise in a per-cycle label; the span is spelled out below the
+ *  chart instead. */
+function cycleMonthYearLabel(cycle: UsageCycle): string {
+  return new Date(cycle.startDate).toLocaleDateString([], {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** "Feb 4, 2026" — the year matters once the span crosses one. */
+function cycleStartLabel(cycle: UsageCycle): string {
+  return new Date(cycle.startDate).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** A cycle's billed total, defended against unvalidated upstream JSON. */
+function cycleTotalGB(cycle: UsageCycle): number {
+  const amount = cycle?.totalAmountGB;
+  return typeof amount === "number" && Number.isFinite(amount) ? amount : 0;
 }
 
 function CycleBars({ cycle }: { cycle: UsageCycle }) {
@@ -55,6 +91,35 @@ function CycleBars({ cycle }: { cycle: UsageCycle }) {
   );
 }
 
+/** One bar per billing cycle — the same chart vocabulary as CycleBars, a month
+ *  to a column instead of a day. */
+function AllCyclesBars({ cycles }: { cycles: UsageCycle[] }) {
+  const maxGB = Math.max(...cycles.map(cycleTotalGB), 1e-9);
+  const columns: RangeBarColumn[] = cycles.map((cycle, index) => {
+    const gb = cycleTotalGB(cycle);
+    return {
+      key: index,
+      label: cycleMonthLabel(cycle),
+      title: `${cycleMonthYearLabel(cycle)} · ${formatGB(gb)}`,
+      bar: (
+        <div
+          className='w-full rounded-t-[3px] bg-chart-ink opacity-80'
+          style={{ height: `${(gb / maxGB) * 100}%` }}
+        />
+      ),
+    };
+  });
+  return (
+    <RangeBars
+      columns={columns}
+      range='month'
+      labelWidthPx={24}
+      heightPx={150}
+      yAxis={{ max: maxGB, format: (v) => formatGB(v) }}
+    />
+  );
+}
+
 const NO_CYCLES: UsageCycle[] = [];
 
 export function CloudDataUsage({ active }: { active: boolean }) {
@@ -66,19 +131,26 @@ export function CloudDataUsage({ active }: { active: boolean }) {
   // identity, which would rebuild every memo keyed on it on every render.
   const cycles = data?.content?.billingCyclesAnnotated ?? NO_CYCLES;
   const plan = data?.content?.servicePlan;
-  const [selected, setSelected] = useState<number | null>(null);
+  // Either ALL_CYCLES or a cycle index as a string, matching the control's values.
+  const [selected, setSelected] = useState<string | null>(null);
 
   // Cycles arrive oldest-first (verified against the live endpoint), so the
   // newest is the last entry. Clamped so a reload that returns fewer cycles
   // can't strand the selection past the end of the list.
   const newestIndex = Math.max(cycles.length - 1, 0);
-  const selectedIndex = Math.min(selected ?? newestIndex, newestIndex);
+  const showAll = selected === ALL_CYCLES;
+  const selectedIndex =
+    selected == null || showAll ? newestIndex : Math.min(Number(selected), newestIndex);
   const cycle = cycles[selectedIndex];
 
-  const monthOptions = useMemo(
-    () => cycles.map((c, i) => ({ label: cycleMonthLabel(c), value: String(i) })),
-    [cycles],
-  );
+  const allTime = useMemo(() => allTimeUsage(cycles), [cycles]);
+
+  // "All" only earns a stop when there is more than one cycle to add up —
+  // with a single cycle it would restate the figure already on screen.
+  const monthOptions = useMemo(() => {
+    const months = cycles.map((c, i) => ({ label: cycleMonthLabel(c), value: String(i) }));
+    return months.length > 1 ? [{ label: "All", value: ALL_CYCLES }, ...months] : months;
+  }, [cycles]);
 
   if (status === "not-connected") {
     // Same framing as the account panel's connect state, so switching between the
@@ -116,48 +188,71 @@ export function CloudDataUsage({ active }: { active: boolean }) {
     <div>
       <div className='mt-3 mb-3.5'>
         <div className='text-[34px] leading-[1.05] font-bold tracking-[-0.01em]'>
-          {formatGB(cycle.totalAmountGB)}
+          {formatGB(showAll ? allTime.totalGB : cycleTotalGB(cycle))}
           <span className='ml-[6px] align-baseline text-[13px] font-medium'>
             {data?.content?.dataBuckets?.[0]?.name ?? "Data"}
           </span>
         </div>
         <div className='mt-0.5 text-[12px] font-medium text-muted-foreground'>
-          <span className='mr-1 font-semibold'>Usage Limit:</span>
-          {unlimited
-            ? `${formatAllowance(plan?.usageLimitGB)} included (unlimited)`
-            : `of ${formatAllowance(plan?.usageLimitGB)} included`}
+          {showAll ? (
+            // The allowance is a per-cycle figure, so it says nothing about a
+            // total across cycles. What the total does need stated is how much
+            // of history it covers.
+            <>
+              <span className='mr-1 font-semibold'>All time:</span>
+              {`${allTime.cycles} billing cycles`}
+            </>
+          ) : (
+            <>
+              <span className='mr-1 font-semibold'>Usage Limit:</span>
+              {unlimited
+                ? `${formatAllowance(plan?.usageLimitGB)} included (unlimited)`
+                : `of ${formatAllowance(plan?.usageLimitGB)} included`}
+            </>
+          )}
         </div>
       </div>
 
       {monthOptions.length > 1 && (
         <SegmentedControl
           options={monthOptions}
-          value={String(selectedIndex)}
-          onChange={(value) => setSelected(Number(value))}
+          value={showAll ? ALL_CYCLES : String(selectedIndex)}
+          onChange={(value) => setSelected(value)}
           label='Billing cycle month'
           className='mb-2.5'
         />
       )}
 
-      <CycleBars cycle={cycle} />
+      {showAll ? <AllCyclesBars cycles={cycles} /> : <CycleBars cycle={cycle} />}
       <div className='mt-1 text-[12px] font-medium'>
-        {new Date(cycle.startDate).toLocaleDateString([], {
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        })}{" "}
-        –{" "}
-        {new Date(cycle.endDate).toLocaleDateString([], {
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        })}{" "}
-        · billing cycle
+        {showAll ? (
+          <>
+            {allTime.from ? cycleStartLabel(cycles[0]) : "—"} – now · every reported billing cycle
+          </>
+        ) : (
+          <>
+            {new Date(cycle.startDate).toLocaleDateString([], {
+              month: "short",
+              day: "numeric",
+              timeZone: "UTC",
+            })}{" "}
+            –{" "}
+            {new Date(cycle.endDate).toLocaleDateString([], {
+              month: "short",
+              day: "numeric",
+              timeZone: "UTC",
+            })}{" "}
+            · billing cycle
+          </>
+        )}
       </div>
 
       <Explainer title='Where does this come from?'>
         This is Starlink’s own billing meter, read from your account. It’s complete and counted in
         UTC — the authoritative figure your statement uses.
+        {showAll
+          ? " “All time” adds up every cycle your account reports, which is as far back as Starlink sends — not necessarily the whole life of the service line. The newest cycle is still running, so the total grows with it."
+          : ""}
       </Explainer>
     </div>
   );

--- a/src/lib/starlinkCloud.test.ts
+++ b/src/lib/starlinkCloud.test.ts
@@ -6,8 +6,10 @@ import {
   formatAllowance,
   isUnlimited,
   dishDisplayName,
+  allTimeUsage,
   type CloudTerminal,
   type DeviceTelemetry,
+  type UsageCycle,
 } from "./starlinkCloud";
 
 const now = Date.now();
@@ -107,5 +109,64 @@ describe("dishDisplayName", () => {
     expect(dishDisplayName({ userTerminalId: "01000000-00000000-004c8bb9" } as CloudTerminal)).toBe(
       "STARLINK 4C8BB9",
     );
+  });
+});
+
+describe("allTimeUsage", () => {
+  const cycle = (startDate: string, totalAmountGB: number): UsageCycle => ({
+    startDate,
+    endDate: startDate,
+    totalAmountGB,
+    dailyData: [],
+  });
+
+  it("sums every reported cycle", () => {
+    const summary = allTimeUsage([
+      cycle("2026-03-04T00:00:00+00:00", 2495.966052108),
+      cycle("2026-04-04T00:00:00+00:00", 4136.937441903),
+      cycle("2026-05-04T00:00:00+00:00", 4333.455701169),
+    ]);
+    expect(summary.totalGB).toBeCloseTo(10966.35919518, 6);
+    expect(summary.cycles).toBe(3);
+  });
+
+  it("reports the window it covers, so the figure is not read as all of history", () => {
+    // The endpoint returns whatever span of cycles it chooses. Naming the first
+    // one is what keeps "all time" an honest label rather than a claim about
+    // every byte the account ever moved.
+    const summary = allTimeUsage([
+      cycle("2026-02-04T00:00:00+00:00", 0),
+      cycle("2026-03-04T00:00:00+00:00", 12),
+    ]);
+    expect(summary.from).toBe("2026-02-04T00:00:00+00:00");
+  });
+
+  it("counts a zero-usage activation cycle in the window but not the total", () => {
+    // The first cycle of a new service line reports 0 GB across 0 days. It is
+    // still where billing started, so it belongs in the span and the count.
+    const summary = allTimeUsage([
+      cycle("2026-02-04T00:00:00+00:00", 0),
+      cycle("2026-03-04T00:00:00+00:00", 500),
+    ]);
+    expect(summary.totalGB).toBe(500);
+    expect(summary.cycles).toBe(2);
+  });
+
+  it("is zero — never NaN — when no cycle has been reported", () => {
+    const summary = allTimeUsage([]);
+    expect(summary.totalGB).toBe(0);
+    expect(summary.cycles).toBe(0);
+    expect(summary.from).toBeNull();
+  });
+
+  it("skips a total that upstream sent as absent or non-numeric", () => {
+    // Unvalidated JSON: one bad cycle must not turn the whole figure into NaN.
+    const cycles = [
+      cycle("2026-03-04T00:00:00+00:00", 100),
+      { ...cycle("2026-04-04T00:00:00+00:00", 0), totalAmountGB: undefined },
+      { ...cycle("2026-05-04T00:00:00+00:00", 0), totalAmountGB: Number.NaN },
+      cycle("2026-06-04T00:00:00+00:00", 50),
+    ] as unknown as UsageCycle[];
+    expect(allTimeUsage(cycles).totalGB).toBe(150);
   });
 });

--- a/src/lib/starlinkCloud.ts
+++ b/src/lib/starlinkCloud.ts
@@ -331,6 +331,40 @@ export function formatAllowance(usageLimitGB: number | undefined): string {
   return `${Number.isInteger(tb) ? tb : tb.toFixed(1)} TB`;
 }
 
+export interface AllTimeUsage {
+  /** Billed total across every cycle the account reported. */
+  totalGB: number;
+  /** How many cycles that total covers. */
+  cycles: number;
+  /** Start of the earliest reported cycle; null when none were reported. */
+  from: string | null;
+}
+
+/**
+ * Every reported billing cycle added up.
+ *
+ * "All time" is the span the account actually reported, not a claim about every
+ * byte the service line ever moved: /cloud/usage returns whatever window of
+ * cycles Starlink chooses to send. So the span is returned alongside the figure
+ * and the UI is expected to show it — a bare total would read as complete
+ * history whether or not it is.
+ *
+ * `totalAmountGB` is unvalidated upstream JSON, so a cycle missing it (or
+ * carrying something non-numeric) is skipped rather than poisoning the sum with
+ * NaN. A cycle reporting a real 0 — which is what the first cycle of a new
+ * service line looks like — still counts toward the span and the cycle count.
+ */
+export function allTimeUsage(cycles: readonly UsageCycle[]): AllTimeUsage {
+  let totalGB = 0;
+  for (const cycle of cycles) {
+    const amount = cycle?.totalAmountGB;
+    if (typeof amount === "number" && Number.isFinite(amount)) totalGB += amount;
+  }
+  // Cycles arrive oldest-first (verified against the live endpoint), the same
+  // ordering CloudDataUsage relies on to find the newest.
+  return { totalGB, cycles: cycles.length, from: cycles[0]?.startDate ?? null };
+}
+
 /** Minor-unit currency amount (57000 = ₦57,000) → localized string. */
 export function formatMoney(amount: number | undefined, currency: string | undefined): string {
   if (amount == null || !currency) return "—";


### PR DESCRIPTION
## What this adds

The billing panel shows one cycle at a time, so the only way to reach a lifetime figure is to step through the month picker and add the values up by hand. This adds an **All** stop to that picker.

Selecting it:

- shows the sum of every billing cycle the account reports as the headline figure
- charts one bar per cycle instead of one per day, reusing the same `RangeBars` vocabulary the daily view already uses
- replaces the per-cycle allowance line with the span the total covers, since an allowance says nothing about a figure spanning several cycles

The stop only appears when there is more than one cycle. With a single cycle it would restate the number already on screen.

## No new polling

The total is derived entirely from data already present in the `/cloud/usage` response. No request is added against the dish, the router or the account, per the hardware rules in CONTRIBUTING.

## On calling it "all time"

`/cloud/usage` returns whatever window of cycles Starlink chooses to send, which is not guaranteed to be the whole life of the service line. A bare total would read as complete history whether or not it is, so `allTimeUsage` returns the span alongside the figure and the panel states it (`Feb 4, 2026 - now, every reported billing cycle`). The explainer says the same thing in words, and notes that the newest cycle is still running.

A cycle whose `totalAmountGB` is absent or non-numeric is skipped rather than turning the sum into `NaN`, since that response is unvalidated JSON. A cycle reporting a real `0`, which is what the first cycle of a new service line looks like, still counts toward the span and the cycle count.

## Changes

- `src/lib/starlinkCloud.ts`: new `allTimeUsage(cycles)` returning `{ totalGB, cycles, from }`
- `src/components/data-usage/CloudDataUsage.tsx`: the All stop, the all-cycles bar chart, and the swapped subtitle and footer

## Tests

Five unit tests for `allTimeUsage` covering the sum, the reported span, a zero-usage activation cycle, no cycles at all, and a non-numeric total. Two component tests covering the All stop totalling correctly and being absent with a single cycle.

```
npm test          1179 passed (103 files)
npm run typecheck clean
npm run lint      clean
npm run format    clean
```

## Verified against hardware

Running against a live Residential service line with 7 reported cycles (Feb 2026 to Aug 2026, including the in-progress one). The All total matches the sum of the individual months shown by the existing per-cycle view, and the monthly bars line up with each cycle's figure. The kit is in bypass mode, so the router half of the app was not exercised by this change and is not touched by it.