### PR TITLE
Rename mesh nodes from the Nodes tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ collector/data
 
 # Machine-specific agent state.
 .claude/
+CLAUDE.local.md
 
 # Working notes and throwaway probe scripts. Local to whoever is mid-task.
 HANDOFF.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,27 +17,15 @@ is on the Starlink network itself — changes are verified against real hardware
   clients on current firmware. The official app gets its cloud data through an authenticated
   `api.starlink.com` session, not the LAN.
 - The router is a small embedded box and has rebooted under ordinary load: **never add a new
-  poll against it without the user's explicit approval.** Reuse replies already being fetched —
+  poll against it without explicit approval.** Reuse replies already being fetched —
   `routerStatusFeed` in the browser, the 5s status poll in the recorder.
 
-## Working with this user
+## CI
 
-- **Findings before code.** Report what you found and the plan, then wait for approval before
-  editing. When the user says "leave this for now", stop editing entirely until redirected.
-- **If the user's message contains a question, answer it fully before any further tool calls.**
-  Deferring the answer while continuing to edit counts as ignoring them.
-- **Bash is strictly for reads and mechanical edits.** Every authored code change goes through
-  the Edit/Write tools so the diff is visible in the chat before it lands. No `sed -i`, no
-  heredocs, no inline `python3` patch scripts, whatever a session default says to prefer.
-  `mv`, `rm`, formatters, codemods, git and search stay fine in Bash.
-- **Run every check CI runs, before committing, not after pushing.** All four:
-  `npm run typecheck`, `npm run lint`, `npm test`, and `npx prettier --check` over the files
-  the commit touches — CI's format job checks changed files only, so a full-tree check
-  reports a backlog that is not yours. A green local run is not a green CI run: tests that
-  open a socket behave differently on a Linux runner than on this machine.
-- Never `git add -A` or `git stash`; commit only the files you yourself changed.
-- No attribution trailers in commit messages, PR bodies or issue bodies: no `Claude-Session`,
-  no `claude.ai/code` link, no `Co-Authored-By`, no "Generated with".
+CI runs `npm run typecheck`, `npm run lint`, `npm test`, and a prettier check. The format job
+checks only changed files, so a full-tree `prettier --check` reports a pre-existing backlog that
+is not yours. Tests that open a socket behave differently on the Linux runner than on macOS, so
+a green local run is not a guaranteed green CI run.
 
 ## Process facts
 
@@ -48,5 +36,5 @@ is on the Starlink network itself — changes are verified against real hardware
 - "Historian" is the component's name in code, service, and docs. User-facing copy stays plain
   English — "history recorder" or "recording" — because UI readers aren't assumed to know the
   industrial term.
-- The user's pasted starlink.com session lives in `.starlink-cookie` at the repo root (written
-  by `dev/starlinkCloudProxy.ts`). It is a live credential: never print it, never commit it.
+- The pasted starlink.com session lives in `.starlink-cookie` at the repo root (written by
+  `dev/starlinkCloudProxy.ts`). It is a live credential: never print it, never commit it.

--- a/cloud/starlinkCloudHandler.test.ts
+++ b/cloud/starlinkCloudHandler.test.ts
@@ -858,6 +858,61 @@ describe("updateRouterConfig", () => {
     ).resolves.toMatchObject({ status: 400 });
     expect(prepared).toBe(false);
   });
+
+  const MESH_RENAME = {
+    kind: "meshName" as const,
+    deviceId: "Router-01000000000000000049375B",
+    displayName: "Garage",
+  };
+
+  it("given: a well-formed mesh rename, should: prepare and dispatch it", async () => {
+    let prepared = false;
+    const handler = createCloudHandler({
+      fetch: gateway(
+        async () =>
+          ({
+            status: 200,
+            ok: true,
+            headers: { get: () => null },
+            arrayBuffer: async () => new Uint8Array([0, 0, 0, 0, 0]).buffer,
+          }) as unknown as Response,
+      ),
+      readCookie: () => SESSION,
+      retryDelayMs: 0,
+      prepareRouterConfigUpdate: async () => {
+        prepared = true;
+        return new Uint8Array();
+      },
+    });
+
+    await expect(handler.updateRouterConfig(MESH_RENAME)).resolves.toMatchObject({ status: 200 });
+    expect(prepared).toBe(true);
+  });
+
+  it("given: a mesh rename with an empty name, should: refuse before the account is touched", async () => {
+    let prepared = false;
+    const handler = createCloudHandler({
+      readCookie: () => SESSION,
+      prepareRouterConfigUpdate: async () => {
+        prepared = true;
+        return new Uint8Array();
+      },
+    });
+
+    await expect(
+      handler.updateRouterConfig({ ...MESH_RENAME, displayName: "  " }),
+    ).resolves.toMatchObject({ status: 400 });
+    expect(prepared).toBe(false);
+  });
+
+  it("given: a mesh rename with a non-router device id, should: refuse it", async () => {
+    await expect(
+      createCloudHandler({ readCookie: () => SESSION }).updateRouterConfig({
+        ...MESH_RENAME,
+        deviceId: "ut0158168c",
+      }),
+    ).resolves.toMatchObject({ status: 400 });
+  });
 });
 
 // The roster and the config read the same way the writes are sent: named by the

--- a/cloud/starlinkCloudHandler.ts
+++ b/cloud/starlinkCloudHandler.ts
@@ -11,6 +11,7 @@ import { GrpcWebError, grpcWebUnaryCall } from "../core/grpcWeb";
 import type { DishConfigJson } from "../core/dishClient";
 import type { RouterClientUpdate } from "../core/routerClientUpdate";
 import {
+  meshNameRefusal,
   normalizeNameservers,
   subnetRefusal,
   type RouterConfigUpdate,
@@ -845,6 +846,12 @@ export function createCloudHandler(options: CloudHandlerOptions = {}) {
       return subnetRefusal(update.subnet, update.password) === null;
     }
     if (update?.kind === "bypass") return typeof update.enabled === "boolean";
+    if (update?.kind === "meshName") {
+      if (typeof update.deviceId !== "string" || !update.deviceId.startsWith("Router-"))
+        return false;
+      if (typeof update.displayName !== "string") return false;
+      return meshNameRefusal(update.displayName) === null;
+    }
     if (update?.kind === "factoryReset") return true;
     if (update?.kind !== "customDns") return false;
     if (!Array.isArray(update.nameservers)) return false;

--- a/core/routerConfigUpdate.test.ts
+++ b/core/routerConfigUpdate.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildMeshConfigs,
   buildRouterConfigRequest,
   buildSubnetNetworks,
+  meshNameRefusal,
   normalizeNameservers,
-  readCurrentNetworks,
+  readRouterConfigContext,
   readCurrentSubnet,
   routerAddressForSubnet,
   subnetRefusal,
@@ -223,7 +225,7 @@ describe("buildRouterConfigRequest for a subnet", () => {
     const request = buildRouterConfigRequest(
       TARGET,
       { kind: "subnet", subnet: "192.168.2.1/24", password: "hunter2hunter2" },
-      ROUTER_NETWORKS,
+      { networks: ROUTER_NETWORKS },
     );
     expect(Object.keys(request.wifiSetConfig!.wifiConfig)).toEqual(["networks", "applyNetworks"]);
     expect(request.wifiSetConfig!.wifiConfig.applyNetworks).toBe(true);
@@ -234,7 +236,7 @@ describe("buildRouterConfigRequest for a subnet", () => {
       buildRouterConfigRequest(
         TARGET,
         { kind: "subnet", subnet: "192.168.2.1/24", password: "hunter2hunter2" },
-        [],
+        { networks: [] },
       ),
     ).toThrow(/no networks/);
   });
@@ -244,9 +246,108 @@ describe("buildRouterConfigRequest for a subnet", () => {
       buildRouterConfigRequest(
         TARGET,
         { kind: "subnet", subnet: "192.168.2.1/24", password: "short" },
-        ROUTER_NETWORKS,
+        { networks: ROUTER_NETWORKS },
       ),
     ).toThrow(/8 to 63 characters/);
+  });
+});
+
+const MESH_ID = "Router-01000000000000000049375B";
+
+/** Shaped like the router's own reply: the changed node plus a second one, and
+ *  the router-assigned `incarnation` present on both. */
+const MESH_CONFIGS = {
+  [MESH_ID]: {
+    displayName: "Mesh 1",
+    auth: "MESH_AUTH_TRUSTED",
+    hardwareVersion: "v2",
+    incarnation: "4319674938922986994",
+  },
+  "Router-0100000000000000000ABCDE": {
+    displayName: "Mesh 2",
+    auth: "MESH_AUTH_TRUSTED",
+    incarnation: "9876543210",
+  },
+};
+
+describe("meshNameRefusal", () => {
+  it("accepts any non-empty name", () => {
+    expect(meshNameRefusal("Garage")).toBeNull();
+  });
+
+  it("refuses a name that is empty once trimmed", () => {
+    expect(meshNameRefusal("   ")).toBe("Name cannot be empty");
+  });
+});
+
+describe("buildMeshConfigs", () => {
+  const built = buildMeshConfigs(MESH_CONFIGS, MESH_ID, "Garage");
+
+  it("changes only the named node's display name", () => {
+    expect(built[MESH_ID].displayName).toBe("Garage");
+    expect(built["Router-0100000000000000000ABCDE"].displayName).toBe("Mesh 2");
+  });
+
+  it("keeps the node's other fields", () => {
+    expect(built[MESH_ID]).toMatchObject({ auth: "MESH_AUTH_TRUSTED", hardwareVersion: "v2" });
+  });
+
+  it("drops the router-assigned incarnation from every entry", () => {
+    for (const entry of Object.values(built)) expect(entry).not.toHaveProperty("incarnation");
+  });
+
+  it("refuses a node the router has not reported", () => {
+    expect(() => buildMeshConfigs(MESH_CONFIGS, "Router-000000000000000000000000", "X")).toThrow(
+      /does not know this mesh node/,
+    );
+  });
+});
+
+describe("buildRouterConfigRequest for a mesh node name", () => {
+  it("sends the meshConfigs map with the apply flag and nothing else", () => {
+    const request = buildRouterConfigRequest(
+      TARGET,
+      { kind: "meshName", deviceId: MESH_ID, displayName: "Garage" },
+      { meshConfigs: MESH_CONFIGS },
+    );
+    expect(Object.keys(request.wifiSetConfig!.wifiConfig)).toEqual([
+      "meshConfigs",
+      "applyMeshConfigs",
+    ]);
+    expect(request.wifiSetConfig!.wifiConfig.applyMeshConfigs).toBe(true);
+  });
+
+  it("trims the name before it is stored", () => {
+    const request = buildRouterConfigRequest(
+      TARGET,
+      { kind: "meshName", deviceId: MESH_ID, displayName: "  Garage  " },
+      { meshConfigs: MESH_CONFIGS },
+    );
+    const map = request.wifiSetConfig!.wifiConfig.meshConfigs as Record<
+      string,
+      { displayName: string }
+    >;
+    expect(map[MESH_ID].displayName).toBe("Garage");
+  });
+
+  it("refuses an empty name before the account is touched", () => {
+    expect(() =>
+      buildRouterConfigRequest(
+        TARGET,
+        { kind: "meshName", deviceId: MESH_ID, displayName: "  " },
+        { meshConfigs: MESH_CONFIGS },
+      ),
+    ).toThrow(/empty/);
+  });
+
+  it("refuses a node the router did not report", () => {
+    expect(() =>
+      buildRouterConfigRequest(
+        TARGET,
+        { kind: "meshName", deviceId: "Router-000000000000000000000000", displayName: "X" },
+        { meshConfigs: MESH_CONFIGS },
+      ),
+    ).toThrow(/does not know this mesh node/);
   });
 });
 
@@ -276,40 +377,58 @@ describe("readCurrentSubnet", () => {
   });
 });
 
-describe("readCurrentNetworks", () => {
+describe("readRouterConfigContext", () => {
   const codec = {
     encodeRequest: () => new Uint8Array([1]),
-    decodeResponse: () => ({ wifiGetConfig: { wifiConfig: { networks: ROUTER_NETWORKS } } }),
+    decodeResponse: () => ({
+      wifiGetConfig: { wifiConfig: { networks: ROUTER_NETWORKS, meshConfigs: MESH_CONFIGS } },
+    }),
+  };
+  const counting = () => {
+    let sent = 0;
+    return {
+      gateway: async () => {
+        sent += 1;
+        return new Uint8Array();
+      },
+      count: () => sent,
+    };
   };
 
-  it("reads the router for a subnet change", async () => {
-    let sent = 0;
-    const networks = await readCurrentNetworks(
+  it("reads the networks for a subnet change", async () => {
+    const { gateway, count } = counting();
+    const context = await readRouterConfigContext(
       { kind: "subnet", subnet: "192.168.2.1/24", password: "hunter2hunter2" },
       codec,
       TARGET,
-      async () => {
-        sent += 1;
-        return new Uint8Array();
-      },
+      gateway,
     );
-    expect(sent).toBe(1);
-    expect(networks).toHaveLength(2);
+    expect(count()).toBe(1);
+    expect(context.networks).toHaveLength(2);
+  });
+
+  it("reads the mesh map for a mesh rename", async () => {
+    const { gateway, count } = counting();
+    const context = await readRouterConfigContext(
+      { kind: "meshName", deviceId: MESH_ID, displayName: "Garage" },
+      codec,
+      TARGET,
+      gateway,
+    );
+    expect(count()).toBe(1);
+    expect(context.meshConfigs).toHaveProperty(MESH_ID);
   });
 
   it("spends no round trip on an update that does not need the current config", async () => {
-    let sent = 0;
-    const networks = await readCurrentNetworks(
+    const { gateway, count } = counting();
+    const context = await readRouterConfigContext(
       { kind: "customDns", nameservers: ["1.1.1.1"] },
       codec,
       TARGET,
-      async () => {
-        sent += 1;
-        return new Uint8Array();
-      },
+      gateway,
     );
-    expect(sent).toBe(0);
-    expect(networks).toEqual([]);
+    expect(count()).toBe(0);
+    expect(context).toEqual({});
   });
 });
 

--- a/core/routerConfigUpdate.ts
+++ b/core/routerConfigUpdate.ts
@@ -86,11 +86,7 @@ export type RouterConfigUpdate =
     }
   | {
       kind: "meshName";
-      /** The paired node's `meshConfigs` key, in the same `Router-<hex>`
-       *  namespace the client list reports. */
       deviceId: string;
-      /** The label to store. The firmware keeps it verbatim and imposes no
-       *  visible limit, so only an empty value is refused. */
       displayName: string;
     };
 
@@ -157,20 +153,10 @@ export function subnetRefusal(subnet: string, password: string): string | null {
   return null;
 }
 
-/** Why a mesh node rename cannot be sent, or null when it can. */
 export function meshNameRefusal(displayName: string): string | null {
   return displayName.trim() === "" ? "Name cannot be empty" : null;
 }
 
-/**
- * The `meshConfigs` map to send for a rename, built from what the router
- * currently reports.
- *
- * The map is rewritten whole, so every other node is carried back untouched.
- * `incarnation` is a router-assigned revision counter with no apply flag;
- * carried back it risks the firmware discarding the whole message, the way a
- * stale `bssid` does in the networks block, so it is dropped from every entry.
- */
 export function buildMeshConfigs(
   meshConfigs: Readonly<Record<string, Json>>,
   deviceId: string,
@@ -179,6 +165,8 @@ export function buildMeshConfigs(
   if (!(deviceId in meshConfigs)) throw new Error("router does not know this mesh node");
   const rebuilt: Record<string, Json> = {};
   for (const [id, node] of Object.entries(meshConfigs)) {
+    // incarnation is router-assigned; echoing it back can make the firmware
+    // discard the write, as a stale bssid does in the networks block.
     const { incarnation: _incarnation, ...kept } = node;
     rebuilt[id] = id === deviceId ? { ...kept, displayName } : kept;
   }
@@ -213,23 +201,11 @@ export async function readRouterWifiConfig(
   return (reply.wifiGetConfig?.wifiConfig as WifiNetworkConfigJson | undefined) ?? null;
 }
 
-/** The current router state a write has to be rebuilt from. Empty for the
- *  updates that name a single field and need no read first. */
 export interface RouterConfigContext {
-  /** Present for a subnet change: the `networks` block, carried back nearly
-   *  intact around the one changed field. */
   networks?: Json[];
-  /** Present for a mesh rename: the `meshConfigs` map, rewritten whole. */
   meshConfigs?: Record<string, Json>;
 }
 
-/**
- * The state a write must preserve, fetched through the caller's gateway.
- *
- * Only a subnet change and a mesh rename rewrite a shared block; every other
- * update skips the round trip and gets the empty context `buildRouterConfigRequest`
- * ignores.
- */
 export async function readRouterConfigContext(
   update: RouterConfigUpdate,
   codec: RouterCodec,
@@ -274,8 +250,6 @@ export async function readCurrentSubnet(
 export function buildRouterConfigRequest(
   targetId: string,
   update: RouterConfigUpdate,
-  /** Current router state, from `readRouterConfigContext`. Required for a subnet
-   *  change and a mesh rename; unused by every other update. */
   context: RouterConfigContext = {},
 ): RouterConfigRequestJson {
   if (!targetId.startsWith("Router-")) throw new Error("invalid router target id");

--- a/core/routerConfigUpdate.ts
+++ b/core/routerConfigUpdate.ts
@@ -83,6 +83,15 @@ export type RouterConfigUpdate =
        *  router's own WiFi down with it, so the machine asking for this is
        *  usually the one that loses its connection. Off is the way back. */
       enabled: boolean;
+    }
+  | {
+      kind: "meshName";
+      /** The paired node's `meshConfigs` key, in the same `Router-<hex>`
+       *  namespace the client list reports. */
+      deviceId: string;
+      /** The label to store. The firmware keeps it verbatim and imposes no
+       *  visible limit, so only an empty value is refused. */
+      displayName: string;
     };
 
 /** The addresses as they will be sent, or null when any of them is not an address
@@ -148,6 +157,34 @@ export function subnetRefusal(subnet: string, password: string): string | null {
   return null;
 }
 
+/** Why a mesh node rename cannot be sent, or null when it can. */
+export function meshNameRefusal(displayName: string): string | null {
+  return displayName.trim() === "" ? "Name cannot be empty" : null;
+}
+
+/**
+ * The `meshConfigs` map to send for a rename, built from what the router
+ * currently reports.
+ *
+ * The map is rewritten whole, so every other node is carried back untouched.
+ * `incarnation` is a router-assigned revision counter with no apply flag;
+ * carried back it risks the firmware discarding the whole message, the way a
+ * stale `bssid` does in the networks block, so it is dropped from every entry.
+ */
+export function buildMeshConfigs(
+  meshConfigs: Readonly<Record<string, Json>>,
+  deviceId: string,
+  displayName: string,
+): Record<string, Json> {
+  if (!(deviceId in meshConfigs)) throw new Error("router does not know this mesh node");
+  const rebuilt: Record<string, Json> = {};
+  for (const [id, node] of Object.entries(meshConfigs)) {
+    const { incarnation: _incarnation, ...kept } = node;
+    rebuilt[id] = id === deviceId ? { ...kept, displayName } : kept;
+  }
+  return rebuilt;
+}
+
 /** The bit of DishClient this needs, named structurally so any codec can serve
  *  it rather than the client alone. */
 interface RouterCodec {
@@ -176,20 +213,36 @@ export async function readRouterWifiConfig(
   return (reply.wifiGetConfig?.wifiConfig as WifiNetworkConfigJson | undefined) ?? null;
 }
 
+/** The current router state a write has to be rebuilt from. Empty for the
+ *  updates that name a single field and need no read first. */
+export interface RouterConfigContext {
+  /** Present for a subnet change: the `networks` block, carried back nearly
+   *  intact around the one changed field. */
+  networks?: Json[];
+  /** Present for a mesh rename: the `meshConfigs` map, rewritten whole. */
+  meshConfigs?: Record<string, Json>;
+}
+
 /**
- * The networks a write must preserve, fetched through the caller's gateway.
+ * The state a write must preserve, fetched through the caller's gateway.
  *
- * Only a subnet change needs them, so every other update skips the round trip
- * and gets the empty list `buildRouterConfigRequest` ignores.
+ * Only a subnet change and a mesh rename rewrite a shared block; every other
+ * update skips the round trip and gets the empty context `buildRouterConfigRequest`
+ * ignores.
  */
-export async function readCurrentNetworks(
+export async function readRouterConfigContext(
   update: RouterConfigUpdate,
   codec: RouterCodec,
   targetId: string,
   callGateway: (requestBytes: Uint8Array) => Promise<Uint8Array>,
-): Promise<Json[]> {
-  if (update.kind !== "subnet") return [];
-  return readRouterNetworks(codec, targetId, callGateway);
+): Promise<RouterConfigContext> {
+  if (update.kind === "subnet")
+    return { networks: await readRouterNetworks(codec, targetId, callGateway) };
+  if (update.kind === "meshName") {
+    const config = await readRouterWifiConfig(codec, targetId, callGateway);
+    return { meshConfigs: (config?.meshConfigs as Record<string, Json> | undefined) ?? {} };
+  }
+  return {};
 }
 
 async function readRouterNetworks(
@@ -221,13 +274,15 @@ export async function readCurrentSubnet(
 export function buildRouterConfigRequest(
   targetId: string,
   update: RouterConfigUpdate,
-  /** Current networks, required for a subnet change and unused otherwise. */
-  networks: readonly Json[] = [],
+  /** Current router state, from `readRouterConfigContext`. Required for a subnet
+   *  change and a mesh rename; unused by every other update. */
+  context: RouterConfigContext = {},
 ): RouterConfigRequestJson {
   if (!targetId.startsWith("Router-")) throw new Error("invalid router target id");
   if (update.kind === "subnet") {
     const refusal = subnetRefusal(update.subnet, update.password);
     if (refusal) throw new Error(refusal);
+    const networks = context.networks ?? [];
     if (networks.length === 0) throw new Error("router reported no networks to change");
     return {
       targetId,
@@ -235,6 +290,23 @@ export function buildRouterConfigRequest(
         wifiConfig: {
           networks: buildSubnetNetworks(networks, update.subnet, update.password),
           applyNetworks: true,
+        },
+      },
+    };
+  }
+  if (update.kind === "meshName") {
+    const refusal = meshNameRefusal(update.displayName);
+    if (refusal) throw new Error(refusal);
+    return {
+      targetId,
+      wifiSetConfig: {
+        wifiConfig: {
+          meshConfigs: buildMeshConfigs(
+            context.meshConfigs ?? {},
+            update.deviceId,
+            update.displayName.trim(),
+          ),
+          applyMeshConfigs: true,
         },
       },
     };

--- a/dev/bypass.mts
+++ b/dev/bypass.mts
@@ -12,7 +12,7 @@ import { resolve } from "node:path";
 import { createCloudHandler } from "../cloud/starlinkCloudHandler.ts";
 import { resilientFetch } from "../cloud/resilientFetch.ts";
 import { DishClient, ROUTER_LAN_HANDLE_URL } from "../core/dishClient.ts";
-import { buildRouterConfigRequest, readCurrentNetworks } from "../core/routerConfigUpdate.ts";
+import { buildRouterConfigRequest, readRouterConfigContext } from "../core/routerConfigUpdate.ts";
 
 const COOKIE_FILE = resolve(process.cwd(), ".starlink-cookie");
 
@@ -58,8 +58,8 @@ const handler = createCloudHandler({
   },
   prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
     const client = await loadRouter();
-    const networks = await readCurrentNetworks(update, client, targetId, callGateway);
-    return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
+    const context = await readRouterConfigContext(update, client, targetId, callGateway);
+    return client.encodeRequest(buildRouterConfigRequest(targetId, update, context));
   },
 });
 

--- a/dev/starlinkCloudProxy.ts
+++ b/dev/starlinkCloudProxy.ts
@@ -19,7 +19,7 @@ import type { DishConfigJson } from "../core/dishClient.ts";
 import { prepareDishConfigUpdate } from "../core/dishConfigUpdate.ts";
 import {
   buildRouterConfigRequest,
-  readCurrentNetworks,
+  readRouterConfigContext,
   readCurrentSubnet,
   readRouterWifiConfig,
   type RouterConfigUpdate,
@@ -129,8 +129,8 @@ export function createFileCloudHandler(options: FileCloudHandlerOptions = {}) {
     // kit whose router answers nothing on the LAN.
     prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
       const client = await loadRouter();
-      const networks = await readCurrentNetworks(update, client, targetId, callGateway);
-      return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
+      const context = await readRouterConfigContext(update, client, targetId, callGateway);
+      return client.encodeRequest(buildRouterConfigRequest(targetId, update, context));
     },
     readRouterSubnet: async (targetId, callGateway) =>
       readCurrentSubnet(await loadRouter(), targetId, callGateway),

--- a/electron/cloud.ts
+++ b/electron/cloud.ts
@@ -23,7 +23,7 @@ import type { DishConfigJson } from "../core/dishClient";
 import { prepareDishConfigUpdate } from "../core/dishConfigUpdate";
 import {
   buildRouterConfigRequest,
-  readCurrentNetworks,
+  readRouterConfigContext,
   readCurrentSubnet,
   readRouterWifiConfig,
   type RouterConfigUpdate,
@@ -158,8 +158,8 @@ export function startCloud(rendererRoot: string, sessionFile?: string): void {
     // networks through the caller's gateway, which has the same reach.
     prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
       const client = await loadRouter();
-      const networks = await readCurrentNetworks(update, client, targetId, callGateway);
-      return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
+      const context = await readRouterConfigContext(update, client, targetId, callGateway);
+      return client.encodeRequest(buildRouterConfigRequest(targetId, update, context));
     },
     readRouterSubnet: async (targetId, callGateway) =>
       readCurrentSubnet(await loadRouter(), targetId, callGateway),

--- a/extension/lib/cloudHandler.ts
+++ b/extension/lib/cloudHandler.ts
@@ -25,7 +25,7 @@ import { DishClient, type DishConfigJson } from "@core/dishClient";
 import { prepareDishConfigUpdate } from "@core/dishConfigUpdate";
 import {
   buildRouterConfigRequest,
-  readCurrentNetworks,
+  readRouterConfigContext,
   readCurrentSubnet,
   readRouterWifiConfig,
   type RouterConfigUpdate,
@@ -78,8 +78,8 @@ const cloudHandler = createCloudHandler({
     prepareRouterClientUpdate(await loadRouter(), update, targetId, callGateway),
   prepareRouterConfigUpdate: async (update, targetId, callGateway) => {
     const client = await loadRouter();
-    const networks = await readCurrentNetworks(update, client, targetId, callGateway);
-    return client.encodeRequest(buildRouterConfigRequest(targetId, update, networks));
+    const context = await readRouterConfigContext(update, client, targetId, callGateway);
+    return client.encodeRequest(buildRouterConfigRequest(targetId, update, context));
   },
   readRouterSubnet: async (targetId, callGateway) =>
     readCurrentSubnet(await loadRouter(), targetId, callGateway),

--- a/src/components/network/DeviceNameEditor.test.tsx
+++ b/src/components/network/DeviceNameEditor.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { render, cleanup } from "vitest-browser-react";
+import { page } from "vitest/browser";
+import type { WifiClientJson } from "@core/dishClient";
+import { DeviceNameEditor, MeshNodeNameEditor } from "./DeviceNameEditor";
+
+afterEach(cleanup);
+
+function saveButton(): HTMLButtonElement {
+  const found = [...document.querySelectorAll("button")].find(
+    (element) => element.textContent?.trim() === "Save",
+  );
+  if (!found) throw new Error('no button labelled "Save"');
+  return found as HTMLButtonElement;
+}
+
+async function settle(ms = 30): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("mesh editor seeds the stored name and does not offer to save it unchanged", async () => {
+  render(
+    <MeshNodeNameEditor
+      deviceId='Router-01000000000000000049375B'
+      currentName='Mesh 1'
+      onRename={vi.fn().mockResolvedValue(undefined)}
+      onDone={() => {}}
+    />,
+  );
+  await settle();
+
+  expect((document.querySelector("input") as HTMLInputElement).value).toBe("Mesh 1");
+  expect(saveButton().disabled).toBe(true);
+});
+
+test("mesh editor sends the trimmed name against the device id", async () => {
+  const onRename = vi.fn().mockResolvedValue(undefined);
+  const onDone = vi.fn();
+  render(
+    <MeshNodeNameEditor
+      deviceId='Router-01000000000000000049375B'
+      currentName='Mesh 1'
+      onRename={onRename}
+      onDone={onDone}
+    />,
+  );
+
+  await page.getByPlaceholder("Node name").fill("  Garage  ");
+  expect(saveButton().disabled).toBe(false);
+  saveButton().click();
+  await settle();
+
+  expect(onRename).toHaveBeenCalledWith("Router-01000000000000000049375B", "Garage");
+  expect(onDone).toHaveBeenCalled();
+});
+
+test("mesh editor keeps save closed for a name that is only whitespace", async () => {
+  render(
+    <MeshNodeNameEditor
+      deviceId='Router-01000000000000000049375B'
+      currentName='Mesh 1'
+      onRename={vi.fn()}
+      onDone={() => {}}
+    />,
+  );
+
+  await page.getByPlaceholder("Node name").fill("   ");
+  expect(saveButton().disabled).toBe(true);
+});
+
+test("device editor sends the new name against the clientId", async () => {
+  const client = { clientId: 7, name: "hostname", givenName: "Nanoleaf" } as WifiClientJson;
+  const onRename = vi.fn().mockResolvedValue(undefined);
+  render(<DeviceNameEditor client={client} onRename={onRename} onDone={() => {}} />);
+
+  await settle();
+  expect(saveButton().disabled).toBe(true);
+  await page.getByPlaceholder("Device name").fill("Living room light");
+  saveButton().click();
+  await settle();
+
+  expect(onRename).toHaveBeenCalledWith(7, "Living room light");
+});

--- a/src/components/network/DeviceNameEditor.tsx
+++ b/src/components/network/DeviceNameEditor.tsx
@@ -1,5 +1,6 @@
-// Inline rename for a device: the pencil affordance beside the name, the edit
-// row it opens, and the failure message the router's write lock produces.
+// Inline rename: the pencil affordance beside a name, the edit row it opens, and
+// the failure message the router's write lock produces. Used for both a client
+// device and a mesh node — the two differ only in what a saved name is keyed by.
 
 import { useState } from "react";
 import type { WifiClientJson } from "@core/dishClient";
@@ -11,11 +12,17 @@ import { displayName } from "./networkFormat";
 import { AccountRequiredError } from "../../lib/routerClientUpdate";
 import { AccountRequiredNotice } from "../shared/AccountRequiredNotice";
 
-export function RenameButton({ onClick }: { onClick: () => void }) {
+export function RenameButton({
+  onClick,
+  label = "Rename device",
+}: {
+  onClick: () => void;
+  label?: string;
+}) {
   return (
     <button
       className='inline-flex h-[26px] w-[26px] flex-none cursor-pointer items-center justify-center rounded-[999px] border-none bg-[color-mix(in_srgb,var(--ink)_6%,var(--surface))] text-ink-secondary [transition:background_120ms_ease,color_120ms_ease] hover:bg-[color-mix(in_srgb,var(--ink)_12%,var(--surface))] hover:text-foreground'
-      aria-label='Rename device'
+      aria-label={label}
       onClick={onClick}
     >
       <PencilIcon />
@@ -23,37 +30,45 @@ export function RenameButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-export function DeviceNameEditor({
-  client,
-  onRename,
+function NameEditorForm({
+  currentName,
+  initialName = currentName,
+  placeholder,
+  extraValid = true,
+  onSave,
   onDone,
 }: {
-  client: WifiClientJson;
-  onRename: (clientId: number, givenName: string) => Promise<void>;
+  /** The name a save is compared against, so an unchanged value is a no-op. */
+  currentName: string;
+  /** What the field starts with, when that is not the same string — a device
+   *  known only by address seeds blank but still counts address as unchanged. */
+  initialName?: string;
+  placeholder: string;
+  /** A further condition on saving beyond "non-empty and changed" — a client
+   *  with no id cannot be renamed, for one. */
+  extraValid?: boolean;
+  onSave: (name: string) => Promise<void>;
   onDone: () => void;
 }) {
-  const [draftName, setDraftName] = useState(client.givenName ?? client.name ?? "");
+  const [draftName, setDraftName] = useState(initialName);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
   const trimmedName = draftName.trim();
-  // Blank or unchanged has nothing to write, so Save is not offered for either.
-  const canSave =
-    client.clientId !== undefined && trimmedName !== "" && trimmedName !== displayName(client);
+  const canSave = extraValid && trimmedName !== "" && trimmedName !== currentName;
 
   const commit = async () => {
-    const { clientId } = client;
-    if (!canSave || clientId === undefined) {
+    if (!canSave) {
       onDone();
       return;
     }
     setBusy(true);
     setError(null);
     try {
-      await onRename(clientId, trimmedName);
+      await onSave(trimmedName);
       onDone();
-    } catch (renameFailure) {
-      setError(renameFailure as Error);
+    } catch (saveFailure) {
+      setError(saveFailure as Error);
     } finally {
       setBusy(false);
     }
@@ -67,7 +82,7 @@ export function DeviceNameEditor({
           autoFocus
           value={draftName}
           disabled={busy}
-          placeholder='Device name'
+          placeholder={placeholder}
           onChange={(event) => {
             setDraftName(event.target.value);
             setError(null);
@@ -96,5 +111,49 @@ export function DeviceNameEditor({
         </div>
       )}
     </>
+  );
+}
+
+export function DeviceNameEditor({
+  client,
+  onRename,
+  onDone,
+}: {
+  client: WifiClientJson;
+  onRename: (clientId: number, givenName: string) => Promise<void>;
+  onDone: () => void;
+}) {
+  return (
+    <NameEditorForm
+      currentName={displayName(client)}
+      initialName={client.givenName ?? client.name ?? ""}
+      placeholder='Device name'
+      extraValid={client.clientId !== undefined}
+      onSave={(name) => onRename(client.clientId as number, name)}
+      onDone={onDone}
+    />
+  );
+}
+
+export function MeshNodeNameEditor({
+  deviceId,
+  currentName,
+  onRename,
+  onDone,
+}: {
+  deviceId: string;
+  /** The stored `meshConfigs` display name — the field this writes, not the
+   *  roster label, which can fall back to a hostname. */
+  currentName: string;
+  onRename: (deviceId: string, displayName: string) => Promise<void>;
+  onDone: () => void;
+}) {
+  return (
+    <NameEditorForm
+      currentName={currentName}
+      placeholder='Node name'
+      onSave={(name) => onRename(deviceId, name)}
+      onDone={onDone}
+    />
   );
 }

--- a/src/components/network/DeviceNameEditor.tsx
+++ b/src/components/network/DeviceNameEditor.tsx
@@ -1,6 +1,5 @@
-// Inline rename: the pencil affordance beside a name, the edit row it opens, and
-// the failure message the router's write lock produces. Used for both a client
-// device and a mesh node — the two differ only in what a saved name is keyed by.
+// Inline rename for a device or mesh node. The write has no LAN path, so a
+// blocked one surfaces the account-required notice rather than a raw error.
 
 import { useState } from "react";
 import type { WifiClientJson } from "@core/dishClient";
@@ -38,14 +37,12 @@ function NameEditorForm({
   onSave,
   onDone,
 }: {
-  /** The name a save is compared against, so an unchanged value is a no-op. */
+  /** Save baseline: an entry equal to this is a no-op. Distinct from
+   *  `initialName` so a device known only by address can seed blank yet still
+   *  treat that address as unchanged. */
   currentName: string;
-  /** What the field starts with, when that is not the same string — a device
-   *  known only by address seeds blank but still counts address as unchanged. */
   initialName?: string;
   placeholder: string;
-  /** A further condition on saving beyond "non-empty and changed" — a client
-   *  with no id cannot be renamed, for one. */
   extraValid?: boolean;
   onSave: (name: string) => Promise<void>;
   onDone: () => void;
@@ -142,8 +139,8 @@ export function MeshNodeNameEditor({
   onDone,
 }: {
   deviceId: string;
-  /** The stored `meshConfigs` display name — the field this writes, not the
-   *  roster label, which can fall back to a hostname. */
+  /** The stored `meshConfigs` name — what the write targets, not the roster
+   *  label, which can fall back to a hostname. */
   currentName: string;
   onRename: (deviceId: string, displayName: string) => Promise<void>;
   onDone: () => void;

--- a/src/components/network/NetworkPanel.cloud.test.tsx
+++ b/src/components/network/NetworkPanel.cloud.test.tsx
@@ -29,6 +29,7 @@ const network: RouterNetwork = {
   accountRosterError: null,
   wifiConfigViaAccount: false,
   renameClient: async () => {},
+  renameMeshNode: async () => {},
   throughputHistory: new Map(),
   rates: new Map(),
   ratesAtRoster: new Map(),

--- a/src/components/network/NetworkPanel.tsx
+++ b/src/components/network/NetworkPanel.tsx
@@ -191,6 +191,7 @@ function NetworkPanelBody({
         radios={radio.current}
         self={self}
         onSelect={onSelect}
+        onRename={network.renameMeshNode}
       />
     );
   }

--- a/src/components/network/NodeDetail.tsx
+++ b/src/components/network/NodeDetail.tsx
@@ -4,6 +4,7 @@
 // reports no per-node throughput or signal (its rxStats / txStats come back
 // empty). This shows what a node actually has: what it serves, and what it is.
 
+import { useState } from "react";
 import type { RadioReading } from "../../hooks/useRadioTemps";
 import type { WifiNetworkConfigJson, WifiStatusJson } from "@core/dishClient";
 import type { SelfIdentity } from "../../lib/selfIdentity";
@@ -11,6 +12,7 @@ import { RouterIcon } from "../../assets/icons/RouterIcon";
 import { formatDeviceEnum, formatUptime } from "../../lib/format";
 import { DataRow, SectionHeading } from "./DataRow";
 import { DeviceRow } from "./NetworkRow";
+import { MeshNodeNameEditor, RenameButton } from "./DeviceNameEditor";
 import { RadioTempsSection } from "./RadioTempsSection";
 import { bandLabel, clientEntryKey } from "./networkFormat";
 import type { NodeEntry } from "./nodeRoster";
@@ -22,6 +24,7 @@ export function NodeDetail({
   radios,
   self,
   onSelect,
+  onRename,
 }: {
   node: NodeEntry;
   wifiConfig: WifiNetworkConfigJson | null;
@@ -33,10 +36,16 @@ export function NodeDetail({
   /** Drill from a node straight into one of its clients, as the app does.
    *  Receives the client row's `clientEntryKey`. */
   onSelect: (entryKey: string | null) => void;
+  /** Rename a mesh node. Absent leaves the name read-only. */
+  onRename?: (deviceId: string, displayName: string) => Promise<void>;
 }) {
+  const [editing, setEditing] = useState(false);
   const client = node.client;
   const meshConfig = node.key ? wifiConfig?.meshConfigs?.[node.key] : undefined;
   const isRouter = client?.role === "CONTROLLER";
+  // A mesh node is renamed by its `meshConfigs` key; the controller is not in
+  // that map, and a live node without a device id has no handle to write to.
+  const canRename = Boolean(onRename) && !isRouter && node.key.startsWith("Router-");
   // The rate the link negotiated, not throughput — the same number the app shows
   // as "Rx rate". The controller reports empty stats for itself, so this is
   // absent there rather than zero.
@@ -57,10 +66,22 @@ export function NodeDetail({
         <div className='min-w-0'>
           <div className='flex items-center gap-2'>
             <span className='text-[18px] font-bold text-foreground'>{node.name}</span>
+            {canRename && !editing && (
+              <RenameButton label='Rename node' onClick={() => setEditing(true)} />
+            )}
           </div>
           <div className='text-[11.5px] font-medium text-muted-foreground'>{node.status}</div>
         </div>
       </div>
+
+      {canRename && editing && onRename && (
+        <MeshNodeNameEditor
+          deviceId={node.key}
+          currentName={meshConfig?.displayName ?? ""}
+          onRename={onRename}
+          onDone={() => setEditing(false)}
+        />
+      )}
 
       <div className='flex flex-col'>
         {client?.role && <DataRow label='Role' value={client.role} />}

--- a/src/components/network/NodeDetail.tsx
+++ b/src/components/network/NodeDetail.tsx
@@ -36,15 +36,14 @@ export function NodeDetail({
   /** Drill from a node straight into one of its clients, as the app does.
    *  Receives the client row's `clientEntryKey`. */
   onSelect: (entryKey: string | null) => void;
-  /** Rename a mesh node. Absent leaves the name read-only. */
   onRename?: (deviceId: string, displayName: string) => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
   const client = node.client;
   const meshConfig = node.key ? wifiConfig?.meshConfigs?.[node.key] : undefined;
   const isRouter = client?.role === "CONTROLLER";
-  // A mesh node is renamed by its `meshConfigs` key; the controller is not in
-  // that map, and a live node without a device id has no handle to write to.
+  // `node.key` is a `meshConfigs` id only when it starts `Router-`; it falls back
+  // to a MAC or a positional key otherwise, and the controller has no entry.
   const canRename = Boolean(onRename) && !isRouter && node.key.startsWith("Router-");
   // The rate the link negotiated, not throughput — the same number the app shows
   // as "Rx rate". The controller reports empty stats for itself, so this is

--- a/src/components/network/nodeRoster.test.ts
+++ b/src/components/network/nodeRoster.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { WifiClientJson, WifiNetworkConfigJson } from "@core/dishClient";
+import { buildNodeRoster } from "./nodeRoster";
+
+const CONTROLLER = "Router-010000000000000001B31340";
+const NODE = "Router-01000000000000000049375B";
+
+const controllerClient: WifiClientJson = {
+  deviceId: CONTROLLER,
+  macAddress: "74:24:9f:43:13:40",
+  role: "CONTROLLER",
+  name: "Controller",
+};
+const repeaterClient: WifiClientJson = {
+  deviceId: NODE,
+  macAddress: "74:24:9f:d9:37:5b",
+  role: "REPEATER",
+  name: "hostname-1",
+};
+
+describe("buildNodeRoster", () => {
+  it("names a live node from its meshConfigs displayName over the hostname", () => {
+    const wifiConfig = {
+      meshConfigs: { [NODE]: { displayName: "Garage" } },
+    } as unknown as WifiNetworkConfigJson;
+    const roster = buildNodeRoster([controllerClient, repeaterClient], wifiConfig);
+    expect(roster.find((node) => node.key === NODE)?.name).toBe("Garage");
+  });
+
+  it("prefers the configured name even when the client carries a givenName", () => {
+    const named: WifiClientJson = { ...repeaterClient, givenName: "Old name" };
+    const wifiConfig = {
+      meshConfigs: { [NODE]: { displayName: "Garage" } },
+    } as unknown as WifiNetworkConfigJson;
+    expect(buildNodeRoster([named], wifiConfig).find((n) => n.key === NODE)?.name).toBe("Garage");
+  });
+
+  it("falls back to the hostname when no name is configured", () => {
+    expect(buildNodeRoster([repeaterClient], null).find((n) => n.key === NODE)?.name).toBe(
+      "hostname-1",
+    );
+  });
+
+  it("lists a paired-but-down node from meshConfigs alone", () => {
+    const wifiConfig = {
+      meshConfigs: { [NODE]: { displayName: "Garage" } },
+    } as unknown as WifiNetworkConfigJson;
+    const roster = buildNodeRoster([controllerClient], wifiConfig);
+    const down = roster.find((node) => node.key === NODE);
+    expect(down).toMatchObject({ name: "Garage", connected: false, status: "Disconnected" });
+  });
+});

--- a/src/components/network/nodeRoster.ts
+++ b/src/components/network/nodeRoster.ts
@@ -19,8 +19,8 @@ export interface NodeEntry {
 
 /** Friendly name for a live node. The API only ever sends the raw role
  *  ("CONTROLLER"), so the router's human label is ours, as in the app; a mesh
- *  node prefers the name saved in its config — the one the rename pencil writes —
- *  over anything else. */
+ *  node prefers the name saved in its config over anything the client entry
+ *  carries. */
 function nodeName(client: WifiClientJson, wifiConfig: WifiNetworkConfigJson | null): string {
   if (client.role === "CONTROLLER") return "Main Router";
   const configured = client.deviceId

--- a/src/components/network/nodeRoster.ts
+++ b/src/components/network/nodeRoster.ts
@@ -19,13 +19,14 @@ export interface NodeEntry {
 
 /** Friendly name for a live node. The API only ever sends the raw role
  *  ("CONTROLLER"), so the router's human label is ours, as in the app; a mesh
- *  node prefers the name saved in its config over its bare hostname. */
+ *  node prefers the name saved in its config — the one the rename pencil writes —
+ *  over anything else. */
 function nodeName(client: WifiClientJson, wifiConfig: WifiNetworkConfigJson | null): string {
   if (client.role === "CONTROLLER") return "Main Router";
   const configured = client.deviceId
     ? wifiConfig?.meshConfigs?.[client.deviceId]?.displayName
     : undefined;
-  return client.givenName || configured || client.name || "Mesh node";
+  return configured || client.givenName || client.name || "Mesh node";
 }
 
 /**

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -21,6 +21,7 @@ import { usageKey, type ClientUsageTotal } from "@core/clientUsage";
 import { apiRequest } from "../lib/apiHost";
 import { subscribeCloudSession } from "../lib/cloudHost";
 import { setRouterClientName } from "../lib/routerClientUpdate";
+import { setMeshNodeName } from "../lib/routerConfigUpdate";
 import { subscribeRouterStatus } from "../lib/routerStatusFeed";
 import {
   CloudNotConnectedError,
@@ -268,6 +269,8 @@ export interface RouterNetwork {
   historianAnswering: boolean | null;
   /** Rename a device on the router (persists across reconnects). */
   renameClient: (clientId: number, givenName: string) => Promise<void>;
+  /** Rename a paired mesh node, keyed by its `Router-<hex>` device id. */
+  renameMeshNode: (deviceId: string, displayName: string) => Promise<void>;
   /** Rolling per-MAC throughput samples (down/up in bps) built from each poll. */
   throughputHistory: Map<string, TelemetrySample[]>;
   /** Live per-MAC rate — the newest sample from the historian's window, which
@@ -592,6 +595,24 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
     );
   }, []);
 
+  const renameMeshNode = useCallback(async (deviceId: string, displayName: string) => {
+    await setMeshNodeName(deviceId, displayName);
+    // The config read is not polled — it refreshes only when the LAN returns
+    // from silence — so this patch is what keeps the new name on screen until
+    // then, the same way `renameClient` leans on the client poll.
+    setWifiConfig((current) =>
+      current
+        ? {
+            ...current,
+            meshConfigs: {
+              ...current.meshConfigs,
+              [deviceId]: { ...current.meshConfigs?.[deviceId], displayName },
+            },
+          }
+        : current,
+    );
+  }, []);
+
   const refreshConfig = useCallback(() => {
     // Re-read from whatever is actually serving this roster: the LAN reader is
     // silent in exactly the case the fallback exists for.
@@ -615,6 +636,7 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
     accountRosterError,
     wifiConfigViaAccount,
     renameClient,
+    renameMeshNode,
     throughputHistory,
     rates,
     ratesAtRoster,

--- a/src/hooks/useRouterNetwork.ts
+++ b/src/hooks/useRouterNetwork.ts
@@ -269,7 +269,6 @@ export interface RouterNetwork {
   historianAnswering: boolean | null;
   /** Rename a device on the router (persists across reconnects). */
   renameClient: (clientId: number, givenName: string) => Promise<void>;
-  /** Rename a paired mesh node, keyed by its `Router-<hex>` device id. */
   renameMeshNode: (deviceId: string, displayName: string) => Promise<void>;
   /** Rolling per-MAC throughput samples (down/up in bps) built from each poll. */
   throughputHistory: Map<string, TelemetrySample[]>;
@@ -597,9 +596,8 @@ export function useRouterNetwork(active: boolean): RouterNetwork {
 
   const renameMeshNode = useCallback(async (deviceId: string, displayName: string) => {
     await setMeshNodeName(deviceId, displayName);
-    // The config read is not polled — it refreshes only when the LAN returns
-    // from silence — so this patch is what keeps the new name on screen until
-    // then, the same way `renameClient` leans on the client poll.
+    // wifiConfig is only re-read when the LAN returns from silence, so without
+    // this patch the new name would not show until the router next went quiet.
     setWifiConfig((current) =>
       current
         ? {

--- a/src/lib/routerConfigUpdate.ts
+++ b/src/lib/routerConfigUpdate.ts
@@ -35,8 +35,6 @@ export async function applyRouterConfigUpdate(
   throw new Error(`Starlink couldn't apply the change: ${message}`);
 }
 
-/** Rename a paired mesh node. Persists on the router and shows in the official
- *  app; goes through the account for the same reason every router write does. */
 export async function setMeshNodeName(deviceId: string, displayName: string): Promise<void> {
   await applyRouterConfigUpdate({ kind: "meshName", deviceId, displayName });
 }

--- a/src/lib/routerConfigUpdate.ts
+++ b/src/lib/routerConfigUpdate.ts
@@ -34,3 +34,9 @@ export async function applyRouterConfigUpdate(
     );
   throw new Error(`Starlink couldn't apply the change: ${message}`);
 }
+
+/** Rename a paired mesh node. Persists on the router and shows in the official
+ *  app; goes through the account for the same reason every router write does. */
+export async function setMeshNodeName(deviceId: string, displayName: string): Promise<void> {
+  await applyRouterConfigUpdate({ kind: "meshName", deviceId, displayName });
+}


### PR DESCRIPTION
Adds inline rename for a mesh node in the Nodes tab, reusing the editor control that device rename uses.

The write goes through the cloud gateway as a `wifi_set_config` carrying the `meshConfigs` map plus `applyMeshConfigs`. Current firmware answers the dedicated `wifi_set_mesh_config` RPC with `Unimplemented` and refuses LAN `set_config`, so this is the only path; it also reaches a bypassed router, like the other router-config writes.

The map is rewritten whole, so other nodes are carried back untouched. The router-assigned `incarnation` is dropped from every entry, the way a stale `bssid` is dropped from the networks block.

`readCurrentNetworks` becomes `readRouterConfigContext`, returning `{ networks, meshConfigs }`, so the subnet and mesh preambles share one shape.

Reachable only for live nodes; the Nodes list cannot open a disconnected one. The controller row has no rename control.