### PR TITLE
Tell an unreported billing cycle apart from a zero one

### DIFF
--- a/src/components/data-usage/CloudDataUsage.test.tsx
+++ b/src/components/data-usage/CloudDataUsage.test.tsx
@@ -152,6 +152,175 @@ describe("CloudDataUsage", () => {
     expect(text()).not.toContain("Jul 6, 2026");
   });
 
+  test("marks a cycle the account never reported instead of drawing it as zero", async () => {
+    // The opening cycle of a service line arrives as 0 GB across zero days.
+    // Drawn as a bar it would claim a month of measured silence; it is an
+    // absence, and the total must not be dated from it either.
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        dataBuckets: [{ name: "Residential Data" }],
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-02-06T00:00:00+00:00",
+            endDate: "2026-03-06T00:00:00+00:00",
+            totalAmountGB: 0,
+            dailyData: [],
+          },
+          {
+            startDate: "2026-03-06T00:00:00+00:00",
+            endDate: "2026-04-06T00:00:00+00:00",
+            totalAmountGB: 463.49,
+            dailyData: [[1], [2]],
+          },
+          {
+            startDate: "2026-04-06T00:00:00+00:00",
+            endDate: "2026-05-06T00:00:00+00:00",
+            totalAmountGB: 304.24,
+            dailyData: [[3], [4]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    const all = await waitFor(
+      () =>
+        [...document.querySelectorAll("[data-slot='segmented-control-item']")].find(
+          (item) => item.textContent?.trim() === "All",
+        ) ?? null,
+      "All stop",
+    );
+    (all as HTMLElement).click();
+
+    await waitFor(
+      () => document.querySelector("[data-slot='cycle-not-reported']"),
+      "not-reported wash",
+    );
+    expect(text()).toContain("Feb 2026 · not reported");
+    expect(text()).not.toContain("Feb 2026 · 0 GB");
+    // Two reported cycles out of the three listed, dated from the first with data.
+    expect(text()).toContain("2 billing cycles");
+    expect(text()).toContain("Mar 6, 2026");
+    expect(text()).not.toContain("Feb 6, 2026");
+  });
+
+  test("says so on an unreported cycle's own tab instead of showing a bare 0 GB", async () => {
+    // Selected on its own, an unreported cycle has no columns to draw, so the
+    // chart area collapses to nothing and the headline claims a measured zero.
+    // Both need to say that nothing was reported.
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        dataBuckets: [{ name: "Residential Data" }],
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-02-06T00:00:00+00:00",
+            endDate: "2026-03-06T00:00:00+00:00",
+            totalAmountGB: 0,
+            dailyData: [],
+          },
+          {
+            startDate: "2026-03-06T00:00:00+00:00",
+            endDate: "2026-04-06T00:00:00+00:00",
+            totalAmountGB: 463.49,
+            dailyData: [[1], [2]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    const feb = await waitFor(
+      () =>
+        [...document.querySelectorAll("[data-slot='segmented-control-item']")].find(
+          (item) => item.textContent?.trim() === "Feb",
+        ) ?? null,
+      "Feb stop",
+    );
+    (feb as HTMLElement).click();
+
+    await waitFor(
+      () => document.querySelector("[data-slot='empty-state']"),
+      "not-reported empty state",
+    );
+    expect(text()).toContain("Not reported");
+    expect(text()).toContain("No daily usage was reported for this billing cycle");
+    // The allowance line would imply a cycle that was measured against it.
+    expect(text()).not.toContain("Usage Limit");
+    // The billing dates are still true and stay on screen.
+    expect(text()).toContain("billing cycle");
+  });
+
+  test("draws the chart normally on a reported cycle's own tab", async () => {
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        dataBuckets: [{ name: "Residential Data" }],
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-02-06T00:00:00+00:00",
+            endDate: "2026-03-06T00:00:00+00:00",
+            totalAmountGB: 0,
+            dailyData: [],
+          },
+          {
+            startDate: "2026-03-06T00:00:00+00:00",
+            endDate: "2026-04-06T00:00:00+00:00",
+            totalAmountGB: 463.49,
+            dailyData: [[1], [2]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    // Defaults to the newest cycle, which is the reported one.
+    await waitFor(() => (text().includes("463") ? true : null), "usage headline");
+    expect(document.querySelector("[data-slot='empty-state']")).toBeNull();
+    expect(text()).toContain("Usage Limit");
+    expect(text()).not.toContain("Not reported");
+  });
+
+  test("keeps a genuine zero cycle as a bar, since its days were reported", async () => {
+    // Days present and all zero is a dish that was off. That is a reading, and
+    // washing it out would hide a real month.
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-02-06T00:00:00+00:00",
+            endDate: "2026-03-06T00:00:00+00:00",
+            totalAmountGB: 0,
+            dailyData: [[0], [0]],
+          },
+          {
+            startDate: "2026-03-06T00:00:00+00:00",
+            endDate: "2026-04-06T00:00:00+00:00",
+            totalAmountGB: 463.49,
+            dailyData: [[1], [2]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    const all = await waitFor(
+      () =>
+        [...document.querySelectorAll("[data-slot='segmented-control-item']")].find(
+          (item) => item.textContent?.trim() === "All",
+        ) ?? null,
+      "All stop",
+    );
+    (all as HTMLElement).click();
+
+    await waitFor(() => (text().includes("billing cycles") ? true : null), "all view");
+    expect(document.querySelector("[data-slot='cycle-not-reported']")).toBeNull();
+    expect(text()).toContain("Feb 2026 · 0 GB");
+    expect(text()).toContain("2 billing cycles");
+  });
+
   test("has no All stop with a single cycle — it would restate the figure on screen", async () => {
     stubUsage({
       content: {

--- a/src/components/data-usage/CloudDataUsage.test.tsx
+++ b/src/components/data-usage/CloudDataUsage.test.tsx
@@ -108,4 +108,70 @@ describe("CloudDataUsage", () => {
     expect(text()).not.toContain("463");
     expect(text()).toContain("unlimited");
   });
+
+  test("offers an All stop that totals every reported cycle", async () => {
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        dataBuckets: [{ name: "Residential Data" }],
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-06-06T00:00:00+00:00",
+            endDate: "2026-07-06T00:00:00+00:00",
+            totalAmountGB: 463.49,
+            dailyData: [[1], [2]],
+          },
+          {
+            startDate: "2026-07-06T00:00:00+00:00",
+            endDate: "2026-08-06T00:00:00+00:00",
+            totalAmountGB: 304.24,
+            dailyData: [[3], [4]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    const all = await waitFor(
+      () =>
+        [...document.querySelectorAll("[data-slot='segmented-control-item']")].find(
+          (item) => item.textContent?.trim() === "All",
+        ) ?? null,
+      "All stop",
+    );
+    (all as HTMLElement).click();
+
+    // 463.49 + 304.24 = 767.73, and the per-cycle allowance line gives way to
+    // the span the total covers.
+    await waitFor(() => (text().includes("768") || text().includes("767") ? true : null), "total");
+    expect(text()).toContain("2 billing cycles");
+    expect(text()).not.toContain("Usage Limit");
+    // Cycles are named by month, not by the billing day, which is the same
+    // number on every one of them and so carries nothing per cycle.
+    expect(text()).toContain("Jul 2026");
+    expect(text()).not.toContain("Jul 6, 2026");
+  });
+
+  test("has no All stop with a single cycle — it would restate the figure on screen", async () => {
+    stubUsage({
+      content: {
+        servicePlan: { usageLimitGB: 100_000 },
+        billingCyclesAnnotated: [
+          {
+            startDate: "2026-07-06T00:00:00+00:00",
+            endDate: "2026-08-06T00:00:00+00:00",
+            totalAmountGB: 304.24,
+            dailyData: [[3], [4]],
+          },
+        ],
+      },
+    });
+    render(<CloudDataUsage active />);
+
+    await waitFor(() => (text().includes("GB") ? true : null), "usage headline");
+    const labels = [...document.querySelectorAll("[data-slot='segmented-control-item']")].map(
+      (item) => item.textContent?.trim(),
+    );
+    expect(labels).not.toContain("All");
+  });
 });

--- a/src/components/data-usage/CloudDataUsage.tsx
+++ b/src/components/data-usage/CloudDataUsage.tsx
@@ -1,11 +1,17 @@
 // Starlink's own billing meter (the authoritative usage the portal shows),
 // read from the account session via /cloud/usage. Monthly cycles + daily bars,
-// laid out like the portal's Total Data Usage card. Distinct from the local
-// "Local session" tab, which is historian-recorded and honest about gaps.
+// laid out like the portal's Total Data Usage card, plus an "All" stop that
+// totals every reported cycle and charts them month by month. Distinct from the
+// local "Local session" tab, which is historian-recorded and honest about gaps.
 
 import { useMemo, useState } from "react";
 import { useCloudUsage } from "../../hooks/useCloudAccount";
-import { isUnlimited, formatAllowance, type UsageCycle } from "../../lib/starlinkCloud";
+import {
+  allTimeUsage,
+  isUnlimited,
+  formatAllowance,
+  type UsageCycle,
+} from "../../lib/starlinkCloud";
 import { formatGigabytes } from "../../lib/format";
 import { RangeBars, type RangeBarColumn } from "../shared/RangeBarChart";
 import { SegmentedControl } from "../ui/segmented-control";
@@ -15,6 +21,9 @@ import { Loading } from "../ui/loading";
 import { Explainer } from "../ui/explainer";
 import { ConnectAccount } from "../shared/ConnectAccount";
 
+/** The segmented control's value for the all-cycles view, distinct from any index. */
+const ALL_CYCLES = "all";
+
 function formatGB(gb: number): string {
   const { value, unit } = formatGigabytes(gb);
   return `${value} ${unit}`;
@@ -22,6 +31,33 @@ function formatGB(gb: number): string {
 
 function cycleMonthLabel(cycle: UsageCycle): string {
   return new Date(cycle.startDate).toLocaleDateString([], { month: "short", timeZone: "UTC" });
+}
+
+/** "Mar 2026" — how a cycle is named. The exact billing day repeats across every
+ *  cycle, so it is noise in a per-cycle label; the span is spelled out below the
+ *  chart instead. */
+function cycleMonthYearLabel(cycle: UsageCycle): string {
+  return new Date(cycle.startDate).toLocaleDateString([], {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** "Feb 4, 2026" — the year matters once the span crosses one. */
+function cycleStartLabel(cycle: UsageCycle): string {
+  return new Date(cycle.startDate).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** A cycle's billed total, defended against unvalidated upstream JSON. */
+function cycleTotalGB(cycle: UsageCycle): number {
+  const amount = cycle?.totalAmountGB;
+  return typeof amount === "number" && Number.isFinite(amount) ? amount : 0;
 }
 
 function CycleBars({ cycle }: { cycle: UsageCycle }) {
@@ -55,6 +91,35 @@ function CycleBars({ cycle }: { cycle: UsageCycle }) {
   );
 }
 
+/** One bar per billing cycle — the same chart vocabulary as CycleBars, a month
+ *  to a column instead of a day. */
+function AllCyclesBars({ cycles }: { cycles: UsageCycle[] }) {
+  const maxGB = Math.max(...cycles.map(cycleTotalGB), 1e-9);
+  const columns: RangeBarColumn[] = cycles.map((cycle, index) => {
+    const gb = cycleTotalGB(cycle);
+    return {
+      key: index,
+      label: cycleMonthLabel(cycle),
+      title: `${cycleMonthYearLabel(cycle)} · ${formatGB(gb)}`,
+      bar: (
+        <div
+          className='w-full rounded-t-[3px] bg-chart-ink opacity-80'
+          style={{ height: `${(gb / maxGB) * 100}%` }}
+        />
+      ),
+    };
+  });
+  return (
+    <RangeBars
+      columns={columns}
+      range='month'
+      labelWidthPx={24}
+      heightPx={150}
+      yAxis={{ max: maxGB, format: (v) => formatGB(v) }}
+    />
+  );
+}
+
 const NO_CYCLES: UsageCycle[] = [];
 
 export function CloudDataUsage({ active }: { active: boolean }) {
@@ -66,19 +131,26 @@ export function CloudDataUsage({ active }: { active: boolean }) {
   // identity, which would rebuild every memo keyed on it on every render.
   const cycles = data?.content?.billingCyclesAnnotated ?? NO_CYCLES;
   const plan = data?.content?.servicePlan;
-  const [selected, setSelected] = useState<number | null>(null);
+  // Either ALL_CYCLES or a cycle index as a string, matching the control's values.
+  const [selected, setSelected] = useState<string | null>(null);
 
   // Cycles arrive oldest-first (verified against the live endpoint), so the
   // newest is the last entry. Clamped so a reload that returns fewer cycles
   // can't strand the selection past the end of the list.
   const newestIndex = Math.max(cycles.length - 1, 0);
-  const selectedIndex = Math.min(selected ?? newestIndex, newestIndex);
+  const showAll = selected === ALL_CYCLES;
+  const selectedIndex =
+    selected == null || showAll ? newestIndex : Math.min(Number(selected), newestIndex);
   const cycle = cycles[selectedIndex];
 
-  const monthOptions = useMemo(
-    () => cycles.map((c, i) => ({ label: cycleMonthLabel(c), value: String(i) })),
-    [cycles],
-  );
+  const allTime = useMemo(() => allTimeUsage(cycles), [cycles]);
+
+  // "All" only earns a stop when there is more than one cycle to add up —
+  // with a single cycle it would restate the figure already on screen.
+  const monthOptions = useMemo(() => {
+    const months = cycles.map((c, i) => ({ label: cycleMonthLabel(c), value: String(i) }));
+    return months.length > 1 ? [{ label: "All", value: ALL_CYCLES }, ...months] : months;
+  }, [cycles]);
 
   if (status === "not-connected") {
     // Same framing as the account panel's connect state, so switching between the
@@ -116,48 +188,71 @@ export function CloudDataUsage({ active }: { active: boolean }) {
     <div>
       <div className='mt-3 mb-3.5'>
         <div className='text-[34px] leading-[1.05] font-bold tracking-[-0.01em]'>
-          {formatGB(cycle.totalAmountGB)}
+          {formatGB(showAll ? allTime.totalGB : cycleTotalGB(cycle))}
           <span className='ml-[6px] align-baseline text-[13px] font-medium'>
             {data?.content?.dataBuckets?.[0]?.name ?? "Data"}
           </span>
         </div>
         <div className='mt-0.5 text-[12px] font-medium text-muted-foreground'>
-          <span className='mr-1 font-semibold'>Usage Limit:</span>
-          {unlimited
-            ? `${formatAllowance(plan?.usageLimitGB)} included (unlimited)`
-            : `of ${formatAllowance(plan?.usageLimitGB)} included`}
+          {showAll ? (
+            // The allowance is a per-cycle figure, so it says nothing about a
+            // total across cycles. What the total does need stated is how much
+            // of history it covers.
+            <>
+              <span className='mr-1 font-semibold'>All time:</span>
+              {`${allTime.cycles} billing cycles`}
+            </>
+          ) : (
+            <>
+              <span className='mr-1 font-semibold'>Usage Limit:</span>
+              {unlimited
+                ? `${formatAllowance(plan?.usageLimitGB)} included (unlimited)`
+                : `of ${formatAllowance(plan?.usageLimitGB)} included`}
+            </>
+          )}
         </div>
       </div>
 
       {monthOptions.length > 1 && (
         <SegmentedControl
           options={monthOptions}
-          value={String(selectedIndex)}
-          onChange={(value) => setSelected(Number(value))}
+          value={showAll ? ALL_CYCLES : String(selectedIndex)}
+          onChange={(value) => setSelected(value)}
           label='Billing cycle month'
           className='mb-2.5'
         />
       )}
 
-      <CycleBars cycle={cycle} />
+      {showAll ? <AllCyclesBars cycles={cycles} /> : <CycleBars cycle={cycle} />}
       <div className='mt-1 text-[12px] font-medium'>
-        {new Date(cycle.startDate).toLocaleDateString([], {
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        })}{" "}
-        –{" "}
-        {new Date(cycle.endDate).toLocaleDateString([], {
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        })}{" "}
-        · billing cycle
+        {showAll ? (
+          <>
+            {allTime.from ? cycleStartLabel(cycles[0]) : "—"} – now · every reported billing cycle
+          </>
+        ) : (
+          <>
+            {new Date(cycle.startDate).toLocaleDateString([], {
+              month: "short",
+              day: "numeric",
+              timeZone: "UTC",
+            })}{" "}
+            –{" "}
+            {new Date(cycle.endDate).toLocaleDateString([], {
+              month: "short",
+              day: "numeric",
+              timeZone: "UTC",
+            })}{" "}
+            · billing cycle
+          </>
+        )}
       </div>
 
       <Explainer title='Where does this come from?'>
         This is Starlink’s own billing meter, read from your account. It’s complete and counted in
         UTC — the authoritative figure your statement uses.
+        {showAll
+          ? " “All time” adds up every cycle your account reports, which is as far back as Starlink sends — not necessarily the whole life of the service line. The newest cycle is still running, so the total grows with it."
+          : ""}
       </Explainer>
     </div>
   );

--- a/src/components/data-usage/CloudDataUsage.tsx
+++ b/src/components/data-usage/CloudDataUsage.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import { useCloudUsage } from "../../hooks/useCloudAccount";
 import {
   allTimeUsage,
+  isCycleReported,
   isUnlimited,
   formatAllowance,
   type UsageCycle,
@@ -45,8 +46,8 @@ function cycleMonthYearLabel(cycle: UsageCycle): string {
 }
 
 /** "Feb 4, 2026" — the year matters once the span crosses one. */
-function cycleStartLabel(cycle: UsageCycle): string {
-  return new Date(cycle.startDate).toLocaleDateString([], {
+function startLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString([], {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -96,15 +97,25 @@ function CycleBars({ cycle }: { cycle: UsageCycle }) {
 function AllCyclesBars({ cycles }: { cycles: UsageCycle[] }) {
   const maxGB = Math.max(...cycles.map(cycleTotalGB), 1e-9);
   const columns: RangeBarColumn[] = cycles.map((cycle, index) => {
+    const reported = isCycleReported(cycle);
     const gb = cycleTotalGB(cycle);
+    const when = cycleMonthYearLabel(cycle);
     return {
       key: index,
       label: cycleMonthLabel(cycle),
-      title: `${cycleMonthYearLabel(cycle)} · ${formatGB(gb)}`,
-      bar: (
+      title: reported ? `${when} · ${formatGB(gb)}` : `${when} · not reported`,
+      bar: reported ? (
         <div
           className='w-full rounded-t-[3px] bg-chart-ink opacity-80'
           style={{ height: `${(gb / maxGB) * 100}%` }}
+        />
+      ) : (
+        // An empty slot, not a zero one: mark the hole rather than draw a bar
+        // claiming no traffic passed. The same treatment the local usage chart
+        // gives a stretch the historian did not cover.
+        <div
+          data-slot='cycle-not-reported'
+          style={{ height: "100%", width: "100%", background: "var(--ink-muted)", opacity: 0.06 }}
         />
       ),
     };
@@ -183,18 +194,29 @@ export function CloudDataUsage({ active }: { active: boolean }) {
   }
 
   const unlimited = isUnlimited(plan);
+  // A single cycle the account reported nothing for. In the All view the same
+  // cycle is one washed column among many, so this only applies on its own tab.
+  const missingCycle = !showAll && !isCycleReported(cycle);
 
   return (
     <div>
       <div className='mt-3 mb-3.5'>
         <div className='text-[34px] leading-[1.05] font-bold tracking-[-0.01em]'>
-          {formatGB(showAll ? allTime.totalGB : cycleTotalGB(cycle))}
-          <span className='ml-[6px] align-baseline text-[13px] font-medium'>
-            {data?.content?.dataBuckets?.[0]?.name ?? "Data"}
-          </span>
+          {/* No figure rather than a figure of zero: nothing measured this
+              cycle, so there is nothing to state. */}
+          {missingCycle
+            ? "Not reported"
+            : formatGB(showAll ? allTime.totalGB : cycleTotalGB(cycle))}
+          {!missingCycle && (
+            <span className='ml-[6px] align-baseline text-[13px] font-medium'>
+              {data?.content?.dataBuckets?.[0]?.name ?? "Data"}
+            </span>
+          )}
         </div>
         <div className='mt-0.5 text-[12px] font-medium text-muted-foreground'>
-          {showAll ? (
+          {missingCycle ? (
+            "Starlink sent no usage for this cycle"
+          ) : showAll ? (
             // The allowance is a per-cycle figure, so it says nothing about a
             // total across cycles. What the total does need stated is how much
             // of history it covers.
@@ -223,12 +245,20 @@ export function CloudDataUsage({ active }: { active: boolean }) {
         />
       )}
 
-      {showAll ? <AllCyclesBars cycles={cycles} /> : <CycleBars cycle={cycle} />}
+      {showAll ? (
+        <AllCyclesBars cycles={cycles} />
+      ) : missingCycle ? (
+        // RangeBars draws nothing without columns, which leaves a hole that
+        // reads as a broken chart rather than as an absence. Say which it is.
+        <EmptyState className='py-14'>
+          No daily usage was reported for this billing cycle.
+        </EmptyState>
+      ) : (
+        <CycleBars cycle={cycle} />
+      )}
       <div className='mt-1 text-[12px] font-medium'>
         {showAll ? (
-          <>
-            {allTime.from ? cycleStartLabel(cycles[0]) : "—"} – now · every reported billing cycle
-          </>
+          <>{allTime.from ? startLabel(allTime.from) : "—"} – now · every reported billing cycle</>
         ) : (
           <>
             {new Date(cycle.startDate).toLocaleDateString([], {
@@ -252,6 +282,9 @@ export function CloudDataUsage({ active }: { active: boolean }) {
         UTC — the authoritative figure your statement uses.
         {showAll
           ? " “All time” adds up every cycle your account reports, which is as far back as Starlink sends — not necessarily the whole life of the service line. The newest cycle is still running, so the total grows with it."
+          : ""}
+        {missingCycle
+          ? " Your account listed this cycle but sent no daily figures for it, so there is nothing to show rather than a measured zero."
           : ""}
       </Explainer>
     </div>

--- a/src/lib/starlinkCloud.test.ts
+++ b/src/lib/starlinkCloud.test.ts
@@ -6,8 +6,10 @@ import {
   formatAllowance,
   isUnlimited,
   dishDisplayName,
+  allTimeUsage,
   type CloudTerminal,
   type DeviceTelemetry,
+  type UsageCycle,
 } from "./starlinkCloud";
 
 const now = Date.now();
@@ -107,5 +109,64 @@ describe("dishDisplayName", () => {
     expect(dishDisplayName({ userTerminalId: "01000000-00000000-004c8bb9" } as CloudTerminal)).toBe(
       "STARLINK 4C8BB9",
     );
+  });
+});
+
+describe("allTimeUsage", () => {
+  const cycle = (startDate: string, totalAmountGB: number): UsageCycle => ({
+    startDate,
+    endDate: startDate,
+    totalAmountGB,
+    dailyData: [],
+  });
+
+  it("sums every reported cycle", () => {
+    const summary = allTimeUsage([
+      cycle("2026-03-04T00:00:00+00:00", 2495.966052108),
+      cycle("2026-04-04T00:00:00+00:00", 4136.937441903),
+      cycle("2026-05-04T00:00:00+00:00", 4333.455701169),
+    ]);
+    expect(summary.totalGB).toBeCloseTo(10966.35919518, 6);
+    expect(summary.cycles).toBe(3);
+  });
+
+  it("reports the window it covers, so the figure is not read as all of history", () => {
+    // The endpoint returns whatever span of cycles it chooses. Naming the first
+    // one is what keeps "all time" an honest label rather than a claim about
+    // every byte the account ever moved.
+    const summary = allTimeUsage([
+      cycle("2026-02-04T00:00:00+00:00", 0),
+      cycle("2026-03-04T00:00:00+00:00", 12),
+    ]);
+    expect(summary.from).toBe("2026-02-04T00:00:00+00:00");
+  });
+
+  it("counts a zero-usage activation cycle in the window but not the total", () => {
+    // The first cycle of a new service line reports 0 GB across 0 days. It is
+    // still where billing started, so it belongs in the span and the count.
+    const summary = allTimeUsage([
+      cycle("2026-02-04T00:00:00+00:00", 0),
+      cycle("2026-03-04T00:00:00+00:00", 500),
+    ]);
+    expect(summary.totalGB).toBe(500);
+    expect(summary.cycles).toBe(2);
+  });
+
+  it("is zero — never NaN — when no cycle has been reported", () => {
+    const summary = allTimeUsage([]);
+    expect(summary.totalGB).toBe(0);
+    expect(summary.cycles).toBe(0);
+    expect(summary.from).toBeNull();
+  });
+
+  it("skips a total that upstream sent as absent or non-numeric", () => {
+    // Unvalidated JSON: one bad cycle must not turn the whole figure into NaN.
+    const cycles = [
+      cycle("2026-03-04T00:00:00+00:00", 100),
+      { ...cycle("2026-04-04T00:00:00+00:00", 0), totalAmountGB: undefined },
+      { ...cycle("2026-05-04T00:00:00+00:00", 0), totalAmountGB: Number.NaN },
+      cycle("2026-06-04T00:00:00+00:00", 50),
+    ] as unknown as UsageCycle[];
+    expect(allTimeUsage(cycles).totalGB).toBe(150);
   });
 });

--- a/src/lib/starlinkCloud.test.ts
+++ b/src/lib/starlinkCloud.test.ts
@@ -7,6 +7,7 @@ import {
   isUnlimited,
   dishDisplayName,
   allTimeUsage,
+  isCycleReported,
   type CloudTerminal,
   type DeviceTelemetry,
   type UsageCycle,
@@ -112,11 +113,52 @@ describe("dishDisplayName", () => {
   });
 });
 
+describe("isCycleReported", () => {
+  it("is false for a cycle carrying no days at all", () => {
+    // What the feed sends for a cycle it has nothing for: 0 GB across 0 days.
+    // That is an absence, not a measurement of zero.
+    expect(
+      isCycleReported({
+        startDate: "2026-02-04T00:00:00+00:00",
+        endDate: "2026-03-04T00:00:00+00:00",
+        totalAmountGB: 0,
+        dailyData: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for a cycle whose days really do add up to zero", () => {
+    // A dish that was off all cycle genuinely used nothing. The days are there,
+    // so the zero is a reading and must not be washed out as missing.
+    expect(
+      isCycleReported({
+        startDate: "2026-02-04T00:00:00+00:00",
+        endDate: "2026-03-04T00:00:00+00:00",
+        totalAmountGB: 0,
+        dailyData: [[0], [0], [0]],
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when dailyData is missing entirely", () => {
+    expect(isCycleReported({ dailyData: undefined } as unknown as UsageCycle)).toBe(false);
+  });
+});
+
 describe("allTimeUsage", () => {
-  const cycle = (startDate: string, totalAmountGB: number): UsageCycle => ({
+  /** A reported cycle: `days` of daily figures behind the total. */
+  const cycle = (startDate: string, totalAmountGB: number, days = 1): UsageCycle => ({
     startDate,
     endDate: startDate,
     totalAmountGB,
+    dailyData: Array.from({ length: days }, () => [0]),
+  });
+
+  /** A cycle the feed sent nothing for. */
+  const unreported = (startDate: string): UsageCycle => ({
+    startDate,
+    endDate: startDate,
+    totalAmountGB: 0,
     dailyData: [],
   });
 
@@ -135,27 +177,50 @@ describe("allTimeUsage", () => {
     // one is what keeps "all time" an honest label rather than a claim about
     // every byte the account ever moved.
     const summary = allTimeUsage([
-      cycle("2026-02-04T00:00:00+00:00", 0),
+      cycle("2026-02-04T00:00:00+00:00", 3),
       cycle("2026-03-04T00:00:00+00:00", 12),
     ]);
     expect(summary.from).toBe("2026-02-04T00:00:00+00:00");
   });
 
-  it("counts a zero-usage activation cycle in the window but not the total", () => {
-    // The first cycle of a new service line reports 0 GB across 0 days. It is
-    // still where billing started, so it belongs in the span and the count.
+  it("starts the span at the first cycle with data, not the first one listed", () => {
+    // A service line whose opening cycle was never reported has no usage behind
+    // that month. Dating the total from it would claim coverage that does not
+    // exist.
     const summary = allTimeUsage([
-      cycle("2026-02-04T00:00:00+00:00", 0),
+      unreported("2026-02-04T00:00:00+00:00"),
       cycle("2026-03-04T00:00:00+00:00", 500),
     ]);
-    expect(summary.totalGB).toBe(500);
+    expect(summary.from).toBe("2026-03-04T00:00:00+00:00");
+  });
+
+  it("counts only the cycles that were reported", () => {
+    const summary = allTimeUsage([
+      unreported("2026-02-04T00:00:00+00:00"),
+      cycle("2026-03-04T00:00:00+00:00", 500),
+      cycle("2026-04-04T00:00:00+00:00", 250),
+    ]);
+    expect(summary.totalGB).toBe(750);
     expect(summary.cycles).toBe(2);
+    expect(summary.unreported).toBe(1);
+  });
+
+  it("keeps a genuine zero in the count and the span", () => {
+    // Days present, all zero: the dish was off, and that is a real reading.
+    const summary = allTimeUsage([
+      cycle("2026-02-04T00:00:00+00:00", 0, 28),
+      cycle("2026-03-04T00:00:00+00:00", 500),
+    ]);
+    expect(summary.cycles).toBe(2);
+    expect(summary.unreported).toBe(0);
+    expect(summary.from).toBe("2026-02-04T00:00:00+00:00");
   });
 
   it("is zero — never NaN — when no cycle has been reported", () => {
     const summary = allTimeUsage([]);
     expect(summary.totalGB).toBe(0);
     expect(summary.cycles).toBe(0);
+    expect(summary.unreported).toBe(0);
     expect(summary.from).toBeNull();
   });
 

--- a/src/lib/starlinkCloud.ts
+++ b/src/lib/starlinkCloud.ts
@@ -331,6 +331,40 @@ export function formatAllowance(usageLimitGB: number | undefined): string {
   return `${Number.isInteger(tb) ? tb : tb.toFixed(1)} TB`;
 }
 
+export interface AllTimeUsage {
+  /** Billed total across every cycle the account reported. */
+  totalGB: number;
+  /** How many cycles that total covers. */
+  cycles: number;
+  /** Start of the earliest reported cycle; null when none were reported. */
+  from: string | null;
+}
+
+/**
+ * Every reported billing cycle added up.
+ *
+ * "All time" is the span the account actually reported, not a claim about every
+ * byte the service line ever moved: /cloud/usage returns whatever window of
+ * cycles Starlink chooses to send. So the span is returned alongside the figure
+ * and the UI is expected to show it — a bare total would read as complete
+ * history whether or not it is.
+ *
+ * `totalAmountGB` is unvalidated upstream JSON, so a cycle missing it (or
+ * carrying something non-numeric) is skipped rather than poisoning the sum with
+ * NaN. A cycle reporting a real 0 — which is what the first cycle of a new
+ * service line looks like — still counts toward the span and the cycle count.
+ */
+export function allTimeUsage(cycles: readonly UsageCycle[]): AllTimeUsage {
+  let totalGB = 0;
+  for (const cycle of cycles) {
+    const amount = cycle?.totalAmountGB;
+    if (typeof amount === "number" && Number.isFinite(amount)) totalGB += amount;
+  }
+  // Cycles arrive oldest-first (verified against the live endpoint), the same
+  // ordering CloudDataUsage relies on to find the newest.
+  return { totalGB, cycles: cycles.length, from: cycles[0]?.startDate ?? null };
+}
+
 /** Minor-unit currency amount (57000 = ₦57,000) → localized string. */
 export function formatMoney(amount: number | undefined, currency: string | undefined): string {
   if (amount == null || !currency) return "—";

--- a/src/lib/starlinkCloud.ts
+++ b/src/lib/starlinkCloud.ts
@@ -331,11 +331,26 @@ export function formatAllowance(usageLimitGB: number | undefined): string {
   return `${Number.isInteger(tb) ? tb : tb.toFixed(1)} TB`;
 }
 
+/**
+ * Whether the feed actually reported this cycle.
+ *
+ * A cycle the account has nothing for arrives as 0 GB across zero days, which is
+ * indistinguishable from real zero usage if you only read the total. The daily
+ * figures are what separates them: days present and adding to zero is a dish
+ * that was off, which is a reading; no days at all is an absence, and must not
+ * be drawn or counted as if it were a measurement of nothing.
+ */
+export function isCycleReported(cycle: UsageCycle): boolean {
+  return Array.isArray(cycle?.dailyData) && cycle.dailyData.length > 0;
+}
+
 export interface AllTimeUsage {
   /** Billed total across every cycle the account reported. */
   totalGB: number;
-  /** How many cycles that total covers. */
+  /** How many cycles that total covers. Unreported cycles are not among them. */
   cycles: number;
+  /** How many cycles the feed listed but reported nothing for. */
+  unreported: number;
   /** Start of the earliest reported cycle; null when none were reported. */
   from: string | null;
 }
@@ -349,20 +364,30 @@ export interface AllTimeUsage {
  * and the UI is expected to show it — a bare total would read as complete
  * history whether or not it is.
  *
+ * The span starts at the first cycle with data rather than the first one listed,
+ * for the same reason: a service line whose opening cycle was never reported has
+ * no usage behind that month, and dating the total from it would claim coverage
+ * that does not exist.
+ *
  * `totalAmountGB` is unvalidated upstream JSON, so a cycle missing it (or
  * carrying something non-numeric) is skipped rather than poisoning the sum with
- * NaN. A cycle reporting a real 0 — which is what the first cycle of a new
- * service line looks like — still counts toward the span and the cycle count.
+ * NaN.
  */
 export function allTimeUsage(cycles: readonly UsageCycle[]): AllTimeUsage {
   let totalGB = 0;
+  let reported = 0;
+  let from: string | null = null;
   for (const cycle of cycles) {
-    const amount = cycle?.totalAmountGB;
+    if (!isCycleReported(cycle)) continue;
+    reported += 1;
+    // Cycles arrive oldest-first (verified against the live endpoint), the same
+    // ordering CloudDataUsage relies on to find the newest, so the first
+    // reported one is the earliest.
+    from ??= cycle.startDate ?? null;
+    const amount = cycle.totalAmountGB;
     if (typeof amount === "number" && Number.isFinite(amount)) totalGB += amount;
   }
-  // Cycles arrive oldest-first (verified against the live endpoint), the same
-  // ordering CloudDataUsage relies on to find the newest.
-  return { totalGB, cycles: cycles.length, from: cycles[0]?.startDate ?? null };
+  return { totalGB, cycles: reported, unreported: cycles.length - reported, from };
 }
 
 /** Minor-unit currency amount (57000 = ₦57,000) → localized string. */


### PR DESCRIPTION
> **Stacked on #30.** This modifies the All view that #30 adds, so it cannot branch off `master` on its own. Until #30 merges, the diff below carries its commit underneath; the commit to review here is the second one, `Tell an unreported billing cycle apart from a zero one`.

## The problem

A billing cycle the account has nothing for arrives like this:

```json
{ "startDate": "2026-02-04...", "totalAmountGB": 0, "dailyData": [], "dataUsageSummaryLines": [] }
```

Read only through `totalAmountGB` that is indistinguishable from a month of genuine zero usage, and it showed up in two places:

- in the All view, as a bar on the floor with a `0 GB` tooltip
- on its own tab, where there are no columns to draw at all, so `RangeBars` returned nothing and the chart area collapsed to blank space under a large `0 GB`

The first states that no traffic passed. The second reads as a broken panel. Nothing measured this cycle. It is an absence.

## What changes

`isCycleReported` separates the two on the evidence that actually distinguishes them, the daily figures:

- days present that add up to zero is a dish that was off, which is a reading, and keeps its ordinary bar and its ordinary chart
- no days at all is an absence, and is now said out loud in both places

**In the All view**, the cycle gets the same faint wash `DataUsagePanel` already uses for a stretch the historian did not cover, with a tooltip reading `Feb 2026 - not reported`.

**On its own tab**, the headline reads `Not reported` instead of a figure, the allowance line gives way to `Starlink sent no usage for this cycle`, and the collapsed chart becomes an empty state reading `No daily usage was reported for this billing cycle.` The billing dates stay, since those are still true.

An unreported cycle also stops counting toward the All headline. It is out of the cycle count, and the span starts at the first cycle with data rather than the first one listed, because dating a total from a month with no usage behind it claims coverage that does not exist.

On a service line whose opening cycle was never reported, the subtitle goes from `7 billing cycles` to `6 billing cycles` and the footer from `Feb 4, 2026 - now` to `Mar 4, 2026 - now`. The total itself does not move, since the absent cycle contributed nothing to it.

## Changes

- `src/lib/starlinkCloud.ts`: `isCycleReported`, and `allTimeUsage` now counts and dates from reported cycles only, returning `unreported` alongside
- `src/components/data-usage/CloudDataUsage.tsx`: the wash and its tooltip in the All view, the not-reported headline, subtitle and empty state on a single cycle, and the footer dated from the span rather than the first listed cycle

## Tests

Three unit tests for `isCycleReported` covering an absent cycle, a genuine zero, and missing `dailyData`. The `allTimeUsage` tests were extended with cases for the recounted span, the reported-only count, and a genuine zero staying in both. Four component tests covering the wash with its recounted headline, a genuine zero keeping its bar, the single-cycle not-reported state, and a reported cycle still drawing normally.

```
npm test          1188 passed (103 files)
npm run typecheck clean
npm run lint      clean
npm run format    clean
```

## Verified against hardware

Checked against a live Residential service line whose seven listed cycles include one the account reported nothing for. In the All view it renders as the wash with `not reported`, the headline reads six billing cycles, and the span starts at the first month with data. On its own tab it reads `Not reported` above the empty state rather than `0 GB` above blank space. The remaining six months are unchanged, and the all-time total is identical either way.