### PR TITLE
feature: hover on event time to show date

### DIFF
--- a/src/components/alerts/OutageLog.tsx
+++ b/src/components/alerts/OutageLog.tsx
@@ -4,9 +4,9 @@
 // raw jargon explained) via outageEventMeta.
 
 import { canonicalCause, outageEventMeta, type OutageEvent } from "@core/telemetry";
-import { formatClockTimeShort, formatEventDuration } from "../../lib/format";
+import { formatClockTimeShort, formatEventDuration, formatDate } from "../../lib/format";
 import { EmptyState } from "../ui/empty-state";
-import { InfoDot } from "../shared/InfoDot";
+import { InfoDot, TooltipOnElement } from "../shared/InfoDot";
 
 // Severity, not the event kind. The thermal episodes reach this list with human
 // labels and no catalogue entry (useThermalEvents), so a kind lookup returns the
@@ -18,6 +18,12 @@ const SEVERITY_COLOR_VAR: Record<OutageEvent["severity"], string> = {
   warning: "--chart-warm",
   critical: "--status-critical",
 };
+
+function OutageTime(startMs: number) : string {
+  return (
+    <span className='font-mono text-[10.5px] whitespace-nowrap text-muted-foreground tabular-nums'>{formatClockTimeShort(startMs)} </span>
+  );
+}
 
 export function OutageLog({ outageEvents }: { outageEvents: OutageEvent[] }) {
   const newestFirst = [...outageEvents].sort((a, b) => b.startMs - a.startMs);
@@ -42,8 +48,8 @@ export function OutageLog({ outageEvents }: { outageEvents: OutageEvent[] }) {
                 className='grid grid-cols-[auto_1fr_auto] items-center gap-2.5 border-b border-border px-0.5 py-2 text-[13px] font-medium last:border-b-0'
                 key={`${outage.startMs}-${canonicalCause(outage.cause)}`}
               >
-                <span className='font-mono text-[10.5px] whitespace-nowrap text-muted-foreground tabular-nums'>
-                  {formatClockTimeShort(outage.startMs)}
+                <span classname='flex min-w-0 items-center gap-2'>
+                  { <TooltipOnElement el={OutageTime(outage.startMs)} info={formatDate(outage.startMs)} />}
                 </span>
                 <span className='flex min-w-0 items-center gap-2'>
                   <span

--- a/src/components/shared/InfoDot.tsx
+++ b/src/components/shared/InfoDot.tsx
@@ -12,6 +12,7 @@
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { cn } from "@/lib/utils";
 import { SeverityDot, type Severity } from "../ui/severity-icon";
+import type { ReactNode } from "react";
 
 // Portalled by Radix, so this is presentation only — the resets (not-italic,
 // normal-case, tracking-normal) guard against whatever context it lands in.
@@ -35,6 +36,29 @@ export function InfoDot({ tip, severity = "normal" }: { tip: string; severity?: 
             collisionPadding={12}
           >
             {tip}
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}
+
+export function TooltipOnElement({ el, info }: { el: ReactNode, info: string }) {
+  return (
+    <TooltipPrimitive.Provider delayDuration={120}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>
+	{el}
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            className={infoTip}
+            side='top'
+            align='start'
+            sideOffset={8}
+            collisionPadding={12}
+          >
+            {info}
           </TooltipPrimitive.Content>
         </TooltipPrimitive.Portal>
       </TooltipPrimitive.Root>

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -66,14 +66,18 @@ export function formatClockTimeShort(timestampMs: number): string {
   return new Date(timestampMs).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }
 
-export function formatDateTime(timestampMs: number): string {
+export function formatDate(timestampMs: number): string {
   const date = new Date(timestampMs);
   const datePart = date.toLocaleDateString(undefined, {
     day: "numeric",
     month: "short",
     year: "numeric",
   });
-  return `${datePart} · ${formatClockTimeShort(timestampMs)}`;
+  return `${datePart}`;
+}
+
+export function formatDateTime(timestampMs: number): string {
+  return `${formatDate(timestampMs)} · ${formatClockTimeShort(timestampMs)}`;
 }
 
 /** The dish's `hasActuators` enum ("HAS_ACTUATORS_YES"/"_NO") → plain Yes/No.


### PR DESCRIPTION
First time using react, radix, and frameworks generally so this may need reworking.

My main problem was in `OutageLog()` to wrap the shown time with the Tool-tip. Initially I used `InfoDot()` as a template for the new function `TooltipOnElement()` but could not find a way to combine its trigger with the call in `OutageLog()` to `formatClockTimeShort()`  so ended up separating that part out into the new function `OutageTime()`

If that can be factored out I'd be pleased to see how.

This addresses issue #27