### PR TITLE
Fix: make the collector lock hold across containers

### DIFF
--- a/collector/collectorLock.mts
+++ b/collector/collectorLock.mts
@@ -1,13 +1,201 @@
+// The lock a collector holds on its data directory.
+//
+// A single collector must own a data dir: two writing the same files duplicate
+// appended rows and clobber each other's snapshots. Every store here reads a
+// whole file and writes a whole file, so a second writer does not interleave
+// badly — it silently erases whatever the first one appended since it last read.
+//
+// Its own module so a host can catch CollectorBusyError without importing the
+// recorder whose loading is what raises it — a module that throws while
+// evaluating never exposes its exports — and so the mechanism can be tested
+// without starting a recorder.
+//
+// ## Why liveness is a heartbeat and not a pid
+//
+// The obvious lock records the owner's pid and lets the next starter probe it
+// with kill(pid, 0). That reads as sound and is not, because a pid only means
+// something inside the pid namespace that issued it. The deployment this
+// project ships — `compose.yaml`, a named volume mounted at /data — is exactly
+// the case where that breaks: the Dockerfile's exec-form CMD makes node pid 1 in
+// every container, so two containers sharing one volume both record `1` and
+// both read `1` back. Each concludes the lock is its own, takes it, and the two
+// recorders proceed to overwrite each other's history. The check is not merely
+// weak across namespaces, it is arbitrary: a pid left by a dead container can
+// equally well name some live process in the next one, and the lock wedges shut
+// instead.
+//
+// So the holder proves it is alive directly, by touching the lock file every
+// HEARTBEAT_MS. A lock that has gone quiet longer than STALE_AFTER_MS had its
+// holder die — killed, crashed, container stopped — and the next starter takes
+// it. Nothing about that reasoning depends on which namespace anybody's pid came
+// from, and a crash still cannot wedge the directory shut, which is the property
+// the pid probe was there to provide.
+//
+// The pid is still written alongside, for the operator reading the error message
+// and reaching for `ps`. Nothing decides anything by it.
+
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  utimesSync,
+  writeSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
 /**
  * Raised when a live collector already owns the data directory.
- *
- * Its own module so a host can catch it without importing the recorder whose
- * loading is what raises it — a module that throws while evaluating never
- * exposes its exports.
  */
 export class CollectorBusyError extends Error {
   constructor(reason: string) {
     super(reason);
     this.name = "CollectorBusyError";
+  }
+}
+
+/** How often the holder proves it is still alive. One utimes call, so the cost
+ *  of a tighter beat is not what sets this — STALE_AFTER_MS is. */
+const HEARTBEAT_MS = 5_000;
+
+/**
+ * How quiet a lock must go before another starter may take it.
+ *
+ * Six missed beats. The recorder writes its stores synchronously and folds a
+ * year of minutes into monthly summaries on one of them, so the event loop can
+ * legitimately stall for seconds at a time; a margin this wide means a busy
+ * recorder is never mistaken for a dead one. The cost is paid only after an
+ * actual crash, where a restart waits out the remainder of the window before
+ * reclaiming — and `restart: unless-stopped` covers that on its own.
+ */
+const STALE_AFTER_MS = 30_000;
+
+const LOCK_FILE_NAME = "historian.lock";
+
+interface HeldLock {
+  dir: string;
+  file: string;
+  /** What makes the lock ours to release. A pid cannot: see the note above. */
+  token: string;
+  heartbeat: ReturnType<typeof setInterval>;
+}
+
+// globalThis, not module-scope state: Vite's SSR restart can re-evaluate this
+// module within one process, and a claim must survive that.
+const HELD = Symbol.for("dishylink.collectorLock.held");
+
+function heldLock(): HeldLock | undefined {
+  return (globalThis as Record<symbol, unknown>)[HELD] as HeldLock | undefined;
+}
+
+/** Milliseconds since the lock was last touched, or null if it is not there. */
+function quietFor(file: string): number | null {
+  try {
+    return Date.now() - statSync(file).mtimeMs;
+  } catch {
+    // Gone between our failed create and this stat — another starter reclaimed
+    // it first. Not an error: the retry finds it either free or freshly held.
+    return null;
+  }
+}
+
+/** The owner's pid, for the error message only. Absent if the lock is gone or
+ *  its contents are not what we write. */
+function recordedPid(file: string): string {
+  try {
+    const pid = readFileSync(file, "utf8").trim().split(" ")[1];
+    return pid ? `pid ${pid}` : "unknown owner";
+  } catch {
+    return "unknown owner";
+  }
+}
+
+function startHeartbeat(file: string): ReturnType<typeof setInterval> {
+  const heartbeat = setInterval(() => {
+    const now = new Date();
+    try {
+      utimesSync(file, now, now);
+    } catch {
+      // The lock was taken from under us, which only happens if this process
+      // stalled past the whole stale window. Nothing to do from a timer: the
+      // release below will find the token no longer ours and leave it alone.
+    }
+  }, HEARTBEAT_MS);
+  // A held lock is never a reason to keep a process alive: a recorder with
+  // nothing else scheduled is a recorder that has stopped recording.
+  heartbeat.unref();
+  return heartbeat;
+}
+
+/**
+ * Take the data directory, or raise saying who has it.
+ *
+ * Raises rather than exits so the caller decides what a busy directory means to
+ * it — the standalone recorder ends the process, an embedded one carries on
+ * without a recorder.
+ *
+ * @throws {CollectorBusyError} when a live collector holds it
+ */
+export function claimDataDir(dataDir: string): void {
+  mkdirSync(dataDir, { recursive: true });
+  const file = join(dataDir, LOCK_FILE_NAME);
+  if (heldLock()?.dir === dataDir) {
+    throw new CollectorBusyError(
+      `this process already owns ${dataDir} — refusing to start a second writer in the same process`,
+    );
+  }
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const fd = openSync(file, "wx");
+      const token = randomUUID();
+      writeSync(fd, `${token} ${process.pid}`);
+      closeSync(fd);
+      (globalThis as Record<symbol, unknown>)[HELD] = {
+        dir: dataDir,
+        file,
+        token,
+        heartbeat: startHeartbeat(file),
+      } satisfies HeldLock;
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const quietMs = quietFor(file);
+      if (quietMs !== null && quietMs < STALE_AFTER_MS) {
+        throw new CollectorBusyError(
+          `another collector (${recordedPid(file)}, last seen ${Math.round(quietMs / 1000)}s ago) ` +
+            `already owns ${dataDir} — refusing to start a second writer`,
+        );
+      }
+      // Its holder stopped proving it was alive, or the lock vanished as we
+      // looked at it. Drop it and race for it again.
+      try {
+        unlinkSync(file);
+      } catch {
+        // Another starter reclaimed it first; the next attempt finds it held.
+      }
+    }
+  }
+  throw new Error(`could not claim ${dataDir} — refusing to start`);
+}
+
+/**
+ * Give the directory back, if this process still holds it.
+ *
+ * The token check is what makes that "if" real: a process stalled past the stale
+ * window has already had its lock reclaimed by someone else, and removing the
+ * file then would hand a live collector's directory to the next starter.
+ */
+export function releaseDataDir(): void {
+  const held = heldLock();
+  if (!held) return;
+  clearInterval(held.heartbeat);
+  (globalThis as Record<symbol, unknown>)[HELD] = undefined;
+  try {
+    if (readFileSync(held.file, "utf8").trim().split(" ")[0] === held.token) unlinkSync(held.file);
+  } catch {
+    // Already gone, or no longer ours to remove.
   }
 }

--- a/collector/collectorLock.test.mts
+++ b/collector/collectorLock.test.mts
@@ -1,0 +1,105 @@
+// The lock exists to stop two recorders writing one data directory, and the way
+// it used to fail is worth pinning: liveness was a pid probe, and a pid means
+// nothing across pid namespaces. Two containers sharing a volume are both pid 1,
+// so each read the other's lock as its own and took it.
+//
+// That case cannot be staged in a unit test — there is one namespace here — but
+// its mechanism can be, exactly: a lock recording *this* process's own pid is
+// what a second container sees, and it must still be refused while its holder is
+// touching it. The pid is a red herring; only the heartbeat decides.
+
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectorBusyError, claimDataDir, releaseDataDir } from "./collectorLock.mts";
+
+let dir: string;
+let lock: string;
+
+beforeEach(() => {
+  dir = join(tmpdir(), `collectorlock-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  lock = join(dir, "historian.lock");
+});
+
+afterEach(() => {
+  releaseDataDir();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const FOREIGN_TOKEN = "00000000-0000-4000-8000-000000000000";
+
+/** A lock held by someone else: our token is not in it, and it was touched at
+ *  `agoMs`, which is the only thing the claim actually judges. */
+function foreignLock(agoMs: number, pid: number = process.pid): void {
+  writeFileSync(lock, `${FOREIGN_TOKEN} ${pid}`);
+  const touchedAt = new Date(Date.now() - agoMs);
+  utimesSync(lock, touchedAt, touchedAt);
+}
+
+const STALE_AFTER_MS = 30_000;
+
+describe("claimDataDir", () => {
+  it("takes a directory nobody holds", () => {
+    claimDataDir(dir);
+    expect(existsSync(lock)).toBe(true);
+  });
+
+  it("creates the data directory when it does not exist yet", () => {
+    const fresh = join(dir, "nested", "data");
+    claimDataDir(fresh);
+    expect(existsSync(join(fresh, "historian.lock"))).toBe(true);
+  });
+
+  it("refuses a directory whose holder is still beating", () => {
+    foreignLock(1_000);
+    expect(() => claimDataDir(dir)).toThrow(CollectorBusyError);
+  });
+
+  // The regression this whole change is for. A pid probe would see this process's
+  // own pid, conclude the lock was its own leftover, and take a live collector's
+  // directory — which is precisely what two containers at pid 1 did to each other.
+  it("refuses a beating holder that recorded this very pid", () => {
+    foreignLock(1_000, process.pid);
+    expect(() => claimDataDir(dir)).toThrow(CollectorBusyError);
+    expect(readFileSync(lock, "utf8")).toContain(FOREIGN_TOKEN);
+  });
+
+  // The other half: a pid that is alive here must not wedge the directory shut
+  // when the lock behind it went quiet. Under the old probe this was a permanent
+  // refusal every time a dead container's pid happened to exist in the next one.
+  it("reclaims a lock that stopped beating, whatever pid it names", () => {
+    foreignLock(STALE_AFTER_MS + 5_000, process.pid);
+    expect(() => claimDataDir(dir)).not.toThrow();
+    expect(readFileSync(lock, "utf8")).not.toContain(FOREIGN_TOKEN);
+  });
+
+  it("refuses a second claim on a directory this process already holds", () => {
+    claimDataDir(dir);
+    expect(() => claimDataDir(dir)).toThrow(CollectorBusyError);
+  });
+});
+
+describe("releaseDataDir", () => {
+  it("removes a lock this process holds", () => {
+    claimDataDir(dir);
+    releaseDataDir();
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it("is a no-op when nothing is held", () => {
+    expect(() => releaseDataDir()).not.toThrow();
+  });
+
+  // A process stalled past the stale window has already had its lock reclaimed.
+  // Releasing on the way out must not then delete the live collector's lock and
+  // hand the directory to whoever starts next.
+  it("leaves a lock alone once someone else has taken it", () => {
+    claimDataDir(dir);
+    foreignLock(1_000);
+    releaseDataDir();
+    expect(existsSync(lock)).toBe(true);
+    expect(readFileSync(lock, "utf8")).toContain(FOREIGN_TOKEN);
+  });
+});

--- a/collector/historian.mts
+++ b/collector/historian.mts
@@ -12,18 +12,7 @@
 //
 // Run: npm run historian   (foreground; see collector/README for always-on setup)
 
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-  writeSync,
-} from "node:fs";
+import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { networkInterfaces } from "node:os";
 import { identityFromEnv } from "../core/hostNetworkIdentity.ts";
@@ -59,7 +48,7 @@ import { resolveRows, foldMinuteCollisions } from "../core/clientHistory.ts";
 import { ClientTotalsStore } from "./clientTotals.mts";
 import { MeterStore } from "./meterStore.mts";
 import { DeviceGroupStore } from "./groupStore.mts";
-import { CollectorBusyError } from "./collectorLock.mts";
+import { claimDataDir, releaseDataDir } from "./collectorLock.mts";
 import { isLocalOrigin } from "./localOrigin.mts";
 import {
   announcementSubject,
@@ -121,7 +110,6 @@ const METERS_FILE = join(DATA_DIR, "meters.json");
 const DEVICE_GROUPS_FILE = join(DATA_DIR, "device-groups.json");
 const ALERTS_FILE = join(DATA_DIR, "alerts.ndjson");
 const OBSTRUCTION_FILE = join(DATA_DIR, "obstruction.ndjson");
-const LOCK_FILE = join(DATA_DIR, "historian.lock");
 const PORT = Number(process.env.HISTORIAN_PORT ?? 8088);
 const POLL_MS = 5_000;
 /**
@@ -1846,80 +1834,20 @@ export function handleRequest(request: IncomingMessage, response: ServerResponse
   response.end("not found");
 }
 
-// A single collector must own a data dir: two writing the same files duplicate
-// appended rows and clobber each other's snapshots. The lock is keyed to the data
-// dir, not the HTTP port — the embedded host never opens a port, so the port never
-// guarded it. The pidfile is reclaimed when its recorded owner is gone, so a crash
-// (which cannot run the release) does not wedge the next start.
-//
-// globalThis, not module-scope state or a PID compare: Vite's SSR restart can
-// re-evaluate this module within one process, and this must survive that.
-const CLAIM_SENTINEL = Symbol.for("dishylink.historian.dataDirClaim");
-
-function claimDataDir(): void {
-  mkdirSync(DATA_DIR, { recursive: true });
-  if ((globalThis as Record<symbol, unknown>)[CLAIM_SENTINEL] === DATA_DIR) {
-    refuseToStart(
-      `this process already owns ${DATA_DIR} — refusing to start a second writer in the same process`,
-      true,
-    );
-  }
-  for (let attempt = 0; attempt < 5; attempt++) {
-    try {
-      const fd = openSync(LOCK_FILE, "wx");
-      writeSync(fd, String(process.pid));
-      closeSync(fd);
-      (globalThis as Record<symbol, unknown>)[CLAIM_SENTINEL] = DATA_DIR;
-      return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      const owner = Number(readFileSync(LOCK_FILE, "utf8").trim());
-      if (owner && owner !== process.pid && processAlive(owner)) {
-        refuseToStart(
-          `another collector (pid ${owner}) already owns ${DATA_DIR} — refusing to start a second writer`,
-          true,
-        );
-      }
-      // The recorded owner is gone; drop its stale lock and race for it again.
-      try {
-        unlinkSync(LOCK_FILE);
-      } catch {
-        // Another starter reclaimed it first; the next attempt finds it held.
-      }
-    }
-  }
-  refuseToStart(`could not claim ${DATA_DIR} — refusing to start`);
-}
-
-/** An embedded recorder shares its host's process, so it raises rather than exits
- *  and leaves the host to decide whether it can carry on without a recorder. */
-function refuseToStart(reason: string, busy = false): never {
-  console.error(`[historian] ${reason}`);
-  if (process.env.HISTORIAN_EMBED === "1")
-    throw busy ? new CollectorBusyError(reason) : new Error(reason);
+/** An embedded recorder shares its host's process, so it re-raises rather than
+ *  exits, and leaves the host to decide whether it can carry on without a
+ *  recorder. */
+function refuseToStart(error: Error): never {
+  console.error(`[historian] ${error.message}`);
+  if (process.env.HISTORIAN_EMBED === "1") throw error;
   process.exit(1);
 }
 
-// Signal 0 probes for the process without delivering anything: ESRCH means it is
-// gone, EPERM means it is alive but owned by another user.
-function processAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
-  }
+try {
+  claimDataDir(DATA_DIR);
+} catch (error) {
+  refuseToStart(error as Error);
 }
-
-function releaseDataDir(): void {
-  try {
-    if (Number(readFileSync(LOCK_FILE, "utf8").trim()) === process.pid) unlinkSync(LOCK_FILE);
-  } catch {
-    // Nothing to release, or the lock is no longer ours to remove.
-  }
-}
-
-claimDataDir();
 process.on("exit", releaseDataDir);
 
 // The dev process serves the collector over loopback HTTP. An embedded host (the

--- a/docker/browserHost.mts
+++ b/docker/browserHost.mts
@@ -179,14 +179,6 @@ const { readCookie } = cookieStore(cookieFile);
 const DATA_DIR = process.env.HISTORIAN_DATA_DIR ?? resolve("collector/data");
 const SELF_DEVICE_FILE = join(DATA_DIR, "self-device.json");
 
-// Pids do not carry across PID namespaces, so a lock left by a previous
-// container names a stranger's process in this one.
-try {
-  rmSync(join(DATA_DIR, "historian.lock"));
-} catch {
-  /* no previous run */
-}
-
 function readSelfDevice(): number | null {
   try {
     const { clientId } = JSON.parse(readFileSync(SELF_DEVICE_FILE, "utf8")) as {


### PR DESCRIPTION
Closes #48

**The problem.** The lock judged liveness by pid, which says nothing across pid namespaces. With node at pid 1 in every container, two containers on one volume each read the other's lock as their own and took it; a stale pid could equally collide with a live process and wedge the directory shut. `docker/browserHost.mts` worked around this by deleting the lock unconditionally at startup, which removed the protection altogether.

**The fix.** The holder now proves it is alive directly, touching the lock file every 5s. A lock quiet for more than 30s (six missed beats) had its holder die and is reclaimed. Nothing decides anything by pid — it's still written for the operator reading the error, which now also reports how long ago the holder was last seen. Ownership is a random token, so a process stalled past the window can't delete the lock of whoever legitimately took over.

The 30s window is the one tradeoff: after a hard crash a restart waits out the remainder before reclaiming. It's sized for the recorder's synchronous whole-file compaction, which can stall the loop for seconds, and `restart: unless-stopped` absorbs it.

The mechanism moved into `collectorLock.mts` — `historian.mts` runs polls and binds a port at import, so the lock could not otherwise be tested. It now has 9 tests, including the container case expressed portably: a lock recording this very process's pid, still beating, must be refused.

**Verified.** typecheck, lint and prettier clean; 110/110 files and 1225/1225 tests pass. Against real hardware on my own Starlink LAN: heartbeat advances the mtime, a second instance on the same data dir is refused, and after `kill -9` a restart refuses while the lock is fresh and reclaims once it goes quiet. No polling behaviour is touched and no new device call is added.

I can't apply labels as an outside contributor — this one is a `bug`.

---
Found and fixed via a structured concurrency review of this repo using Claude Code and its ECC agent/skill tooling; the diagnosis, design and verification are my own — I'm a senior software engineer (Accenture, currently engaged at Worldline). The first version of this fix only closed the same-namespace case; the pid-1 hole turned up on review, which is what prompted the heartbeat approach. Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)