### PR TITLE
bug/Locate the running instance instead of crashing on a second launch

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -650,6 +650,14 @@ function registerMenuBarThroughputHandler(): void {
 }
 
 void app.whenReady().then(async () => {
+  // A second launch (the desktop shortcut while the tray copy runs) would start a
+  // second collector and crash on the data-dir writer lock; hand the launch to the
+  // running instance instead.
+  if (!app.requestSingleInstanceLock()) {
+    app.quit();
+    return;
+  }
+  app.on("second-instance", showWindow);
   // Dev shows Electron's default icon; a packaged build carries its own, so set the
   // dock icon only in dev.
   if (process.platform === "darwin" && !app.isPackaged) {


### PR DESCRIPTION
Dishylink never claimed Electron's single-instance lock, so launching from the desktop shortcut while the tray copy was running spun up a second process. That process reached startCollector, hit the data-dir writer lock the first process already held, and threw CollectorBusyError as a fatal "A JavaScript error occurred in the main process" box.

Acquire requestSingleInstanceLock as the first step of whenReady, before any collector or cloud startup: a second instance now quits immediately and hands the launch to the already-running instance, whose second-instance handler brings its window forward (building one if it was launched at login into the tray).

Closes #39